### PR TITLE
fixing navbar toggling

### DIFF
--- a/_includes/footer-scripts.html
+++ b/_includes/footer-scripts.html
@@ -12,7 +12,7 @@
 
 {% if page.js %}
   {% for js in page.js %}
-	<script src="{{ assets/js | prepend: site.baseurl }}"></script>
+	<script src="{{ js | prepend: site.baseurl }}"></script>
   {% endfor %}
 {% endif %}
 
@@ -22,11 +22,11 @@
     {% if js contains 'jquery' %}
       <script>
       	if (typeof jQuery == 'undefined') {
-      	  document.write('<script src="{{ assets/js | prepend: site.baseurl }}"></scr' + 'ipt>');
+      	  document.write('<script src="{{ js | prepend: site.baseurl }}"></scr' + 'ipt>');
       	}
       </script>
     {% else %}
-	<script src="{{ assets/js | prepend: site.baseurl }}"></script>
+	<script src="{{ js | prepend: site.baseurl }}"></script>
     {% endif %}
   {% endfor %}
 {% endif %}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -69,6 +69,7 @@ var main = {
   },
 
   initImgs : function() {
+
     // If the page was large images to randomly select from, choose an image
     if ($("#header-big-imgs").length > 0) {
       main.bigImgEl = $("#header-big-imgs");


### PR DESCRIPTION
This was an oversight on my part - when I was re-arranging static files I was testing the logic of the include statements, and I then wound up finding the full paths in the base.html layout. However I left behind an edit to the paths of the js files so they weren't included. Strangely, there is no error in the browser and the basic functionality is intact so we didn't notice a thing! I figured it out by inspecting the hamburger menu and seeing a complete lack of event listeners, evidence that the javascript was completely missing.

It will be hard to tell how this looks on mobile without mobile, so we might have to do this in a few iterations! This minimally restores the expected functionality of the menu.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>