### PR TITLE
adding job for xsede architect

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,7 @@
+- name: Architect, PACE team at Georgia Institute of Technology
+  location: Atlanta, GA
+  url: https://pace.gatech.edu/xsedeosg-architect
+  expires: 2020-06-10
 - name: Staff Scientist/Software Engineer at New Mexico Tech
   location: Socorro, NM
   url: https://www.nmt.edu/hr/docs/hr/jobs/StaffSciSoftEngIRIS20-030.pdf


### PR DESCRIPTION
This will add the XSEDE Architect position at Georgia Institute of Technology.

cc @usrse-maintainers
