### PR TITLE
Adding data for events, instructions for adding, and tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ test_map: &test_map
      cd ~/repo/tests
      $HOME/conda/bin/python -m unittest test_mapdata
      $HOME/conda/bin/python -m unittest test_jobs
+     $HOME/conda/bin/python -m unittest test_events
 
 deploy: &deploy
   name: Deploy back to GitHub pages, only in the case that CIRCLECI_TRIGGER is found

--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ We will test that all fields are defined, the url exists, and that the "expires"
 as a `datetime.date` object in Python. If you copy the format above, you should
 be ok.
 
+
+### 3. How do I add an event?
+
+You can add an event or training to the site via the [_data/events.yml](_data/events.yml)
+file. Here is an example:
+
+```yaml
+- name: "PEARC19"
+  location: Chicago, IL
+  url: https://www.pearc19.pearc.org/
+  expires: 2019-08-01
+  description: Join us at PEARC19 (https://www.pearc19.pearc.org/) for a Birds of a Feather (BOF) session "Building a Community of Research Software Engineers."  Our session is scheduled for 5:15 PM on Monday, July 29.
+```
+
+The name will be shown at the top, and will link to the url that you specify. The location
+and url will also be rendered on the page. The description can be any length of markdown and html
+that you need, and it's suggested to preview the site to make sure it looks as you expect.
+This data structure will also be tested for correct date formatting, and presence of all fields.
+
 ## Tests
 
 These tests are also run during the continuous integration to catch any errors,

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,0 +1,10 @@
+- name: "PEARC19"
+  location: Chicago, IL
+  url: https://www.pearc19.pearc.org/
+  expires: 2019-08-01
+  description: Join us at PEARC19 (https://www.pearc19.pearc.org/) for a Birds of a Feather (BOF) session "Building a Community of Research Software Engineers."  Our session is scheduled for 5:15 PM on Monday, July 29.
+- name: "Supercomputing 2019 (SC19)"
+  location: Denver, CO
+  url: https://sc19.supercomputing.org/
+  expires: 2019-11-22
+  description: "Join us at SC19 for two RSE related panel sessions:<br>  - 1. [Developing and Managing Research Software in Universities and National Labs](https://sc19.supercomputing.org/presentation/?id=pan108&sess=sess226) <br>  - 2. [Sustainability of HPC Research Computing - The Importance of Collaborations  for Fostering Career Paths for Facilitators, Research Software Engineers, and Gateway Creators](https://sc19.supercomputing.org/presentation/?id=pan109&sess=sess227) <br><br>See the [SC panel schedule](https://sc19.supercomputing.org/program/panels/#schedule) for timing and location."

--- a/pages/resources/events-archive.md
+++ b/pages/resources/events-archive.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Events Archive
+description: Archive of events, organized by year
+permalink: /events-archive/
+---
+
+{% include scrolltop.html %}
+{% for event in site.data.events %}{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}{% capture expires %}{{ event.expires | date: '%s'}}{% endcapture %}{% if expires < nowunix %}{% assign yearDate = event.expires | date: "%Y" %}
+{% if yearDate != myDate %}{% if added %}</ul>{% endif %}
+<h1 style="margin-top:20px; margin-bottom:10px">{{ yearDate }}</h1>
+<ul>{% assign myDate = yearDate %}{% endif %}
+   <li><a href="{{ event.url }}" target="_blank">{{ event.date | date: "%B %-d, %Y" }} {{ event.name }}</a>: {% assign added = true %} <em>{{ event.location }}</em></li>
+ {% if forloop.last %}</ul>{% endif %}{% endif %}{% endfor %}
+
+
+<button class="btn btn-primary" style="float:right;">
+  <a href="{{ site.baseurl }}/events-training/" style="color:white">Back to Events</a></button>

--- a/pages/resources/events-training.md
+++ b/pages/resources/events-training.md
@@ -4,31 +4,17 @@ title: Events & Training
 permalink: /events-training/
 ---
 
-
-### Jul 28 - Aug 1 2019: [PEARC19](https://www.pearc19.pearc.org/)  ###
-Join us at [PEARC19](https://www.pearc19.pearc.org/) for a Birds of a Feather (BOF) 
-session "Building a Community of Research Software Engineers."  Our session is
-scheduled for 5:15 PM on Monday, July 29; see
-the [conference website](https://www.pearc19.pearc.org/) for more details. 
-
+{% for event in site.data.events %}{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}{% capture expires %}{{ event.expires | date: '%s'}}{% endcapture %}{% if expires > nowunix %}
+<h3><a target="_blank" href="{{ event.url }}" target="_blank">{{ event.name }}: <em>{{ event.location }}</em></a></h3>
+{{ event.description }}
 <br>
+{% endif %}{% endfor %}
 
-### November 17 - 22 2019: [SC19](https://sc19.supercomputing.org/) ###
-Join us at [SC19](https://sc19.supercomputing.org/) for two RSE related panel sessions:
-1. [Developing and Managing Research Software in Universities and National
-Labs](https://sc19.supercomputing.org/presentation/?id=pan108&sess=sess226) 
-1. [Sustainability of HPC Research Computing: The Importance of Collaborations 
-for Fostering Career Paths for Facilitators, Research Software Engineers, and 
-Gateway Creators](https://sc19.supercomputing.org/presentation/?id=pan109&sess=sess227). 
-
-See the [SC panel schedule](https://sc19.supercomputing.org/program/panels/#schedule) 
-for timing and location. 
-
-<br>
-
+<button class="btn btn-primary">
+<a style="color:white" href="{{ site.baseurl }}/events-archive/">Events Archive</a></button><br>
 
 _Have an RSE-related event or training?  Have it posted here!  [Join](https://us-rse.org/join/)
-the US-RSE slack channel and contact us!_
+the US-RSE slack channel and contact us!_ 
 
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# Read in the events.yml file to validate each entry. Required are:
+# - name: "PEARC19"
+#  location: Chicago, IL
+#  url: https://www.pearc19.pearc.org/
+#  expires: 2019-08-01
+#  description: Description of the event
+
+import unittest
+import requests
+import yaml
+import datetime
+import os
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+print("########################################################### test_events")
+
+class TestEvents(unittest.TestCase):
+
+    def setUp(self):
+        self.events = os.path.join(os.path.dirname(here), '_data', 'events.yml')
+       
+    def test_loading_file(self):
+        '''test loading of the yaml file
+        '''
+        print("Testing loading of the events.yml file")
+        self.assertTrue(os.path.exists(self.events))
+        with open(self.events, 'r') as stream:
+            eventsdata = yaml.safe_load(stream)
+
+    def test_content(self):
+        '''validate required fields are provided
+        '''
+        print("validate required fields are provided")
+        with open(self.events, 'r') as stream:
+            events = yaml.safe_load(stream)
+
+        requireds = ['name', 'location', 'url', 'expires', 'description']
+        for entry in events:
+
+            # All fields required and not null
+            print("Testing %s" % entry)
+            for field in requireds:
+                print('Looking for %s' % field)
+                self.assertTrue(field in entry)
+                self.assertTrue(entry[field] not in ['', None])
+
+            # Expires must be a valid YYYY-MM-DD
+            self.assertTrue(isinstance(entry['expires'], datetime.date))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request will add programatically rendered events from an events.yml file, tests, and a new events archive page organized by year. This means that adding a new event comes down to adding an entry:

```yaml
- name: "PEARC19"
  location: Chicago, IL
  url: https://www.pearc19.pearc.org/
  expires: 2019-08-01
  description: Join us at PEARC19 (https://www.pearc19.pearc.org/) for a Birds of a Feather (BOF) session "Building a Community of Research Software Engineers."  Our session is scheduled for 5:15 PM on Monday, July 29.

```

And then it will render on the events page, as long as it's not expired:

![image](https://user-images.githubusercontent.com/814322/62473316-780e4f00-b76e-11e9-88d3-facad8c4c587.png)

And as soon as it expires it moves to the expired page:

![image](https://user-images.githubusercontent.com/814322/62473250-5f059e00-b76e-11e9-97c2-972f93f44552.png)

Note that they link back and forth to one another, as it's expected that a user would want to easily go back to where he/she came from. I've also added instructions to the README for adding an event. 

Importantly, the archive and events would be updated like the jobs - only moving to the new location when the site is statically re-generated. Since we do regular work on it to regenerate the pages, I don't think we need automation at this point. However, if it becomes the case that work dies down (and the jobs/events don't switch to archive quickly enough) we would need a nightly build or similar (like the blogs does).

This will close #81 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>