### PR TITLE
Add new jobs from Slack

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,62 +1,34 @@
-- {expires: 2020-12-01, location: 'Harvard University, Cambridge, MA',
+- {expires: 2021-03-01, location: 'Harvard University, Cambridge, MA',
     name: Data Scientist / Engineer,
     url: 'https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25240&siteid=5341&PageType=JobDetails&jobid=1542050#jobDetails=1542050_5341'}
-- {expires: 2020-12-01, location: 'Harvard University, Cambridge, MA',
+- {expires: 2021-03-01, location: 'Harvard University, Cambridge, MA',
     name: Research Software Engineer (Scientific Software Developer),
     url: 'https://www.rc.fas.harvard.edu/about/employment/#Research_Software_Engineer_Scientific_Software_Developer'}
-- {expires: 2020-12-01, location: 'Amazon Web Services, Inc., Seattle, WA (potential for remote)',
+- {expires: 2020-03-01, location: 'Amazon Web Services, Inc., Seattle, WA (potential for remote)',
     name: Developer Advocate for HPC & Batch,
     url: 'https://www.amazon.jobs/en/jobs/1276398/developer-advocate-for-hpc-batch'}
-- {expires: 2020-12-01, location: 'University of Michigan, Ann Arbor, MI',
-    name: Big Data Software Developer,
-    url: 'https://careers.umich.edu/job_detail/189585/big_data_software_developer'}
-- {expires: 2020-11-01, location: (part to full time contract) Virtual/Remote, name: Data
-    Curation Engineer for Calico Life Sciences, url: 'https://www.linkedin.com/jobs/cap/view/2019595826/?pathWildcard=2019595826&trk=job_capjs'}
-- {expires: 2020-09-01, location: 'Greenbelt, MD and telework eligible', name: System
-    Architect for ESDIS at the GSFC, url: 'https://www.usajobs.gov/GetJob/ViewDetails/577014000'}
-- {expires: 2020-09-08, location: 'Greenbelt, MD and telework eligible', name: 'Computer
-    Engineer, AST, Data Systems (early career)', url: 'https://www.usajobs.gov/GetJob/ViewDetails/577321400'}
-- {expires: 2020-09-08, location: 'Greenbelt, MD and telework eligible', name: 'Computer
-    Engineer, AST, Data Systems, Deputy Manager of the Earth Science Data and Information
-    System Project', url: 'https://www.usajobs.gov/GetJob/ViewDetails/577340000'}
-- {expires: 2020-09-08, location: 'Greenbelt, MD and telework eligible', name: Cloud
-    development computer engineer and IT-Security Engineer (two positions), url: 'https://www.usajobs.gov/GetJob/ViewDetails/577341200'}
-- {expires: 2020-10-15, location: 'University of Colorado School of Medicine, Aurora,
-    CO', name: Research Associate for Software Engineering, url: 'https://cu.taleo.net/careersection/2/jobdetail.ftl?job=18969&lang=en&src=LinkedIn'}
-- {expires: 2020-10-15, location: 'South San Francisco, CA (currently remote)', name: 'Senior
+- {expires: 2021-01-15, location: 'South San Francisco, CA (currently remote)', name: 'Senior
     Software Engineer, Calico Life Sciences', url: 'https://www.calicolabs.com/careers/?gh_jid=4824646002'}
-- {expires: 2020-07-15, location: 'Stanford, CA', name: 'Oncology OnCore Application
+- {expires: 2021-01-15, location: 'Stanford, CA', name: 'Oncology OnCore Application
     Specialist, Stanford School of Medicine', url: 'https://careersearch.stanford.edu/jobs/oncology-oncore-application-specialist-oncore-reporting-group-lead-9854?et=Ysg27Ti9'}
-- {expires: 2020-08-02, location: 'Golden, CO', name: Computational Scientist/Apps
-    Specialist, url: 'https://jobs.mines.edu/en-us/job/494406/computational-scientist'}
-- {expires: 2020-08-02, location: 'Socorro, NM', name: Staff Scientist/Software Engineer
-    at New Mexico Tech, url: 'https://www.nmt.edu/hr/docs/hr/jobs/StaffSciSoftEngIRIS20-030.pdf'}
-- {expires: 2020-08-02, location: 'Boston, MA', name: Senior Research Computing Systems
+- {expires: 2021-01-15, location: 'Boston, MA', name: Senior Research Computing Systems
     Engineer at Boston University, url: 'http://www.bu.edu/tech/support/research/rcs/jobs/'}
-- {expires: 2020-08-02, location: University of Alabama, name: Research Software Engineer,
-  url: 'http://carver.cs.ua.edu/RSE.htm'}
-- {expires: 2020-08-02, location: 'Cambridge, MA', name: Senior Research Software
+- {expires: 2021-01-15, location: 'Cambridge, MA', name: Senior Research Software
     Engineer (Data Engineer), url: 'http://bit.ly/fasrc_senior_rse'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
+- {expires: 2021-01-15, location: Indiana University Bloomington, name: Research Software
     Engineer / Application Support Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
+- {expires: 2021-01-15, location: Indiana University Bloomington, name: Research Software
     Engineer / UI Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: DevOps / Software
+- {expires: 2021-01-15, location: Indiana University Bloomington, name: DevOps / Software
     Engineers, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: Cloud and
+- {expires: 2021-01-15, location: Indiana University Bloomington, name: Cloud and
     Cluster Administrator, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: NumFOCUS, name: 'Scientific Software Developer-
-    Contract Basis [SunPy Project]', url: 'https://numfocus.org/uncategorized/scientific-software-developer-contract-basis-sunpy-project'}
-- {expires: 2020-08-02, location: 'Dartmouth College, Hanover MA', name: Software
-    Developer, url: 'https://searchjobs.dartmouth.edu/postings/54423'}
-- {expires: 2020-08-01, location: 'Princeton University, Princeton, NJ', name: Professional
-    Specialist, url: 'https://puwebp.princeton.edu/AcadHire/apply/application.xhtml?listingId=16041'}
-- {expires: 2020-09-01, location: 'Chan Zuckerberg Initiative Imaging Science, Redwood
+- {expires: 2021-01-15, location: 'Chan Zuckerberg Initiative Imaging Science, Redwood
     City, CA', name: Senior Software Engineer, url: 'https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1875135?gh_jid=1875135'}
-- {expires: 2020-11-01, location: 'Johns Hopkins University, Baltimore, Maryland',
+- {expires: 2021-01-15, location: 'Johns Hopkins University, Baltimore, Maryland',
   name: Software Engineer, url: 'https://jobs.jhu.edu/job/Baltimore-Software-Engineer-MD-21205/645431000/'}
 - {expires: 2020-12-31, location: 'National Center for Supercomputing Applications
     / University of Illinois, Urbana, IL', name: Assistant Research Programmer/Research
     Programmer/Senior Research Programmer, url: 'https://jobs.illinois.edu/academic-job-board/job-details?jobID=130370&job=research-programmer-national-center-for-supercomputing-applications-130370'}
-- {expires: 2020-10-01, location: 'University of Chicago, Chicago, IL', name: Software
+- {expires: 2021-01-15, location: 'University of Chicago, Chicago, IL', name: Software
     Engineer (funcX project), url: 'https://www.globus.org/jobs/backend-software-engineer'}

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -25,6 +25,32 @@
     CO', name: Research Associate for Software Engineering, url: 'https://cu.taleo.net/careersection/2/jobdetail.ftl?job=18969&lang=en&src=LinkedIn'}
 - {expires: 2020-10-15, location: 'South San Francisco, CA (currently remote)', name: 'Senior
     Software Engineer, Calico Life Sciences', url: 'https://www.calicolabs.com/careers/?gh_jid=4824646002'}
+- {expires: 2020-07-15, location: 'Stanford, CA', name: 'Oncology OnCore Application
+    Specialist, Stanford School of Medicine', url: 'https://careersearch.stanford.edu/jobs/oncology-oncore-application-specialist-oncore-reporting-group-lead-9854?et=Ysg27Ti9'}
+- {expires: 2020-08-02, location: 'Golden, CO', name: Computational Scientist/Apps
+    Specialist, url: 'https://jobs.mines.edu/en-us/job/494406/computational-scientist'}
+- {expires: 2020-08-02, location: 'Socorro, NM', name: Staff Scientist/Software Engineer
+    at New Mexico Tech, url: 'https://www.nmt.edu/hr/docs/hr/jobs/StaffSciSoftEngIRIS20-030.pdf'}
+- {expires: 2020-08-02, location: 'Boston, MA', name: Senior Research Computing Systems
+    Engineer at Boston University, url: 'http://www.bu.edu/tech/support/research/rcs/jobs/'}
+- {expires: 2020-08-02, location: University of Alabama, name: Research Software Engineer,
+  url: 'http://carver.cs.ua.edu/RSE.htm'}
+- {expires: 2020-08-02, location: 'Cambridge, MA', name: Senior Research Software
+    Engineer (Data Engineer), url: 'http://bit.ly/fasrc_senior_rse'}
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
+    Engineer / Application Support Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
+    Engineer / UI Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: DevOps / Software
+    Engineers, url: 'https://brainlife.io/docs/careers/jobs/'}
+- {expires: 2020-08-02, location: Indiana University Bloomington, name: Cloud and
+    Cluster Administrator, url: 'https://brainlife.io/docs/careers/jobs/'}
+- {expires: 2020-08-02, location: NumFOCUS, name: 'Scientific Software Developer-
+    Contract Basis [SunPy Project]', url: 'https://numfocus.org/uncategorized/scientific-software-developer-contract-basis-sunpy-project'}
+- {expires: 2020-08-02, location: 'Dartmouth College, Hanover MA', name: Software
+    Developer, url: 'https://searchjobs.dartmouth.edu/postings/54423'}
+- {expires: 2020-08-01, location: 'Princeton University, Princeton, NJ', name: Professional
+    Specialist, url: 'https://puwebp.princeton.edu/AcadHire/apply/application.xhtml?listingId=16041'}
 - {expires: 2020-09-01, location: 'Chan Zuckerberg Initiative Imaging Science, Redwood
     City, CA', name: Senior Software Engineer, url: 'https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1875135?gh_jid=1875135'}
 - {expires: 2020-11-01, location: 'Johns Hopkins University, Baltimore, Maryland',

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -4,7 +4,7 @@
 - {expires: 2021-03-01, location: 'Harvard University, Cambridge, MA',
     name: Research Software Engineer (Scientific Software Developer),
     url: 'https://www.rc.fas.harvard.edu/about/employment/#Research_Software_Engineer_Scientific_Software_Developer'}
-- {expires: 2020-03-01, location: 'Amazon Web Services, Inc., Seattle, WA (potential for remote)',
+- {expires: 2021-03-01, location: 'Amazon Web Services, Inc., Seattle, WA (potential for remote)',
     name: Developer Advocate for HPC & Batch,
     url: 'https://www.amazon.jobs/en/jobs/1276398/developer-advocate-for-hpc-batch'}
 - {expires: 2021-01-15, location: 'South San Francisco, CA (currently remote)', name: 'Senior

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,6 @@
+- {expires: 2020-12-01, location: 'Harvard University, Cambridge, MA',
+    name: Research Software Engineer (Scientific Software Developer),
+    url: 'https://www.rc.fas.harvard.edu/about/employment/#Research_Software_Engineer_Scientific_Software_Developer'}
 - {expires: 2020-12-01, location: 'Amazon Web Services, Inc., Seattle, WA (potential for remote)',
     name: Developer Advocate for HPC & Batch,
     url: 'https://www.amazon.jobs/en/jobs/1276398/developer-advocate-for-hpc-batch'}

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -13,32 +13,6 @@
     CO', name: Research Associate for Software Engineering, url: 'https://cu.taleo.net/careersection/2/jobdetail.ftl?job=18969&lang=en&src=LinkedIn'}
 - {expires: 2020-10-15, location: 'South San Francisco, CA (currently remote)', name: 'Senior
     Software Engineer, Calico Life Sciences', url: 'https://www.calicolabs.com/careers/?gh_jid=4824646002'}
-- {expires: 2020-07-15, location: 'Stanford, CA', name: 'Oncology OnCore Application
-    Specialist, Stanford School of Medicine', url: 'https://careersearch.stanford.edu/jobs/oncology-oncore-application-specialist-oncore-reporting-group-lead-9854?et=Ysg27Ti9'}
-- {expires: 2020-08-02, location: 'Golden, CO', name: Computational Scientist/Apps
-    Specialist, url: 'https://jobs.mines.edu/en-us/job/494406/computational-scientist'}
-- {expires: 2020-08-02, location: 'Socorro, NM', name: Staff Scientist/Software Engineer
-    at New Mexico Tech, url: 'https://www.nmt.edu/hr/docs/hr/jobs/StaffSciSoftEngIRIS20-030.pdf'}
-- {expires: 2020-08-02, location: 'Boston, MA', name: Senior Research Computing Systems
-    Engineer at Boston University, url: 'http://www.bu.edu/tech/support/research/rcs/jobs/'}
-- {expires: 2020-08-02, location: University of Alabama, name: Research Software Engineer,
-  url: 'http://carver.cs.ua.edu/RSE.htm'}
-- {expires: 2020-08-02, location: 'Cambridge, MA', name: Senior Research Software
-    Engineer (Data Engineer), url: 'http://bit.ly/fasrc_senior_rse'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
-    Engineer / Application Support Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: Research Software
-    Engineer / UI Engineer, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: DevOps / Software
-    Engineers, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: Indiana University Bloomington, name: Cloud and
-    Cluster Administrator, url: 'https://brainlife.io/docs/careers/jobs/'}
-- {expires: 2020-08-02, location: NumFOCUS, name: 'Scientific Software Developer-
-    Contract Basis [SunPy Project]', url: 'https://numfocus.org/uncategorized/scientific-software-developer-contract-basis-sunpy-project'}
-- {expires: 2020-08-02, location: 'Dartmouth College, Hanover MA', name: Software
-    Developer, url: 'https://searchjobs.dartmouth.edu/postings/54423'}
-- {expires: 2020-08-01, location: 'Princeton University, Princeton, NJ', name: Professional
-    Specialist, url: 'https://puwebp.princeton.edu/AcadHire/apply/application.xhtml?listingId=16041'}
 - {expires: 2020-09-01, location: 'Chan Zuckerberg Initiative Imaging Science, Redwood
     City, CA', name: Senior Software Engineer, url: 'https://boards.greenhouse.io/chanzuckerberginitiative/jobs/1875135?gh_jid=1875135'}
 - {expires: 2020-11-01, location: 'Johns Hopkins University, Baltimore, Maryland',

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,4 +1,7 @@
 - {expires: 2020-12-01, location: 'Harvard University, Cambridge, MA',
+    name: Data Scientist / Engineer,
+    url: 'https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25240&siteid=5341&PageType=JobDetails&jobid=1542050#jobDetails=1542050_5341'}
+- {expires: 2020-12-01, location: 'Harvard University, Cambridge, MA',
     name: Research Software Engineer (Scientific Software Developer),
     url: 'https://www.rc.fas.harvard.edu/about/employment/#Research_Software_Engineer_Scientific_Software_Developer'}
 - {expires: 2020-12-01, location: 'Amazon Web Services, Inc., Seattle, WA (potential for remote)',

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,6 @@
+- {expires: 2020-12-01, location: 'University of Michigan, Ann Arbor, MI',
+    name: Big Data Software Developer,
+    url: 'https://careers.umich.edu/job_detail/189585/big_data_software_developer'}
 - {expires: 2020-11-01, location: (part to full time contract) Virtual/Remote, name: Data
     Curation Engineer for Calico Life Sciences, url: 'https://www.linkedin.com/jobs/cap/view/2019595826/?pathWildcard=2019595826&trk=job_capjs'}
 - {expires: 2020-09-01, location: 'Greenbelt, MD and telework eligible', name: System

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,6 @@
+- {expires: 2020-12-01, location: 'Amazon Web Services, Inc., Seattle, WA (potential for remote)',
+    name: Developer Advocate for HPC & Batch,
+    url: 'https://www.amazon.jobs/en/jobs/1276398/developer-advocate-for-hpc-batch'}
 - {expires: 2020-12-01, location: 'University of Michigan, Ann Arbor, MI',
     name: Big Data Software Developer,
     url: 'https://careers.umich.edu/job_detail/189585/big_data_software_developer'}


### PR DESCRIPTION
This adds 4 recent jobs posted in slack. 

It also removes a number of old entries that expired before Aug 31, 2020 to clean things up. The file was getting cumbersome. I didn't remove every expired job. I left the ones that expired Sept 1 and later.  

I think the clean_jobs.py script should have caught all of these. I'll open an issue. 

cc @usrse-maintainers
