### PR TITLE
Update expiration date for Princeton RSE job

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,7 +1,7 @@
 - name: "Research Software Engineer"
   location: Princeton, NJ
   url: https://main-princeton.icims.com/jobs/10347/research-software-engineer/job
-  expires: 2019-07-01
+  expires: 2019-08-01
 - name: "Software Consultants"
   location: University Park Campus
   url: https://psu.jobs/job/88890


### PR DESCRIPTION
It's still not filled, so let's try for another few weeks.  Moving the expiration date to Aug 1. 