### PR TITLE
Updating links for jobs and slack

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,7 +49,7 @@ navbar-links:
     - Contribute: "get-involved"
   Careers:
     - What is an RSE?: "what-is-an-rse"
-    - RSE openings: "jobs"
+    - RSE Jobs: "jobs"
 
 # --- Background colour/image options --- #
 

--- a/pages/resources/links.md
+++ b/pages/resources/links.md
@@ -25,5 +25,6 @@ _These resources can be helpful to establish RSE positions, groups, or further u
  - [RSE Starter Pack](https://us-rse.org/starter-pack/#/) getting started to create an RSE community as an RSE
  - [The Story of the Research Software Engineer](https://www.youtube.com/watch?v=trAfA9VWLTQ) video introduction to Research Software Engineering
  - [US-RSE Logos](https://github.com/usrse/logo) repository
+ - [US-RSE Slack](https://usrse.slack.com/)
 
 


### PR DESCRIPTION
This is a small PR to respond to both personal experience and feedback about organization of content.  The changes include:

## changing "RSE positions" to be "jobs." 

The reason is because after coming back to the site after some time, I intuitively was looking for a "Jobs" link but couldn't find one. It took me about 3x the amount of time to realize that we call it RSE positions. I think just saying that it's jobs is more straight forward, and the fact that they are RSE related is implied based on being on the site.

## Slack Link

A colleague was looking for the slack link, and she/he intuitively went to links, but didn't see it there. The link was only found as a "reach out to us on slack" footer for an unrelated page, found via a search. I think we should have the link placed where it will be looked for - right now under the resources list of links makes sense.

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
