### PR TITLE
Add Preliminary AGM event page

### DIFF
--- a/_events/2020/2020-12-AGM.md
+++ b/_events/2020/2020-12-AGM.md
@@ -1,0 +1,27 @@
+---
+title: US-RSE First Annual General Meeting
+subtitle: All Member US-RSE Event
+location: Online via Zoom
+expires: 2020-12-05
+event_date: "December 4, 2020"
+layout: event
+repeated: false
+---
+
+The first US-RSE Association Annual General Meeting (AGM) will take place on Friday December 4, 2020 from 1-3pm ET.
+
+#### Registration link
+The AGM is open to all US-RSE members.
+Prior registration will be required and must match the email address on file with US-RSE. Registration links will be circulated via the US-RSE mailing list and in the US-RSE slack workspace.
+
+Not a member yet? [Join](https://us-rse.org/join/) now!
+
+#### Preliminary Agenda
+
+1. **State of the US-RSE Association:** A year in review and plans for 2021
+1. **Steering Committee Candidate Statements and Q&A**
+1. **Open member discussion**
+
+This page will be updated and a finalized agenda will be circulated prior to the meeting.
+
+If you have questions or would like to contribute to AGM planning process or have suggestions of discussion topics please contact contact@us-rse.org or reach out via [slack](https://usrse.slack.com/).


### PR DESCRIPTION
This adds an events page for the December 2020 Annual General Meeting. 
It can/will be updated as more details are set but I want to get something up now as it's an important event to put on everyone's radar. 

## Checklist:
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the CHANGELOG and (if necessary) the README.md

cc @usrse-maintainers
