### PR TITLE
Fix Travis badge and branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
 # branch whitelist
 branches:
   only:
-  - gh-pages     # test the gh-pages branch
+  - master     # test the master branch
   - /pages-(.*)/ # test every branch which starts with "pages-"
   - add-travis
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The United States (US) Research Software Engineer Community
 
-[![Build Status](https://travis-ci.org/USRSE/usrseweb.svg?branch=gh-pages)](https://travis-ci.org/USRSE/usrseweb)
+[![Build Status](https://travis-ci.org/USRSE/usrse.github.io.svg?branch=master)](https://travis-ci.org/USRSE/usrse.github.io)
 
 ## What is this?
 


### PR DESCRIPTION
With the change from publishing gh-pages to master and the repo rename, travis script and badge needed to be updated.  I think this is it. 