### PR TITLE
removing job that doesnt exist anymore

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -26,7 +26,7 @@
     Developer, url: 'https://searchjobs.dartmouth.edu/postings/54423'}
 - {expires: 2020-08-01, location: 'Princeton University, Princeton, NJ', name: Professional
     Specialist, url: 'https://puwebp.princeton.edu/AcadHire/apply/application.xhtml?listingId=16041'}
-- {expires: 2020-09-01, location: 'Chan Zuckerberg Initiative Imaging Science Redwood City, CA', 
+- {expires: 2020-09-01, location: 'Chan Zuckerberg Initiative Imaging Science, Redwood City, CA', 
     name: Senior Software Engineer, url: 'https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1875135?gh_jid=1875135'}
 - {expires: 2020-11-01, location: 'Johns Hopkins University, Baltimore, Maryland',
   name: Software Engineer, url: 'https://jobs.jhu.edu/job/Baltimore-Software-Engineer-MD-21205/645431000/'}

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -24,11 +24,9 @@
     Contract Basis [SunPy Project]', url: 'https://numfocus.org/uncategorized/scientific-software-developer-contract-basis-sunpy-project'}
 - {expires: 2020-08-02, location: 'Dartmouth College, Hanover MA', name: Software
     Developer, url: 'https://searchjobs.dartmouth.edu/postings/54423'}
-- {expires: 2020-08-01, location: 'Institute for Health Metrics and Evaluation (IHME),
-    University of Washington, Seattle, WA', name: Software Engineer, url: 'http://www.healthdata.org/job-posting/software-engineer'}
 - {expires: 2020-08-01, location: 'Princeton University, Princeton, NJ', name: Professional
     Specialist, url: 'https://puwebp.princeton.edu/AcadHire/apply/application.xhtml?listingId=16041'}
-- {Imaging: null, Science: null, expires: 2020-09-01, location: 'Chan Zuckerberg Initiative,
-    Redwood City, CA', name: Senior Software Engineer, url: 'https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1875135?gh_jid=1875135'}
+- {expires: 2020-09-01, location: 'Chan Zuckerberg Initiative Imaging Science Redwood City, CA', 
+    name: Senior Software Engineer, url: 'https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1875135?gh_jid=1875135'}
 - {expires: 2020-11-01, location: 'Johns Hopkins University, Baltimore, Maryland',
   name: Software Engineer, url: 'https://jobs.jhu.edu/job/Baltimore-Software-Engineer-MD-21205/645431000/'}


### PR DESCRIPTION
This job isn't expired (so it's not flagged for removal via our script) but it must have been filled because the page is 404-ing, so this PR will remove it. There also is a weird value for the metadata for the Chan Zuckerberg job so I'm fixing that too.

http://www.healthdata.org/job-posting/software-engineer

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
