### PR TITLE
removing expired job for pittsburgh supercomputing system

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -6,8 +6,6 @@
     at New Mexico Tech, url: 'https://www.nmt.edu/hr/docs/hr/jobs/StaffSciSoftEngIRIS20-030.pdf'}
 - {expires: 2020-08-02, location: 'Boston, MA', name: Senior Research Computing Systems
     Engineer at Boston University, url: 'http://www.bu.edu/tech/support/research/rcs/jobs/'}
-- {expires: 2020-08-02, location: Pittsburgh Supercomputing Center, name: Research
-    Software Specialist, url: 'https://www.psc.edu/about-psc/employment/3116-research-software-specialist-2014428'}
 - {expires: 2020-08-02, location: University of Alabama, name: Research Software Engineer,
   url: 'http://carver.cs.ua.edu/RSE.htm'}
 - {expires: 2020-08-02, location: 'Cambridge, MA', name: Senior Research Software


### PR DESCRIPTION
The url no longer exists https://www.psc.edu/about-psc/employment/3116-research-software-specialist-2014428 although the expiration date isn't until next month.