### PR TITLE
Adding rse job at internet2

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,7 @@
+- name: "Research Software Engineer at Internet2"
+  location: "Ann Arbor, MI or remote"
+  url: https://www.linkedin.com/jobs/view/1572354114/?fbclid=IwAR3s2kKIy4z5cKpU5XfHifxN0B2x9RJNWqVFRUIJqi82VdR2MAOlOTwpH6o
+  expires: 2020-01-01
 - name: "Senior Scientific Programmer at Boston University"
   location: Boston, MA
   url: http://www.bu.edu/tech/support/research/rcs/jobs/


### PR DESCRIPTION
This will add a position at Internet2 shared by a colleague on the Campus Champions slack! How awesome that the full title is "Research Software Engineer?" Let's hope that the LinkedIn link doesn't poop out (others have before).

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>
