### PR TITLE
hiding logo when screen flips to being tiny and using hamburger menu

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
       </button>
       {% if site.title-img %}
-        <a class="navbar-brand navbar-brand-logo" href="{{ site.url }}"><img alt="logo" src="{{ site.title-img }}"/></a>
+        <a class="navbar-brand navbar-brand-logo logo" href="{{ site.url }}"><img alt="logo" src="{{ site.title-img }}"/></a>
       {% else %}
         <a class="navbar-brand" href="{{ site.url }}">{{ site.title }}</a>
       {% endif %}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -57,6 +57,11 @@ hr.small {
     padding-top: 130px;
   }
 }
+@media only screen and (max-width: 768px) {
+  .logo {
+    display: none;
+  }
+}
 
 .main-explain-area {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;


### PR DESCRIPTION
This is a final tweak so that the logo is just completely hidden when the screen gets small (at the same pixel value when it flips to showing the hamburger menu in the first place).

![image](https://user-images.githubusercontent.com/814322/58897148-a5cf0d00-86c5-11e9-8029-31e88eba3ea2.png)

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

