### PR TITLE
updating contributors graphic generation to be conservative

### DIFF
--- a/.github/workflows/update-contributors-graphic.yml
+++ b/.github/workflows/update-contributors-graphic.yml
@@ -29,25 +29,27 @@ jobs:
     - name: Checkout New Branch
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH_AGAINST: "master"
       run: |
-        echo "GitHub Actor: ${GITHUB_ACTOR}"
+        printf "GitHub Actor: ${GITHUB_ACTOR}\n"
+        export BRANCH_FROM="update/sourcecred-$(date '+%Y-%m-%d')"
         git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         git branch
-        git checkout -b update/sourcecred-$(date '+%Y-%m-%d')
+        git checkout -b "${BRANCH_FROM}" || git checkout "${BRANCH_FROM}"
         git branch
 
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@users.noreply.github.com"
 
         git add contributors.svg
-        git commit -m "Automated deployment to update contributors.svg $(date '+%Y-%m-%d')" --allow-empty
-        git push origin update/sourcecred-$(date '+%Y-%m-%d')
-    - name: Open pull request
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH_AGAINST: "master"
-      run: |
-          export BRANCH_FROM="update/sourcecred-$(date '+%Y-%m-%d')"
-          wget https://raw.githubusercontent.com/USRSE/usrse.github.io/14617e0af7771636911aecf31d38fa88cd4f3adb/scripts/graphic_pull_request.sh
-          chmod +x graphic_pull_request.sh
-          /bin/bash graphic_pull_request.sh
+
+        if git diff-index --quiet HEAD --; then
+           printf "No changes\n"
+        else
+           printf "Changes\n"
+           git commit -m "Automated deployment to update contributors.svg $(date '+%Y-%m-%d')"
+           git push origin "${BRANCH_FROM}"
+           wget https://raw.githubusercontent.com/USRSE/usrse.github.io/14617e0af7771636911aecf31d38fa88cd4f3adb/scripts/graphic_pull_request.sh
+           chmod +x graphic_pull_request.sh
+           /bin/bash graphic_pull_request.sh
+        fi


### PR DESCRIPTION
Currently, when we generate an updated graphic, if there are no changes, the action pushes anyway with `--allow-empty`. It would be nice to just skip the push entirely so I don't need to do an empty review and close, which is the intention of this PR.

This means that we do a check of the staged changes against the current head, and only commit, push, and open a pull request in the case that there are changes. We were previously using the --allow-empty tag, which would open an empty PR and require me to review and close it

I also updated echos to printfs, because I learned that there are some security vulnerabilities with echo.

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
