### PR TITLE
Add US-RSE code of conduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ There isn't a definitive rule, and it comes down to the intuition of a contribut
 and reviewers that are discussing the change. If you or your reviewers think that
 a change warrants adding a line to the log, you should add it.
 
-
+**2019-09-27** Adding Code of Conduct (@cosden)
 **2019-09-06** Adding pull request template and contributing.md (@vsoch)
 **2019-07-25** Adjusting name to US Research Software Engineer Association (@vsoch)
 **2019-06-13** Removing Gemfile.lock (@vsoch)

--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,7 @@ navbar-links:
     - RSE Groups: "rse-groups"
     - RSE Map: "map"
     - Steering Committee: "steering-committee"
+    - Code of Conduct: "code-of-conduct"
   Resources:
     - Community Blogs: "https://usrse.github.io/blog"
     - Events & Training: "events-training"

--- a/pages/community/code-of-conduct.md
+++ b/pages/community/code-of-conduct.md
@@ -89,7 +89,7 @@ and are committed to preserving and maintaining the welcoming nature of our comm
 
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the
 circumstances.
-All reports will be kept confidential, with the exception of cases where the steering committee determines it prudent to share the report with law enforcement.
+All reports will be kept confidential, with the exception of cases where the Steering Committee determines the report should shared with law enforcement.
 In those cases, the report will be shared with the proper legal authorities.
 
 In some cases the US-RSE Leadership may determine that a public statement will need to be made. If that’s the case, the identities of

--- a/pages/community/code-of-conduct.md
+++ b/pages/community/code-of-conduct.md
@@ -47,7 +47,7 @@ All communication should be appropriate for a professional audience including pe
 kind and courteous. There’s never a need to be mean, rude, or disrespectful. Thank you for helping make this a welcoming, friendly
 community for all.
 
-We, the members of US-RSE Association, strive to:
+We, the members of the US-RSE Association, strive to:
 
 * Be empathetic, respectful, welcoming, friendly, and patient. We remember that every US-RSE event, project, and program is crafted by
 human beings who deserve to be treated with kindness and empathy. We work together to resolve conflict and assume good intentions. We
@@ -59,7 +59,7 @@ people feel uncomfortable or threatened is not a productive one.
 <br>
 
 ## Unacceptable Behavior
-We, the members of US-RSE Association, are committed to making participation in this community a harassment-free experience.
+We, the members of the US-RSE Association, are committed to making participation in this community a harassment-free experience.
 
 We will not accept harassment or other exclusionary behaviors, such as:
 * The use of sexualized language or imagery  
@@ -85,7 +85,7 @@ addresses, without explicit permission
 
 ## Reporting Guidelines
 If you believe someone is violating the code of conduct, please report this in a timely manner (see How to Submit a Report). Code of
