### PR TITLE
Add bullet to explicitly mention slack invite

### DIFF
--- a/pages/join.md
+++ b/pages/join.md
@@ -10,6 +10,7 @@ By joining the US-RSE Association you will:
 * Receive announcements of events organized by and for RSEs
 * Connect with research software engineers from across the country in many disciplines
 * Help us to raise awareness of the importance of software in research and vital role we play in creating this software
+* Receive an invitation for the US-RSE slack workspace
 
 <div class="get-started-wrap">
     <a class="btn btn-success btn-lg get-started-btn" href="https://forms.gle/CRsH7sKAk3UvZJfB9" target="_blank" style="margin:40px;">Join the US-RSE Association!</a>

--- a/pages/join.md
+++ b/pages/join.md
@@ -10,7 +10,7 @@ By joining the US-RSE Association you will:
 * Receive announcements of events organized by and for RSEs
 * Connect with research software engineers from across the country in many disciplines
 * Help us to raise awareness of the importance of software in research and vital role we play in creating this software
-* Receive an invitation to join the US-RSE slack workspace
+* Receive an invitation to join the US-RSE Slack workspace
 
 <div class="get-started-wrap">
     <a class="btn btn-success btn-lg get-started-btn" href="https://forms.gle/CRsH7sKAk3UvZJfB9" target="_blank" style="margin:40px;">Join the US-RSE Association!</a>

--- a/pages/join.md
+++ b/pages/join.md
@@ -10,7 +10,7 @@ By joining the US-RSE Association you will:
 * Receive announcements of events organized by and for RSEs
 * Connect with research software engineers from across the country in many disciplines
 * Help us to raise awareness of the importance of software in research and vital role we play in creating this software
-* Receive an invitation for the US-RSE slack workspace
+* Receive an invitation to join the US-RSE slack workspace
 
 <div class="get-started-wrap">
     <a class="btn btn-success btn-lg get-started-btn" href="https://forms.gle/CRsH7sKAk3UvZJfB9" target="_blank" style="margin:40px;">Join the US-RSE Association!</a>


### PR DESCRIPTION
A question came up from a potential member about how to join US-RSE slack. As it stands now, there is no mention of where to get an invite. 

This is an attempt to avoid such confusion by explicitly say that joining US-RSE and filling out the form will get you a slack invitation.

## Checklist:
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the CHANGELOG and (if necessary) the README.md

cc @usrse-maintainers
