### PR TITLE
Fix/update membership counts edge bug

### DIFF
--- a/.github/workflows/member-counts.yaml
+++ b/.github/workflows/member-counts.yaml
@@ -18,7 +18,7 @@ jobs:
         sudo apt-get update && sudo apt-get install -y python3 python3-pip wget
         sudo pip3 install requests
         # Ensure using a particular version
-        wget https://raw.githubusercontent.com/USRSE/usrse.github.io/71ae72c2a5524c502e0bb51c5ca764dd854eea18/scripts/update_counts.py
+        wget https://raw.githubusercontent.com/USRSE/usrse.github.io/67b0e14f46178d5f9dbd5a9a118d26fa5b93748e/scripts/update_counts.py
         chmod +x update_counts.py
         mv update_counts.py scripts/update_counts.py
         python3 scripts/update_counts.py

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,7 +1,3 @@
-- name: "Research Software Engineer"
-  location: Princeton University
-  url: https://research-princeton.icims.com/jobs/11166/research-software-engineer/job
-  expires: 2020-02-15
 - name: "Research Software Engineering Fellow"
   location: NumFOCUS
   url: https://numfocus.org/blog/now-hiring-matplotlib-research-software-engineering-fellow

--- a/_data/memberCounts.csv
+++ b/_data/memberCounts.csv
@@ -22,3 +22,4 @@ September 2019,13,179
 October 2019,18,197
 November 2019,43,240
 December 2019,19,259
+January 2020,20,279

--- a/scripts/update_counts.py
+++ b/scripts/update_counts.py
@@ -80,8 +80,12 @@ def main():
     # [['August, 2019', '22', '168']...]
     data = read_rows(filepath)
 
-    # The last row must be the previous month year
-    last_row = "%s %s" %(previous_month, year)
+    # The last row must be the previous month year, unless December, then it's next year
+    if previous_month == "December":
+        last_row = "%s %s" %(previous_month, year+1)    
+    else:
+        last_row = "%s %s" %(previous_month, year)
+
     if data[-1][0] != last_row:
         print("Last month should be %s, but found %s. The file is already updated." %(last_row, data[-1][0]))
         sys.exit(0)

--- a/scripts/update_counts.py
+++ b/scripts/update_counts.py
@@ -82,7 +82,7 @@ def main():
 
     # The last row must be the previous month year, unless December, then it's next year
     if previous_month == "December":
-        last_row = "%s %s" %(previous_month, year-1)
+        last_row = "%s %s" %(previous_month, int(year)-1)
     else:
         last_row = "%s %s" %(previous_month, year)
 

--- a/scripts/update_counts.py
+++ b/scripts/update_counts.py
@@ -82,7 +82,7 @@ def main():
 
     # The last row must be the previous month year, unless December, then it's next year
     if previous_month == "December":
-        last_row = "%s %s" %(previous_month, year+1)    
+        last_row = "%s %s" %(previous_month, year-1)
     else:
         last_row = "%s %s" %(previous_month, year)
 


### PR DESCRIPTION
This should address the issue that when we transition from December of the previous year, we need to subtract 1 to get the previous year. I also ran the script locally to both test and update the count, since the workflow didn't handle it.