### PR TITLE
Create 2020-01-28-community-call.md

### DIFF
--- a/_events/2020/2020-01-28-community-call.md
+++ b/_events/2020/2020-01-28-community-call.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: Winter Community Call
+posted_by: Christina Maimone
+tags: [event]
+---
+
+Our next community call is February 11, 2pm EST.  The main topic of discussion is a draft US-RSE Communications Guide to help coordinate activities of the group.  
+
+Other topics are also welcome!  Bring them up on the call or on Slack.
+
+The Zoom connection details and a link to the draft US-RSE Communications Guide is posted in the general channel on Slack.   

--- a/_events/2020/2020-01-28-community-call.md
+++ b/_events/2020/2020-01-28-community-call.md
@@ -1,8 +1,8 @@
 ---
-layout: post
 title: Winter Community Call
-posted_by: Christina Maimone
-tags: [event]
+expires: 2020-02-12
+event_date: "February 11, 2020"
+layout: event
 ---
 
 Our next community call is February 11, 2pm EST.  The main topic of discussion is a draft US-RSE Communications Guide to help coordinate activities of the group.  


### PR DESCRIPTION
Posting on the upcoming community call to the events page.  

Is there a way to have this included on the main feed as well without making a separate post?  Would we even want to do that?