### PR TITLE
Add Xpert Network Webinar and PEARC20 Workshop

### DIFF
--- a/_events/2020/2020-03-xpert-network.md
+++ b/_events/2020/2020-03-xpert-network.md
@@ -1,0 +1,14 @@
+---
+title: Xpert Network Webinar Series
+subtitle:
+location: Online
+url:  https://sites.udel.edu/xpert-cdi/event-category/online-meeting/ 
+expires: 2020-12-31
+event_date: "Reoccurring: 3rd Thursday of each month, 3-4pm ET"
+layout: event
+---
+
+This project aims to advance science by increasing the productivity of researchers who use computational and data-intensive (CDI) methods for pushing the frontiers by developing a network for exchange of best practices in expert assistance and in the creation of supporting tool environments.
+
+Connection details and additional information on the current webinar agenda is available [here](https://sites.udel.edu/xpert-cdi/event-category/online-meeting/).
+

--- a/_events/2020/2020-07-pearc20.md
+++ b/_events/2020/2020-07-pearc20.md
@@ -1,0 +1,23 @@
+---
+title: Research Software Engineers Community Workshop
+subtitle: PEARC20
+location: PEARC20 Portland, OR
+url: https://pearc.acm.org/pearc20/
+expires: 2020-07-31
+event_date: "July 26-30, 2020"
+layout: event
+---
+
+
+Join us at PEARC20 for a full day workshop focused on Research
+Software Engineers.  The workshop will provide an opportunity for
+research software engineers to connect in person, share their work,
+and contribute to the growth of the community.  There will be
+presentations from RSEs about their work and their groups, and about
+the development of the RSE community.  We will work together to
+identify key tasks for building the research software engineering
+community and organize working groups to address these issues after
+the conference.
+
+More information will be available as the event nears at the [PEARC20
+conference website](https://pearc.acm.org/pearc20/).


### PR DESCRIPTION
## Description
This adds two events:
1. A reoccurring webinar (Xpert Network) that is likely to be of interest to many community members
1. The recently accepted PEARC20 workshop

I've previewed it locally and to be honest, I'm not sure I like how the Events page orders things (appears to be in reverse chronological order), but I can't decide, nor do I have the time to tinker.  I see merits to both.  Figured I'd submit it here and let others weigh in. 

cc @usrse-maintainers
