### PR TITLE
Adding plot with membership counts by month/year

### DIFF
--- a/_data/memberCounts.csv
+++ b/_data/memberCounts.csv
@@ -1,0 +1,19 @@
+Date,Count,Total
+"February, 2018",2,2
+"March, 2018",1,3
+"April, 2018",1,4
+"May, 2018",1,5
+"June, 2018",1,6
+"July, 2018",0,6
+"August, 2018",0,6
+"September, 2018",0,6
+"October, 2019",0,6
+"November, 2018",3,9
+"December, 2018",0,9
+"January, 2019",1,10
+"February, 2019",1,11
+"March, 2019",9,20
+"April, 2019",9,29
+"May, 2019",17,46
+"June, 2019",39,85
+"July, 2019",49,134

--- a/_includes/member-graph.html
+++ b/_includes/member-graph.html
@@ -1,0 +1,89 @@
+<div class="container-fluid" style="padding:50px">
+    <div class="row" id="app">
+        <div class="col-md-12">
+            <canvas id="rse-generator" height="200px" style="background-color:white"></canvas>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
+<script src="https://unpkg.com/vue-chartjs/dist/vue-chartjs.min.js"></script>
+<script>
+
+// Ensure the saved image has a white background
+var backgroundColor = 'white';
+Chart.plugins.register({
+    beforeDraw: function(c) {
+        var ctx = c.chart.ctx;
+        ctx.fillStyle = backgroundColor;
+        ctx.fillRect(0, 0, c.chart.width, c.chart.height);
+    }
+});
+
+new Vue ({
+  el: '#app',
+  data: {
+    labels: "Software Engineering, Open Source Development, User Support, Research, Documentation",
+    chart: undefined,
+    title: "Membership in the US Research Software Engineering Association",
+  },
+  mounted: function() {
+    this.render();
+  },
+  methods: {
+    clone: function(obj) {
+      return JSON.parse(JSON.stringify(obj));
+    },
+
+    // Helper functions
+    getRandomColor: function() {
+        var letters = '0123456789ABCDEF';
+        var color = '#';
+        for (var i = 0; i < 6; i++) {
+            color += letters[Math.floor(Math.random() * 16)];
+        }
+        return color;
+    },
+
+    render: function() {
+      if (this.chart)
+        this.chart.destroy()
+      var canvas = document.getElementById("rse-generator");
+      var ctx = canvas.getContext('2d');
+
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      // Generate dataset and labels
+      var labels = [{% for entry in site.data.memberCounts %}"{{ entry.Date }}"{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
+      var dataset = [{% for entry in site.data.memberCounts %}{{ entry.Total }}{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
+
+      var datasets = [{
+          label: "Total Members",
+          data: dataset,
+          borderColor: [this.getRandomColor()]
+      }]
+
+      this.chart = new Chart(ctx, {
+          type: 'line',
+          data: {
+              labels: labels,
+              datasets: datasets
+          },
+          options: {
+            title: {
+                padding: 30,
+                display: true,
+                text: this.title,
+            },
+            legend: {
+               display: true,
+               position: "bottom"
+            }
+          }
+      });
+    }
+  }
+})
+</script>

--- a/pages/join.md
+++ b/pages/join.md
@@ -5,6 +5,8 @@ permalink: /join/
 subtitle: Why should I join the US-RSE Association?
 ---
 
+{% include member-graph.html %}
+
 By joining the community you will:
 
 * Receive announcements of events organized by and for RSEs


### PR DESCRIPTION
This pull request will add a plot to the join page to show the growth of us-rse over time! Here is a quick snapshot:

![image](https://user-images.githubusercontent.com/814322/62081402-844f5500-b220-11e9-943b-019dd118016c.png)


## How does it work?

The data itself is read from a simple csv file, memberCounts.csv, that is served from data. It's a file that includes month/year, count, and totals. We have it organized by month/year because the units specified here directly determine the scale of the Y axis for the plot, and we don't want it to be uneven (@cosden can comment on this because he pointed it out!) Here is the current data:

```csv
Date,Count,Total
"February, 2018",2,2
"March, 2018",1,3
"April, 2018",1,4
"May, 2018",1,5
"June, 2018",1,6
"July, 2018",0,6
"August, 2018",0,6
"September, 2018",0,6
"October, 2019",0,6
"November, 2018",3,9
"December, 2018",0,9
"January, 2019",1,10
"February, 2019",1,11
"March, 2019",9,20
"April, 2019",9,29
"May, 2019",17,46
"June, 2019",39,85
"July, 2019",49,134
```
Importantly, the data is programatically generated (but not downloaded to the file) in the Spreadsheet associated with the updated Google form, and historical data has been summarized and included, also by month, in the same format. I included both the historical raw data and the script to generate the counts so there is absolutely no doubt about how it was produced here: https://gist.github.com/vsoch/b86537e3b9171a2292e0587f20bd47fe

For the spreadsheet (admins of the organization have access) there is a second tab:

![image](https://user-images.githubusercontent.com/814322/62081020-bf04bd80-b21f-11e9-9533-935b01d15da2.png)

And the historical data generated from the gist above is highlighted in yellow at the top. Notice that the first column after the date is general counts, and the third column uses that counts column plus the cell above it to keep a running total.

![image](https://user-images.githubusercontent.com/814322/62081076-e2c80380-b21f-11e9-961f-a1ab82084413.png)

**Important** July 2019 is a special case, because we have BOTH data generated from the new form, along with historical data. Thus, to generate the count, we have a formula PLUS the original count from the spreadsheet (45)

```
=COUNT(FILTER('Form Responses 1'!A2:A100000,YEAR('Form Responses 1'!A2:A100000)=YEAR(A19), MONTH('Form Responses 1'!A2:A100000)=MONTH(A19))) + 45
```
This means that all following cells have that same calculation, but without the +45, which serves to look in the previous sheet for entries in column A from row 1 through 100000, and count cells
that have the YEAR corresponding to the YEAR in the current sheet's AX (for example, 2019) and the Month in the same sheet's AX (for example July). The result of this calculation is the count of timestamps in the previous sheet that have any record in July of 2019.

```
=COUNT(FILTER('Form Responses 1'!A2:A100000,YEAR('Form Responses 1'!A2:A100000)=YEAR(A19), MONTH('Form Responses 1'!A2:A100000)=MONTH(A19))) + 45
```
And so, to update the data for the site, you can either export to csv (and replace the whole thing or just the recent months) or just copy paste and replace the spaces with commas. The export is nice because it preserves the commas in quotes for the dates.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>