### PR TITLE
Updating for september counts

### DIFF
--- a/_data/memberCounts.csv
+++ b/_data/memberCounts.csv
@@ -17,4 +17,5 @@ Date,Count,Total
 "May, 2019",17,46
 "June, 2019",39,85
 "July, 2019",61,146
-"August, 2019",22,168
+"August, 2019",22,166
+"September, 2019",13,179


### PR DESCRIPTION
This will update the data to include September counts! 

 - The September total is 179, with 13 new members since August
 - The August count is off by two (168 instead of 166). I'm not sure where 168 came from, but the spreadsheet says 166 for August, you can verify here:

https://docs.google.com/spreadsheets/d/1FTnl8ucFKYtiS2xhNiK8VwXeE5BuBDCzL_k9SbqyG6A/edit#gid=1109363929

And so I've fixed this number too.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

cc @usrse-maintainers
