### PR TITLE
Create 2020-04-09-virtual-workshop.md

### DIFF
--- a/_posts/2020-04-09-virtual-workshop.md
+++ b/_posts/2020-04-09-virtual-workshop.md
@@ -7,9 +7,9 @@ tags: [workshop]
 We are excited to announce that the US-RSE Association will host a virtual workshop on April 22 and 23, 2020!  
 
 This workshop will be held in three online sessions:
-1. The RSE Landscape - Reports on RSE groups and activities, with discussion (Wednesday 4/22, 12:00-1:30 PM EDT)
-1. Technical talks - Short talks about projects that RSEs are working on (Wednesday 4/22, 3:00-4:30 PM EDT)
-1. Next steps for the US-RSE organization - Breakout sessions to discuss ideas. What do *you* want from US-RSE? (Thursday 4/23, 12:00-1:30 PM EDT)
+1. **The RSE Landscape** - Reports on RSE groups and activities, with discussion (Wednesday 4/22, 12:00-1:30 PM EDT)
+1. **Technical talks** - Short talks about projects that RSEs are working on (Wednesday 4/22, 3:00-4:30 PM EDT)
+1. **Next steps for the US-RSE organization** - Breakout sessions to discuss ideas. What do *you* want from US-RSE? (Thursday 4/23, 12:00-1:30 PM EDT)
 
 A detailed agenda is in the works and will be posted online when ready.
 

--- a/_posts/2020-04-09-virtual-workshop.md
+++ b/_posts/2020-04-09-virtual-workshop.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: Virtual US-RSE Workshop
+tags: [workshop]
+---
+
+We are excited to announce that the US-RSE Association will host a virtual workshop on April 22 and 23, 2020!  
+
+This workshop will be held in three online sessions:
+1. The RSE Landscape - Reports on RSE groups and activities, with discussion (Wednesday 4/22, 12:00-1:30 PM EDT)
+1. Technical talks - Short talks about projects that RSEs are working on (Wednesday 4/22, 3:00-4:30 PM EDT)
+1. Next steps for the US-RSE organization - Breakout sessions to discuss ideas. What do *you* want from US-RSE? (Thursday 4/23, 12:00-1:30 PM EDT)
+
+A detailed agenda is in the works and will be posted online when ready.
+
+The workshop is free, but we ask that all participants preregister so that we know how many to expect and can prepare appropriately. The registration form will be posted soon.
+
+The sessions will be held using Zoom.  Connection information will be sent to registered participants before the workshop.
+(We've seen the recent news about Zoom security issues, and we will be taking appropriate security precautions.)
+
+If you have questions or would like to contribute please contact contact@us-rse.org or reach out via [slack](https://usrse.slack.com/).
+To join the slack channel follow the link to join US-RSE [here](https://us-rse.org/join/). 


### PR DESCRIPTION
Add an announcement post about the upcoming virtual workshop.  Basically a copy and past from the slack announcement but with a couple hyperlinks at the bottom.  

If an events page eventually follows, we could update this with a link to it. 