### PR TITLE
Add calendar page with embedded google calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ There isn't a definitive rule, and it comes down to the intuition of a contribut
 and reviewers that are discussing the change. If you or your reviewers think that
 a change warrants adding a line to the log, you should add it.
 
+**2020-02-17** Adding calendar page with embedded google calendar (@jordanperr)
 **2019-11-15** Adding List of Community Driven Initiative (Get Involved) (@lparsons)
 **2019-09-27** Adding Code of Conduct (@cosden)
 **2019-09-06** Adding pull request template and contributing.md (@vsoch)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM jekyll/jekyll
 
 COPY Gemfile .
-COPY Gemfile.lock .
 
 RUN bundle install --quiet --clean
 

--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ navbar-links:
     - Steering Committee: "steering-committee"
     - Code of Conduct: "code-of-conduct"
   Resources:
+    - Calendar: "calendar"
     - Community Blogs: "https://usrse.github.io/blog"
     - Events & Training: "events-training"
     - Links: "links"

--- a/pages/resources/calendar.md
+++ b/pages/resources/calendar.md
@@ -5,4 +5,4 @@ description: Calendar of US-RSE Events
 permalink: /calendar/
 ---
 
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23eeeeee&amp;ctz=America%2FDenver&amp;src=dXMtcnNlLm9yZ184bzc3NHIxbDdvMHY3dHY1aW02ZnFhdXM1b0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%23009688&amp;showTitle=1&amp;showNav=1&amp;mode=AGENDA" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23eeeeee&amp;src=dXMtcnNlLm9yZ184bzc3NHIxbDdvMHY3dHY1aW02ZnFhdXM1b0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%23009688&amp;showTitle=1&amp;showNav=1&amp;mode=AGENDA" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/pages/resources/calendar.md
+++ b/pages/resources/calendar.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Calendar
+description: Calendar of US-RSE Events
+permalink: /calendar/
+---
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23eeeeee&amp;ctz=America%2FDenver&amp;src=dXMtcnNlLm9yZ184bzc3NHIxbDdvMHY3dHY1aW02ZnFhdXM1b0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%23009688&amp;showTitle=1&amp;showNav=1&amp;mode=AGENDA" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a Calendar page under the Resources tab that features an embedded google calendar. This calendar is owned by @christophernhill and the steering committee should have edit privileges.

## Motivation and Context
- Adds calendar, as discussed in steering committee meeting 2-7-2020
- Closes issue #116 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ x ] I have previewed changes locally
- [ x ] I have updated the CHANGELOG and (if necessary) the README.md

cc @usrse-maintainers
