### PR TITLE
Adding redirect page for workshop agenda

### DIFF
--- a/pages/redirects/2020-april-workshop-agenda.md
+++ b/pages/redirects/2020-april-workshop-agenda.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: US-RSE Community Building Workshop
+permalink: /2020-april-workshop/agenda/
+redirect: https://us-rse.org/first-community-workshop/agenda/
+subtitle: US-RSE Community Building Workshop Agenda
+---


### PR DESCRIPTION
This will address #186, namely that an agenda subpage is still 404 (and we assume it is linked from previous emails, etc.)

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
