### PR TITLE
adding small logo to close #43

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ description: Community of Research Software Engineers
 
 # Image to show in the navigation bar - image must be a square (width = height)
 # Remove this parameter if you don't want an image in the navbar
-#avatar: "/img/avatar-icon.png"
+avatar: "/assets/img/avatar-icon.png"
 
 # List of links in the navigation bar
 navbar-links:

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -61,13 +61,13 @@ hr.small {
   .logo img {
     display: none;
   }
-  .logo {
+{% if site.avatar %}.logo {
     margin-left: 18px;
     width: 50px;
     background-repeat: no-repeat;
     background-size: 50px 50px;
-    background-image: url("/assets/img/avatar-icon.png");
-  }
+    background-image: url("{{ site.avatar }}");
+  }{% endif %}
 }
 
 .main-explain-area {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,8 +58,15 @@ hr.small {
   }
 }
 @media only screen and (max-width: 768px) {
-  .logo {
+  .logo img {
     display: none;
+  }
+  .logo {
+    margin-left: 18px;
+    width: 50px;
+    background-repeat: no-repeat;
+    background-size: 50px 50px;
+    background-image: url("/assets/img/avatar-icon.png");
   }
 }
 


### PR DESCRIPTION
This will close #43, specifically we now show a tiny logo when the screen is small:

![image](https://user-images.githubusercontent.com/814322/58975614-5fe07a80-8793-11e9-81d3-6fd2608391da.png)

I just changed the logic to (when we go below a certain number of pixels) to set the display to none not for the logo class, but for the .logo img (the image it contains). That way .logo is still showing, and I can set it's background image (in the same block) to be the tiny one. I'm fairly terrible at web design, but this seems to do the trick :) 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>