### PR TITLE
Update Job page

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -44,3 +44,6 @@
     University of Washington, Seattle, WA', name: Software Engineer, url: 'http://www.healthdata.org/job-posting/software-engineer'}
 - {expires: 2020-08-01, location: 'Princeton University, Princeton, NJ', name: Professional
     Specialist, url: 'https://puwebp.princeton.edu/AcadHire/apply/application.xhtml?listingId=16041'}
+- {expires: 2020-09-01, location: 'Chan Zuckerberg Initiative, Redwood City, CA', name: Senior Software Engineer, 
+    Imaging, Science, url: 'https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1875135?gh_jid=1875135'}    
+  

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,44 +1,28 @@
 - {expires: 2020-07-15, location: 'Stanford, CA', name: 'Oncology OnCore Application
     Specialist, Stanford School of Medicine', url: 'https://careersearch.stanford.edu/jobs/oncology-oncore-application-specialist-oncore-reporting-group-lead-9854?et=Ysg27Ti9'}
-- {expires: 2020-06-28, location: 'Golden, CO', name: Computational Scientist/Apps
+- {expires: 2020-08-02, location: 'Golden, CO', name: Computational Scientist/Apps
     Specialist, url: 'https://jobs.mines.edu/en-us/job/494406/computational-scientist'}
-- {expires: 2020-06-10, location: 'Socorro, NM', name: Staff Scientist/Software Engineer
+- {expires: 2020-08-02, location: 'Socorro, NM', name: Staff Scientist/Software Engineer
     at New Mexico Tech, url: 'https://www.nmt.edu/hr/docs/hr/jobs/StaffSciSoftEngIRIS20-030.pdf'}
-- {expires: 2020-04-10, location: 'Boston, MA', name: Senior Research Computing Systems
+- {expires: 2020-08-02, location: 'Boston, MA', name: Senior Research Computing Systems
     Engineer at Boston University, url: 'http://www.bu.edu/tech/support/research/rcs/jobs/'}
-- {expires: 2020-03-10, location: Caltech, name: 'Software Engineer/Research Software
-    Engineer: CliMA project', url: 'https://clima.caltech.edu/join-our-team/'}
-- {expires: 2020-02-15, location: NumFOCUS, name: Research Software Engineering Fellow,
-  url: 'https://numfocus.org/blog/now-hiring-matplotlib-research-software-engineering-fellow'}
-- {expires: 2020-02-01, location: Pittsburgh Supercomputing Center, name: Research
+- {expires: 2020-08-02, location: Pittsburgh Supercomputing Center, name: Research
     Software Specialist, url: 'https://www.psc.edu/about-psc/employment/3116-research-software-specialist-2014428'}
-- {expires: 2020-03-01, location: University of Alabama, name: Research Software Engineer,
+- {expires: 2020-08-02, location: University of Alabama, name: Research Software Engineer,
   url: 'http://carver.cs.ua.edu/RSE.htm'}
-- {expires: 2020-02-01, location: University of Illinois at Urbana-Champaign, name: Visiting
-    Research Scientist, url: 'https://jobs.illinois.edu/academic-job-board/job-details?jobID=123477&job=visiting-research-scientist-school-of-information-sciences-123477'}
-- {expires: 2019-10-01, location: 'Boston, MA', name: Senior Scientific Programmer
-    at Boston University, url: 'http://www.bu.edu/tech/support/research/rcs/jobs/'}
-- {expires: 2020-06-30, location: 'Cambridge, MA', name: Senior Research Software
+- {expires: 2020-08-02, location: 'Cambridge, MA', name: Senior Research Software
     Engineer (Data Engineer), url: 'http://bit.ly/fasrc_senior_rse'}
-- {expires: 2019-09-01, location: University Park Campus, name: Software Consultants,
-  url: 'https://psu.jobs/job/88890'}
-- {expires: 2019-10-01, location: Indiana University Bloomington, name: Research Software
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
     Engineer / Application Support Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2019-10-01, location: Indiana University Bloomington, name: Research Software
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
     Engineer / UI Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2019-10-01, location: Indiana University Bloomington, name: Community
-    Developer / Outreach Coordinator, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2019-10-01, location: Indiana University Bloomington, name: DevOps / Software
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: DevOps / Software
     Engineers, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2019-10-01, location: Indiana University Bloomington, name: Cloud and
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: Cloud and
     Cluster Administrator, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2019-11-01, location: Brown University, name: Research Software Engineer/Senior
-    Research Software Engineer, url: 'https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/180-George-Street/Research-Software-Engineer-Senior-Research-Software-Engineer_REQ162388'}
-- {expires: 2020-01-15, location: 'Princess Margaret Cancer Centre, Toronto, ON, Canada',
-  name: 'Technical Software Developer, Data and Distributed Computing, CanDIG', url: 'https://www.recruitingsite.com/csbsites/uhncareers/JobDescription.asp?SiteID=10031&JobNumber=852516'}
-- {expires: 2020-07-01, location: NumFOCUS, name: 'Scientific Software Developer-
+- {expires: 2020-08-02, location: NumFOCUS, name: 'Scientific Software Developer-
     Contract Basis [SunPy Project]', url: 'https://numfocus.org/uncategorized/scientific-software-developer-contract-basis-sunpy-project'}
-- {expires: 2020-07-01, location: 'Dartmouth College, Hanover MA', name: Software
+- {expires: 2020-08-02, location: 'Dartmouth College, Hanover MA', name: Software
     Developer, url: 'https://searchjobs.dartmouth.edu/postings/54423'}
 - {expires: 2020-08-01, location: 'Institute for Health Metrics and Evaluation (IHME),
     University of Washington, Seattle, WA', name: Software Engineer, url: 'http://www.healthdata.org/job-posting/software-engineer'}


### PR DESCRIPTION
It looks like a lot of jobs have expired but still are active. 

This PR:
* Adds the CZI job 
* Removes old inactive jobs
* Updates the expiration dates for jobs that still appear active

I set all the expiration dates that I changed to 2020-08-02. 

cc @usrse-maintainers
