### PR TITLE
Change gh-pages to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The site is built with [Jekyll](https://jekyllrb.com/) and hosted on GitHub.
 ## How do I contribute?
 
 We encourage the community to contribute to the content of the website.  
-To do this: fork the repository, make your proposed changes, test locally (see below), and then create a pull request against `gh-pages`.
+To do this: fork the repository, make your proposed changes, test locally (see below), and then create a pull request against `master`.
 
 ### 1. How do I update the map?
 


### PR DESCRIPTION
This is a tiny PR that changes the README to refer to the master branch (from gh-pages).

Just trying to set the precedent for doing substantive changes (outside of map coords etc) in PRs.

And this should be the last thing required for issue #39 