### PR TITLE
Add 2020-april-workshop redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,33 @@ not be repeated, and should be placed in a folder named by date.
 Repeated events are always shown at the top of the events page, and 
 do not expire.
 
+### 4. How do I add a page redirect?
+
+We have a special header field that you can define if you want a page to redirect 
+elsewhere. We do this by way of a meta tag, and we give the viewer 2 seconds
+to see a message that they are being redirected.  To keep these pages
+organized, we have them located in the `redirects` folder:
+
+```
+$ ls pages/redirects/
+2020-april-workshop.md
+```
+
+And the header front end matter should look like the following:
+
+```yaml
+---
+layout: page
+title: US-RSE Community Building Workshop
+permalink: /2020-april-workshop/
+redirect: https://us-rse.org/first-community-workshop
+---
+```
+
+The above says that the page titled "US-RSE Community Building Workshop" served
+at permalink /2020-april-workshop will be redirected to 
+https://us-rse.org/first-community-workshop.
+
 ## Tests
 
 Tests are run during continuous integration to catch any errors and to preview

--- a/_events/2020/2020-april-community-workshop.md
+++ b/_events/2020/2020-april-community-workshop.md
@@ -2,7 +2,7 @@
 title: US-RSE Workshop
 subtitle: A First US-RSE Community Building Workshop
 location: Princeton, NJ
-url: https://us-rse.org/2020-oct-workshop/
+url: https://us-rse.org/first-community-workshop
 expires: 2020-04-23
 event_date: "April 21–22, 2020"
 layout: event
@@ -25,4 +25,4 @@ US-RSE Association. We will also plan follow-up activities to grow the
 community.
 
 More information, including how to participate, can be found on the
-[workshop event page](https://us-rse.org/2020-oct-workshop/).
+[workshop event page](https://us-rse.org/first-community-workshop/).

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,7 @@
 
   <meta name="author" content="{{ site.author.name }}" />
 
+  {% if page.redirect %}<meta http-equiv="refresh" content="2;url={{ page.redirect }}"/>{% endif %}
   {% if page.subtitle %}
   <meta name="description" content="{{ page.subtitle }}">
   {% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -8,6 +8,7 @@ layout: base
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
       {{ content }}
+        {% if page.redirect %}This page is redirecting you to <a href="{{ page.redirect }}">{{ page.redirect }}</a>.{% endif %}
         {% if page.comments %}<div class="disqus-comments">
 	    {% include disqus.html %}
         </div>{% endif %}

--- a/_posts/2019-11-14-april-2020-workshop.md
+++ b/_posts/2019-11-14-april-2020-workshop.md
@@ -10,7 +10,7 @@ This won't be an attempt to be an RSE conference, but a workshop focused on plan
 
 
 The workshop will have breakout sessions focused on a number of different topics pertinent to the US-RSE community.
-We’ll be working together to generate content for the us-rse.org website that promotes and supports current/future RSEs in alignment with the [mission](https://us-rse.org/mission/) of the US-RSE Association. We will also plan follow-up activities to grow the community. More specific workshop information and details can be found at [US-RSE Community Building Workshop](https://us-rse.org/2020-oct-workshop/).
+We’ll be working together to generate content for the us-rse.org website that promotes and supports current/future RSEs in alignment with the [mission](https://us-rse.org/mission/) of the US-RSE Association. We will also plan follow-up activities to grow the community. More specific workshop information and details can be found at [US-RSE Community Building Workshop](https://us-rse.org/first-community-workshop/).
 
 You can find out more and express interest in attending by filling out the **[US-RSE Workshop Interest Form](https://forms.gle/tzronZUGdUTT9zzb9)**.
 

--- a/pages/redirects/2020-april-workshop.md
+++ b/pages/redirects/2020-april-workshop.md
@@ -2,11 +2,6 @@
 layout: page
 title: US-RSE Community Building Workshop
 permalink: /2020-april-workshop/
-subtitle: 
+redirect: https://us-rse.org/first-community-workshop
+subtitle: US-RSE Community Building Workshop
 ---
-
-This page is redirecting you to https://us-rse.org/first-community-workshop.
-
-<script>
-window.location = "https://us-rse.org/first-community-workshop";
-</script>

--- a/pages/redirects/2020-april-workshop.md
+++ b/pages/redirects/2020-april-workshop.md
@@ -1,0 +1,12 @@
+---
+layout: page
+title: US-RSE Community Building Workshop
+permalink: /2020-april-workshop/
+subtitle: 
+---
+
+This page is redirecting you to https://us-rse.org/first-community-workshop.
+
+<script>
+window.location = "https://us-rse.org/first-community-workshop";
+</script>


### PR DESCRIPTION
### Draft 

Thanks to COVID-19, we had to postpone the April 2020 Community Building Workshop.  The workshop page was a separate github project "2020-april-workshop".  Rather than keep the url, that project was changed to "first-community-workshop". 

This PR creates a redirects folder (in case it's needed in the future) with a simple file that is permalinked at /2020-april-workshop/ that has a redirect to us-rse.org/first-community-workshop.

### Before Merge
Needs https://github.com/USRSE/2020-oct-workshop/pull/7 to be merged and the corresponding repo renamed

