### PR TITLE
Refresh News & Update feed and create mission

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ navbar-links:
   Home: ""
   Community:
     - About: "about"
+    - Mission: "mission"
     - RSE Groups: "rse-groups"
     - RSE Map: "map"
     - Steering Committee: "steering-committee"

--- a/_posts/2019-07-11-twitter.md
+++ b/_posts/2019-07-11-twitter.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: US-RSE is now on Twitter!
+subtitle: 
+posted_by: Ian Cosden
+---
+
+
+The title says it all: US-RSE will now be tweeting at
+[@us_rse](https://twitter.com/us_rse).  Follow for updates, news, and
+announcements!  
+

--- a/_posts/2019-07-15-19-PEARC19.md
+++ b/_posts/2019-07-15-19-PEARC19.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: RSE BoF at PEARC19 
+subtitle: US-RSE Members Organizing Community BoF
+posted_by: Ian Cosden
+---
+
+
+Join us in person at the [PEARC19 Conference](https://www.pearc19.pearc.org/)
+there will be a Birds of a Feather (BOF) session "Building a Community
+of Research Software Engineers."  The session is scheduled for 5:15pm
+Monday, July 15 in the New Orleans room.  
+
+If you'll be attending PEARC19 this is a great opportunity to discuss
+US-RSE issues and connect to other members of this growing community!
+
+Find out who else will be there and joing in on the discssion by
+joining the [conversation]({{site.url}}/join).
+
+

--- a/_posts/2019-07-15-19-PEARC19.md
+++ b/_posts/2019-07-15-19-PEARC19.md
@@ -14,7 +14,7 @@ Monday, July 15 in the New Orleans room.
 If you'll be attending PEARC19 this is a great opportunity to discuss
 US-RSE issues and connect to other members of this growing community!
 
-Find out who else will be there and joing in on the discssion by
+Find out who else will be there and join in on the discussion by
 joining the [conversation]({{site.url}}/join).
 
 

--- a/pages/mission.md
+++ b/pages/mission.md
@@ -12,7 +12,7 @@ to target our activities and actions to serving these three aspects:
 
 
 
-## Community 
+## 1. Community 
 
   We seek to provide a coherent association of those who identify with
   the role (not necessarily title) of Research Software Engineer based
@@ -20,12 +20,12 @@ to target our activities and actions to serving these three aspects:
   group aims to provide the members of the community the ability to
   share knowledge, professional connections, and resources.
 
-## Advocacy
+## 2. Advocacy
 
   We aim to promote RSEs impact on research, highlighting the
   increasingly critical and valuable role RSEs serve.
 
-## Resources 
+## 3. Resources 
 
   We strive to provide useful resources to multiple demographics.
   For current and future RSEs we strive to provide technical and

--- a/pages/mission.md
+++ b/pages/mission.md
@@ -8,8 +8,7 @@ permalink: /mission/
 
 
 The US-RSE organization is centered around three main goals.  We aim
-to target our activities and actions to serving these three main
-goals:
+to target our activities and actions to serving these three aspects:
 
 
 

--- a/pages/mission.md
+++ b/pages/mission.md
@@ -1,0 +1,37 @@
+---
+layout: page
+title: The US-RSE Mission
+subtitle: Goals and Aims of the US-RSE Association
+bigimg:
+permalink: /mission/
+---
+
+
+The US-RSE organization is centered around three main goals.  We aim
+to target our activities and actions to serving these three main
+goals:
+
+
+
+## Community 
+
+  We seek to provide a coherent association of those who identify with
+  the role (not necessarily title) of Research Software Engineer based
+  on our [inclusive definition]({{site.url}}/what-is-an-rse).  This
+  group aims to provide the members of the community the ability to
+  share knowledge, professional connections, and resources.
+
+## Advocacy
+
+  We aim to promote RSEs impact on research, highlighting the
+  increasingly critical and valuable role RSEs serve.
+
+## Resources 
+
+  We strive to provide useful resources to multiple demographics.
+  For current and future RSEs we strive to provide technical and
+  career development resources to support their professional
+  development.  We aim to provide access to information and material
+  to support the establishment and expansion of RSE positions and
+  groups within the research ecosystem including the material for
+  making business justifications for RSEs.


### PR DESCRIPTION
In an effort to make the page more current, and not stale, this PR adds two short posts to the news feed at the bottom of the main page:
1. An update about PEARC19
1. An update about the new twitter account starting.  

So it doesn't get lost in the shuffle, the Goals post (which was at the top of the news and update) has been moved to a mission tab under the "About" menu.  

This can be split or a discussion (here or on slack) but I thought it would be easier to start with something concrete, and go from there. 