### PR TITLE
Adding scheduler architect job at georgia tech

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -2,6 +2,10 @@
   location: Atlanta, GA
   url: https://pace.gatech.edu/xsedeosg-architect
   expires: 2020-06-10
+- name: Scheduler Architect, PACE team at Georgia Institute of Technology
+  location: Atlanta, GA
+  url: https://pace.gatech.edu/scheduler-architect
+  expires: 2020-06-10
 - name: Staff Scientist/Software Engineer at New Mexico Tech
   location: Socorro, NM
   url: https://www.nmt.edu/hr/docs/hr/jobs/StaffSciSoftEngIRIS20-030.pdf


### PR DESCRIPTION
This PR will add a Scheduler Architect position with the PACE team at Georgia Tech, a contribution from slack.

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
