### PR TITLE
add twitter link in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -83,7 +83,7 @@ social-network-links:
 #  email: "someone@example.com"
 #  facebook:
   github: USRSE
-#  twitter:
+  twitter: us_rse
 #  reddit:
 #  google-plus:
 #  linkedin:


### PR DESCRIPTION
Just realized we didn't have the twitter logo/link in the footer here.  I can't think of a reason not to have it now that we have an account. 