### PR TITLE
removing job with 404 and updating dh-rse whitepaper link

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -33,7 +33,5 @@
 - {expires: 2020-12-31, location: 'National Center for Supercomputing Applications
     / University of Illinois, Urbana, IL', name: Assistant Research Programmer/Research
     Programmer/Senior Research Programmer, url: 'https://jobs.illinois.edu/academic-job-board/job-details?jobID=130370&job=research-programmer-national-center-for-supercomputing-applications-130370'}
-- {expires: 2020-09-15, location: 'Princeton University, Princeton, NJ', name: Software
-    Engineer, url: 'https://main-princeton.icims.com/jobs/11856/software-engineer/job'}
 - {expires: 2020-10-01, location: 'University of Chicago, Chicago, IL', name: Software
     Engineer (funcX project), url: 'https://www.globus.org/jobs/backend-software-engineer'}

--- a/_posts/2019-07-31-DH-RSE-Whitepaper.md
+++ b/_posts/2019-07-31-DH-RSE-Whitepaper.md
@@ -10,4 +10,4 @@ At the Digital Humanities Conference 2019 in Utrecht, a group of Digital Humanit
 
 Rather than forming a new group, the workshop participants chose to use the existing infrastructure of [DHTech](https://dh-tech.github.io/) (website, Slack channel, and mailing list), a group of Digital Humanities RSEs, to collaborate on and publish the white paper. DHTech was started two years earlier at DH2017 by several of the workshop participants with the idea to build an international community of DH RSEs. 
 
-See [DH Research Software Engineers - For We Are Many](https://dh-tech.github.io/dhrse-whitepaper/) to read the white paper.
+See [DH Research Software Engineers - For We Are Many](https://dh-tech.github.io/dhrse-whitepaper#/) to read the white paper.


### PR DESCRIPTION
The daily job to remove expired jobs failed because of two broken links:

 - the DH RSE whitepaper link was changed, and has been updated here
 - one of the Princeton jobs is not expired, but the page is 404, so it's removed.

This PR will fix both of those above!