### PR TITLE
update community workshop dates to 2021

### DIFF
--- a/_events/2021/2021-first-community-workshop.md
+++ b/_events/2021/2021-first-community-workshop.md
@@ -3,8 +3,8 @@ title: US-RSE Workshop
 subtitle: A First US-RSE Community Building Workshop
 location: Princeton, NJ
 url: https://us-rse.org/first-community-workshop
-expires: 2020-10-29
-event_date: "October 27–28, 2020"
+expires: 2021-10-06
+event_date: "October 5–6, 2021"
 layout: event
 repeated: false
 ---
@@ -12,7 +12,7 @@ repeated: false
 
 We are excited to announce that through a generous grant from the
 Alfred P. Sloan Foundation, we will be able to hold a first US-RSE
-Association community building workshop, October 27-28, 2020 in
+Association community building workshop, October 5-6, 2021 in
 Princeton, NJ. This won’t be an attempt to be an RSE conference, but a
 workshop focused on planning the best path forward to grow the US-RSE
 Association.


### PR DESCRIPTION
Updated the 2021 event page and moved it to a new 2021 event directory. 


- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally

cc @usrse-maintainers