-conduct violations reduce the value of the community for everyone. US-RSE Association members take reports of misconduct very seriously
+conduct violations reduce the value of the community for everyone. The US-RSE Association members take reports of misconduct very seriously
 and are committed to preserving and maintaining the welcoming nature of our community.
 
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the
@@ -118,5 +118,5 @@ the [SciPy Code of Conduct](https://github.com/jupyter/governance/blob/master/co
 the [Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual),
 and the [NeurIPS Code of Conduct](https://nips.cc/public/CodeOfConduct).
 
-US-RSE Code of Conduct is licensed under a [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
+The US-RSE Association Code of Conduct is licensed under a [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
 

--- a/pages/community/code-of-conduct.md
+++ b/pages/community/code-of-conduct.md
@@ -89,7 +89,7 @@ and are committed to preserving and maintaining the welcoming nature of our comm
 
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the
 circumstances.
-All reports will be kept confidential, with the exception of cases where the Steering Committee determines the report should shared with law enforcement.
+All reports will be kept confidential, with the exception of cases where the Steering Committee determines the report should be shared with law enforcement.
 In those cases, the report will be shared with the proper legal authorities.
 
 In some cases the US-RSE Leadership may determine that a public statement will need to be made. If that’s the case, the identities of

--- a/pages/community/code-of-conduct.md
+++ b/pages/community/code-of-conduct.md
@@ -33,7 +33,7 @@ This code is not exhaustive or complete. It serves to distill our understanding 
 try to follow this code in spirit as much as in letter, to create a friendly and productive environment that enriches the US-RSE
 community.
 
-We require all US-RSE Association sponsored and affiliated projects, activities, and events, to adopt a code of conduct that encourages a productive, respectful environment for all contributors and community members. The US-RSE Association Code of Conduct follows below.
+We require all US-RSE Association sponsored and affiliated projects, activities, and events, to adopt a code of conduct that encourages a productive, respectful environment for all contributors and community members.
 
 If a person is found to violate the US-RSE Association Code of Conduct, the Steering Committee may take any action they deem appropriate
 to resolve the situation, including warning the person in question, removing them from a specific activity, banning them from further

--- a/pages/community/code-of-conduct.md
+++ b/pages/community/code-of-conduct.md
@@ -1,0 +1,122 @@
+---
+layout: page
+title: Code of Conduct
+permalink: /code-of-conduct/
+subtitle: The US-RSE Association Code of Conduct.
+---
+
+## Diversity Statement
+The US-RSE Association welcomes and encourages participation in our community by people of all backgrounds and identities. We, the members
+of the US-RSE Association, are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning. We work together as a community to help each other live out these values.
+
+We have created this diversity statement because we believe that a diverse community is stronger, more vibrant, and produces better
+software and better research. A diverse community where people treat each other with respect has more potential contributors,
+more sources for ideas, and fewer shared assumptions that might hinder the achievement of our goals.
+
+Although we have phrased the formal diversity statement generically to make it all-inclusive, we recognize that there are specific
+identities that are impacted by systemic discrimination and marginalization. We welcome all people to participate in the US-RSE
+Association regardless of their identity or background.
+
+<br>
+
+## Introduction & Scope
+
+This code of conduct should be honored by everyone who participates in the US-RSE community. It should be honored in any US-RSE-related
+activities, by anyone claiming affiliation with US-RSE, and especially when someone is representing the US-RSE Association in any role (including as an event volunteer or speaker).
+
+This code of conduct applies to all spaces managed by the US-RSE Association, including all public and private mailing lists, issue
+trackers, wikis, forums, code repositories, and any other communication channel used by our community. The code of conduct equally
+applies at US-RSE Association events and governs standards of behavior for attendees, speakers, volunteers, booth staff, and event
+sponsors.
+
+This code is not exhaustive or complete. It serves to distill our understanding of a collaborative, inclusive community culture. Please
+try to follow this code in spirit as much as in letter, to create a friendly and productive environment that enriches the US-RSE
+community.
+
+We require all US-RSE Association sponsored and affiliated projects, activities, and events, to adopt a code of conduct that encourages a productive, respectful environment for all contributors and community members. The US-RSE Association Code of Conduct follows below.
+
+If a person is found to violate the US-RSE Association Code of Conduct, the Steering Committee may take any action they deem appropriate
+to resolve the situation, including warning the person in question, removing them from a specific activity, banning them from further
+participation in activities (in person or online), or expulsion from the US-RSE Association.
+
+<br>
+
+## Standards for Behavior
+
+All communication should be appropriate for a professional audience including people of many different backgrounds. Please always be
+kind and courteous. There’s never a need to be mean, rude, or disrespectful. Thank you for helping make this a welcoming, friendly
+community for all.
+
+We, the members of US-RSE Association, strive to:
+
+* Be empathetic, respectful, welcoming, friendly, and patient. We remember that every US-RSE event, project, and program is crafted by
+human beings who deserve to be treated with kindness and empathy. We work together to resolve conflict and assume good intentions. We
+may all experience some frustration from time to time, but we do not allow frustration to turn into a personal attack. A community where
+people feel uncomfortable or threatened is not a productive one.  
+* Be collaborative. Our work depends on the participation of many people, and in turn others depend on our work. Effective and friendly collaboration enables everyone to better achieve their goals.  
+* Be careful in the words that we choose. We are careful and respectful in our communication, and we take responsibility for our own speech. Be kind to others. Do not insult or put down other members of the community.
+
+<br>
+
+## Unacceptable Behavior
+We, the members of US-RSE Association, are committed to making participation in this community a harassment-free experience.
+
+We will not accept harassment or other exclusionary behaviors, such as:
+* The use of sexualized language or imagery  
+* Excessive profanity (please avoid curse words; people differ greatly in their sensitivity to swearing)  
+* Posting sexually explicit or violent material
+* Violent or intimidating threats or language directed against another person or group
+* Inappropriate physical contact and/or unwelcome sexual attention or sexual comments
+* Sexist, racist, or otherwise discriminatory jokes and language
+* Trolling or insulting and derogatory comments
+* Written or verbal comments which have the effect of excluding people on the basis of membership in a specific group, including level
+of experience, gender, gender identity and expression, sexual orientation, disability, neurotype, personal appearance, body size, race,
+ethnicity, age, religion, or nationality
+* Public or private harassment
+* Sharing private content, such as emails sent privately or non-publicly, or direct message history, without the sender’s consent
+* Continuing to initiate interaction (such as photography, recording, messaging, or conversation) with someone after being asked to stop
+* Sustained disruption of talks, events, or communications, such as heckling of a speaker
+* Publishing (or threatening to post) other people’s personally identifying information (“doxing”), such as physical or electronic
+addresses, without explicit permission
+* Other unethical or unprofessional conduct
+* Advocating for, or encouraging, any of the above behaviors
+
+<br>
+
+## Reporting Guidelines
+If you believe someone is violating the code of conduct, please report this in a timely manner (see How to Submit a Report). Code of
+conduct violations reduce the value of the community for everyone. US-RSE Association members take reports of misconduct very seriously
+and are committed to preserving and maintaining the welcoming nature of our community.
+
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the
+circumstances. All reports will be kept confidential.
+
+In some cases the US-RSE Leadership may determine that a public statement will need to be made. If that’s the case, the identities of
+all involved parties and reporters will remain confidential unless those individuals instruct us otherwise.
+
+For possibly unintentional breaches of the code of conduct, you may want to respond to the person and point out this code of conduct 
+(either in public or in private, whatever is most appropriate). If you would prefer not to do that, please report the issue (see How to 
+Submit a Report) or contact a US-RSE Association Steering Committee member for assistance.
+
+Take care of each other. Alert the US-RSE Association Steering Committee (contact@us-rse.org) if you notice a dangerous situation, 
+someone in distress, or violations of this code of conduct, even if they seem inconsequential.
+
+### How to Submit a Report
+If you feel your safety is in jeopardy or the situation is an emergency, contact local law enforcement before making a report to the US-RSE Association. (In the U.S., dial 911.)
+
+The US-RSE Association is committed to promptly addressing any reported issues. If you have experienced or witnessed behavior that violates the US-RSE Association Code of Conduct, please send an email to contact@us-rse.org. These emails are sent to the US-RSE Association Steering Committee.
+
+<br>
+
+## License
+This code of conduct has been adapted from the NumFocus code of conduct, which was itself adapted from numerous sources, including the
+[Geek Feminism wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy), created by the Ada Initiative and other volunteers, 
+which is under a [Creative Commons Zero license](https://creativecommons.org/share-your-work/public-domain/cc0/), 
+the [Contributor Covenant version 1.2.0](http://contributor-covenant.org/version/1/2/0/), 
+the [Bokeh Code of Conduct](https://github.com/bokeh/bokeh/blob/master/CODE_OF_CONDUCT.md), 
+the [SciPy Code of Conduct](https://github.com/jupyter/governance/blob/master/conduct/enforcement.md),
+the [Carpentries Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#enforcement-manual),
+and the [NeurIPS Code of Conduct](https://nips.cc/public/CodeOfConduct).
+
+US-RSE Code of Conduct is licensed under a [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
+

--- a/pages/community/code-of-conduct.md
+++ b/pages/community/code-of-conduct.md
@@ -73,7 +73,6 @@ We will not accept harassment or other exclusionary behaviors, such as:
 of experience, gender, gender identity and expression, sexual orientation, disability, neurotype, personal appearance, body size, race,
 ethnicity, age, religion, or nationality
 * Public or private harassment
-* Sharing private content, such as emails sent privately or non-publicly, or direct message history, without the sender’s consent
 * Continuing to initiate interaction (such as photography, recording, messaging, or conversation) with someone after being asked to stop
 * Sustained disruption of talks, events, or communications, such as heckling of a speaker
 * Publishing (or threatening to post) other people’s personally identifying information (“doxing”), such as physical or electronic
@@ -89,7 +88,9 @@ conduct violations reduce the value of the community for everyone. The US-RSE As
 and are committed to preserving and maintaining the welcoming nature of our community.
 
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the
-circumstances. All reports will be kept confidential.
+circumstances.
+All reports will be kept confidential, with the exception of cases where the steering committee determines it prudent to share the report with law enforcement.
+In those cases, the report will be shared with the proper legal authorities.
 
 In some cases the US-RSE Leadership may determine that a public statement will need to be made. If that’s the case, the identities of
 all involved parties and reporters will remain confidential unless those individuals instruct us otherwise.


### PR DESCRIPTION
## Description
Adds the US-RSE official code of conduct 

## Motivation and Context
Based on the discussion in the slack channel this is likely ready for prime time.  It can change later, but this is an excellent first iteration. 

## Checklist:
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [x] I have updated the CHANGELOG and (if necessary) the README.md

cc @usrse-maintainers


