### PR TITLE
adding additional support links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: US-RSE Code of Conduct
+    url: https://us-rse.org/code-of-conduct/
+    about: Read our Code of Conduct
+  - name: Get in Contact
+    url: https://us-rse.org/steering-committee/
+    about: Get in Contact with the Steering Committee
+  - name: US-RSE How to Get Involved
+    url: https://us-rse.org/get-involved/
+    about: How to get involved with US-RSE
+  - name: Join US-RSE
+    url: https://us-rse.org/join/
+    about: If you aren't a member, you can join US-RSE here.


### PR DESCRIPTION
Sometimes people might want to get help / be directed to the code of conduct, or get in contact with someone outside of GitHub. I was reading about the ability to [configure](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) contact links in issues, and thought it might be a good thing to do for our repository. Note that I haven't tried this before (_and_ GitHub just had a UI change) so I'm not entirely sure what it will look like, but I suspect the contact links will appear under "Helpful Resources" or similar in the column to the right.

And if we hate it, we can always remove it! :) But I do think this could be useful for new contributors, etc.