### PR TITLE
Disabling action for membership counts, limited to testing branch

### DIFF
--- a/.github/workflows/member-counts.yaml
+++ b/.github/workflows/member-counts.yaml
@@ -4,8 +4,10 @@ on:
 
   # Only here for development
   push:
+    branches:
+      - test/github-action
     paths:
-      - "*"
+      - '.github/workflows/member-counts.yaml'
     
   schedule:
     # Run on the first of every month


### PR DESCRIPTION
This tweak to the GitHub workflow to generate membership counts (under development) should disable the workflow from running in a standard PR. Successful condition to merge this comes down to that workflow not running.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>