### PR TITLE
Adding button to save image to file for membership graph

### DIFF
--- a/_includes/member-graph.html
+++ b/_includes/member-graph.html
@@ -1,11 +1,21 @@
+<style>
+canvas {
+  cursor: pointer;
+}
+</style>
+
 <div class="container-fluid" style="padding:50px">
     <div class="row" id="app">
         <div class="col-md-12">
-            <canvas id="rse-generator" height="200px" style="background-color:white"></canvas>
+            <canvas id="membership-graph" height="200px" style="background-color:white"></canvas>
+        </div>
+        <div class="form-group">
+            <button v-on:click="saveImage()" style="float:right" class="btn btn-primary">Save Image</button>
         </div>
     </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/g/filesaver.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
 <script src="https://unpkg.com/vue-chartjs/dist/vue-chartjs.min.js"></script>
@@ -46,10 +56,20 @@ new Vue ({
         return color;
     },
 
+    saveImage: function() {
+       var canvas = document.getElementById("membership-graph");
+       canvas.toBlob(function(blob) {
+          var d = new Date();
+          var month = d.getMonth();
+          var year = d.getFullYear();
+          saveAs(blob, month + "-" + year + "-us-rse-membership.png");
+       });
+    },
+
     render: function() {
       if (this.chart)
         this.chart.destroy()
-      var canvas = document.getElementById("rse-generator");
+      var canvas = document.getElementById("membership-graph");
       var ctx = canvas.getContext('2d');
 
       ctx.fillStyle = "#ffffff";

--- a/_includes/member-graph.html
+++ b/_includes/member-graph.html
@@ -1,9 +1,3 @@
-<style>
-canvas {
-  cursor: pointer;
-}
-</style>
-
 <div class="container-fluid" style="padding:50px">
     <div class="row" id="app">
         <div class="col-md-12">


### PR DESCRIPTION
This will add a button to download the membership graph. Clicking isn't intuitive, and it would surprise the user if it was done, so I chose a button instead. The image is saved with the month and year, anticipating that someone in us-rse might want to save each of the monthly images. An example is included here:

![7-2019-us-rse-membership](https://user-images.githubusercontent.com/814322/62579901-f48a5600-b872-11e9-95bd-69ee7ef972cb.png)

This will close #84 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>