### PR TITLE
adding testing job to update contributors

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,82 @@
+name: allcontributors-auto-detect
+
+on:
+  pull_request: []
+  push:
+    branches:
+      - master
+
+jobs:
+  Update:
+    name: Generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Tributors Update
+      
+        # Important! Update to release https://github.com/con/tributors
+        uses: con/tributors@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:        
+
+          # Single text list (space separated) of parsers, leave unset to auto-detect
+          parsers: unset
+
+          # INFO, DEBUG, ERROR, WARNING, etc.
+          log_level: DEBUG
+
+          # If files already exist and an init is done, force overwrite
+          force: true
+
+          # the minimum number of contributions required to add a user
+          threshold: 1
+
+      - name: Checkout New Branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_AGAINST: "master"
+        run: |
+          printf "GitHub Actor: ${GITHUB_ACTOR}\n"
+          export BRANCH_FROM="tributors/update-$(date '+%Y-%m-%d')"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          BRANCH_EXISTS=$(git ls-remote --heads origin ${BRANCH_FROM})
+          if [[ -z ${BRANCH_EXISTS} ]]; then
+              printf "Branch does not exist in remote.\n"
+          else
+              printf "Branch already exists in remote.\n"
+              exit 1
+          fi
+          git branch
+          git checkout -b "${BRANCH_FROM}" || git checkout "${BRANCH_FROM}"
+          git branch
+
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+          git status
+ 
+          git add README.md
+          git add .all-contributorsrc
+
+          if git diff-index --quiet HEAD --; then
+             export OPEN_PULL_REQUEST=0
+             printf "No changes\n"
+          else
+             export OPEN_PULL_REQUEST=1
+             printf "Changes\n"
+             git commit -m "Automated deployment to update contributors $(date '+%Y-%m-%d')"
+             git push origin "${BRANCH_FROM}"
+          fi
+          echo "::set-env name=OPEN_PULL_REQUEST::${OPEN_PULL_REQUEST}"
+          echo "::set-env name=PULL_REQUEST_FROM_BRANCH::${BRANCH_FROM}"
+          echo "::set-env name=PULL_REQUEST_TITLE::[tributors] ${BRANCH_FROM}"
+          echo "::set-env name=PULL_REQUEST_BODY::Downsizing images automated pull request."
+
+      - name: Open Pull Request
+        uses: vsoch/pull-request-action@1.0.6
+        if: ${{ env.OPEN_PULL_REQUEST == '1' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_BRANCH: "master"


### PR DESCRIPTION
This will add a workflow (to run after merges to master) that will update the contributors rendering in the readme, if warranted. I've added pull_request to the triggers to see if it runs okay, and we will also want to update to a released version.