### PR TITLE
Adding style check for portrait and device width for rse graph display

### DIFF
--- a/_includes/member-graph.html
+++ b/_includes/member-graph.html
@@ -1,3 +1,10 @@
+<style>
+@media screen and (max-width:767px) and (orientation:portrait) {
+  #app {
+    display: none;
+  }
+}
+</style>
 <div class="container-fluid" style="padding:50px">
     <div class="row" id="app">
         <div class="col-md-12">


### PR DESCRIPTION
This will add css so that the members graph doesn't show when in portrait on devices with width less than 767px. It will close #133.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

cc @usrse-maintainers
