### PR TITLE
Adding agendas button to steering-committee page

### DIFF
--- a/pages/community/steering-committee.md
+++ b/pages/community/steering-committee.md
@@ -20,7 +20,7 @@ subtitle: The US-RSE is community driven and organized.
 * Jordan Perr-Sauer, National Renewable Energy Laboratory
 
 <a href="https://docs.google.com/document/d/124vHK6f2gb3XKuTYhzBQbCPOKvkgwW5Xnh7nBAKEKho/edit?usp=sharing" target="_blank">
-<button class="btn btn-primary"><i style="margin-right:10px" class="fa fa-file-text-o"></i> Agendas</button></a>
+<button class="btn btn-primary"><i style="margin-right:10px" class="fa fa-file-text-o"></i> Meeting Minutes</button></a>
 
 <hr>
 

--- a/pages/community/steering-committee.md
+++ b/pages/community/steering-committee.md
@@ -19,7 +19,10 @@ subtitle: The US-RSE is community driven and organized.
 * Lance Parsons, Princeton University
 * Jordan Perr-Sauer, National Renewable Energy Laboratory
 
+<a href="https://docs.google.com/document/d/124vHK6f2gb3XKuTYhzBQbCPOKvkgwW5Xnh7nBAKEKho/edit?usp=sharing" target="_blank">
+<button class="btn btn-primary"><i style="margin-right:10px" class="fa fa-file-text-o"></i> Agendas</button></a>
 
+<hr>
 
 ### Want to get involved?
 


### PR DESCRIPTION
This will add a button to link to (in a new tab) the steering committee agendas read only document:

![image](https://user-images.githubusercontent.com/814322/62801061-dc087e80-bab2-11e9-9579-1acd01ea134e.png)

I used a button with an icon to give the user a hint about what's behind the link. We open in a new tab since it's leaves the site.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>