### PR TITLE
Testing if renamed action repository means action name needs update

### DIFF
--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: URLs-checker
-      uses: urlstechie/URLs-checker@0.1.7
+      uses: urlstechie/urlchecker-action@0.1.7
       with:
         # A comma-separated list of file types to cover in the URL checks
         file_types: .md,.py,.yml


### PR DESCRIPTION
We're working more on the url checker, and are renaming the action repository to see if we need to update the action accordingly. This PR will test that - if it breaks the action, then we should maintain the old name, and update if we bump the version. If it passes, then we are good to merge. I've never renamed an action repo so I'm excited to see what happens :)

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
