### PR TITLE
Fixing description when shared

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -71,7 +71,7 @@
   {% elsif page.subtitle %}
   <meta property="og:description" content="{{ page.subtitle }}">
   {% else %}
-  <meta property="og:description" content="{{ page.content | strip_html | xml_escape | truncatewords: 50 }}">
+  <meta property="og:description" content="{{ page.title }}">
   {% endif %}
 
 
@@ -112,7 +112,7 @@
   {% elsif page.subtitle %}
   <meta name="twitter:description" content="{{ page.subtitle }}">
   {% else %}
-  <meta name="twitter:description" content="{{ page.content | strip_html | xml_escape | truncatewords: 50 }}">
+  <meta name="twitter:description" content="{{ page.title }}">
   {% endif %}
 
   {% if page.share-img %}


### PR DESCRIPTION
Currently, the description renders the page.content and for some reason it's not rendering as html, but instead raw jinja. I'm not sure why this is the case, but in the meantime we can just show the page title as the third option for the description. This will close #53 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>