### PR TITLE
Incorrect path to signup button

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ If you are having trouble try `rm -rf _site`, followed by `bundle update`, then 
 <!--- ## Join us! --->
 
 <a href="https://docs.google.com/forms/d/e/1FAIpQLScBQ6AYpYYK2wL21egcaVvH0ZEvtShU-0s-XbqnY3okUsyIZw/viewform">
-<img width="250px" alt="signup button" src="img/signup.png"></a> 
+<img width="250px" alt="signup button" src="assets/img/signup.png"></a> 


### PR DESCRIPTION
The signup button is currently 404 in the README.md, it's located under assets/img and not just img/.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>