### PR TITLE
Config change for baseurl and logo

### DIFF
--- a/.circleci/circle_urls.sh
+++ b/.circleci/circle_urls.sh
@@ -2,4 +2,3 @@ REPO_ID=$(curl https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_
 echo "Repo ID is ${REPO_ID}"
 BASEURL=https://${CIRCLE_BUILD_NUM}-${REPO_ID}-gh.circle-artifacts.com/0/usrse.github.io
 sed -i "8 s,.*,baseurl: $BASEURL,g" "_config.yml"
-sed -i "9 s,.*,title-img: $BASEURL/assets/img/logo_600px.png,g" "_config.yml"

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 # DO NOT CHANGE THE LINE NUMBERS HERE without changing .circleci/circle_urls.sh
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
 url: "https://us-rse.org"
-baseurl: ""
+baseurl: ""  # set via .circleci/circle_urls.sh -- set it there
 title-img: /assets/img/logo_600px.png  # relative path: baseurl will be prepended
 twitter-img: /assets/img/logo_600px.png  # relative path
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,9 @@
 # DO NOT CHANGE THE LINE NUMBERS HERE without changing .circleci/circle_urls.sh
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
 url: "https://us-rse.org"
-baseurl: ""  # set via .circleci/circle_urls.sh -- set it there
-title-img: /assets/img/logo_600px.png  # relative path: baseurl will be prepended
-twitter-img: /assets/img/logo_600px.png  # relative path
+baseurl: ""  # for testing, also check .circleci/circle_urls.sh 
+title-img: /assets/img/logo_600px.png  # baseurl will be prepended
+twitter-img: /assets/img/logo_600px.png  # url + baseurl will be prepended
 
 # If you are building a GitHub project page then use these settings:
 #url: "http://username.github.io/projectname"

--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,8 @@
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
 url: "https://us-rse.org"
 baseurl: ""
-title-img: /assets/img/logo_600px.png
-twitter-img: https://us-rse.org/assets/img/logo_600px.png
+title-img: /assets/img/logo_600px.png  # relative path: baseurl will be prepended
+twitter-img: /assets/img/logo_600px.png  # relative path
 
 # If you are building a GitHub project page then use these settings:
 #url: "http://username.github.io/projectname"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -118,7 +118,7 @@
   {% if page.share-img %}
   <meta name="twitter:image" content="{{ page.share-img }}" />
   {% elsif site.twitter-img %}
-  <meta name="twitter:image" content="{{site.baseurl}}{{ site.twitter-img }}" />
+  <meta name="twitter:image" content="{{site.url}}{{site.baseurl}}{{ site.twitter-img }}" />
   {% endif %}
 
   {% if site.matomo %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -118,7 +118,7 @@
   {% if page.share-img %}
   <meta name="twitter:image" content="{{ page.share-img }}" />
   {% elsif site.twitter-img %}
-  <meta name="twitter:image" content="{{ site.twitter-img }}" />
+  <meta name="twitter:image" content="{{site.baseurl}}{{ site.twitter-img }}" />
   {% endif %}
 
   {% if site.matomo %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
       </button>
       {% if site.title-img %}
-        <a class="navbar-brand navbar-brand-logo logo" href="{{ site.url }}"><img alt="logo" src="{{ site.title-img }}"/></a>
+        <a class="navbar-brand navbar-brand-logo logo" href="{{ site.url }}"><img alt="logo" src="{{site.baseurl}}{{ site.title-img }}"/></a>
       {% else %}
         <a class="navbar-brand" href="{{ site.url }}">{{ site.title }}</a>
       {% endif %}


### PR DESCRIPTION
- Removes line from .circleci/circle_urls.sh that sets the path to the logo image.  
- Updates files that use site.title-img and site.twitter-img to add the baseurl before the relative path.

Tested locally.  Creating PR to make sure other tests still pass.