### PR TITLE
Whitelisting map.yml for urlchecker

### DIFF
--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -27,4 +27,4 @@ jobs:
         white_listed_patterns: sc19.supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com
 
         # White list the following files
-        white_listed_files: README.md,SocialNetworks.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
+        white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/


### PR DESCRIPTION
The map.yml is technically no longer rendered for the site, but kept as a static file because there is valuable data there. Since one of the links mentioned in https://github.com/USRSE/usrse.github.io/issues/220 is having an SSL issue, it makes sense to disable the urlchecker for it. This PR can be merged when the urlchecker test passes.