### PR TITLE
Adding BU position for scientific programmer

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,7 @@
+- name: "Senior Scientific Programmer at Boston University"
+  location: Boston, MA
+  url: http://www.bu.edu/tech/support/research/rcs/jobs/
+  expires: 2019-10-01
 - name: "Front-End Software Developer at Harvard University"
   location: Cambridge, MA
   url: https://www.linkedin.com/jobs/view/front-end-software-developer-at-harvard-university-1302590987


### PR DESCRIPTION
This will add a scientific programmer position at Boston University.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>