### PR TITLE
Adding calico data engineer contract job

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,4 @@
+- {expires: 2020-11-01, location: '(part to full time contract) Virtual/Remote', name: Data Curation Engineer for Calico Life Sciences, url: 'https://www.linkedin.com/jobs/cap/view/2019595826/?pathWildcard=2019595826&trk=job_capjs'}
 - {expires: 2020-09-01, location: 'Greenbelt, MD and telework eligible', name: System
     Architect for ESDIS at the GSFC, url: 'https://www.usajobs.gov/GetJob/ViewDetails/577014000'}
 - {expires: 2020-09-08, location: 'Greenbelt, MD and telework eligible', name: 'Computer


### PR DESCRIPTION
This will add another Calico Labs Data Engineer (contract) role to our jobs board!

cc @usrse-maintainers
