### PR TITLE
Adding logo link to Resources

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ navbar-links:
     - Community Blogs: "https://usrse.github.io/blog"
     - Events & Training: "events-training"
     - Links: "links"
+    - Logos: "https://github.com/usrse/logo"
     - Newsletters: "newsletters"
     - News Archive: "archive"
   Get involved:

--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,6 @@ navbar-links:
     - Community Blogs: "https://usrse.github.io/blog"
     - Events & Training: "events-training"
     - Links: "links"
-    - Logos: "https://github.com/usrse/logo"
     - Newsletters: "newsletters"
     - News Archive: "archive"
   Get involved:

--- a/pages/resources/links.md
+++ b/pages/resources/links.md
@@ -25,4 +25,6 @@ _These resources can be helpful to establish RSE positions, groups, or further u
  - [How to start an RSE Group](https://rse.ac.uk/resources/how-to-start-an-rse-group/) as a leader
  - [RSE Starter Pack](https://us-rse.org/starter-pack/#/) getting started to create an RSE community as an RSE
  - [The Story of the Research Software Engineer](https://www.youtube.com/watch?v=trAfA9VWLTQ) video introduction to Research Software Engineering
+ - [US-RSE Logos](https://github.com/usrse/logo) repository
+
 


### PR DESCRIPTION
This will add a logos link to the resources tab, which links directly to the logos repository. The goal is to make it easy for a browser to find our logo resources.

![Screenshot from 2019-07-30 10-04-04](https://user-images.githubusercontent.com/814322/62136163-8ad9dd00-b2b1-11e9-8834-64d9dc70469f.png)

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>