### PR TITLE
removing check for expiration on jobs

### DIFF
--- a/pages/careers/jobs.md
+++ b/pages/careers/jobs.md
@@ -7,12 +7,8 @@ permalink: /jobs/
 ## Current RSE openings
 
 <ol>{% for job in site.data.jobs %}
-{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
-{% capture expires %}{{ job.expires | date: '%s'}}{% endcapture %}
-
-{% if expires > nowunix %}
-   <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
-{% endif %}{% endfor %}</ol>
+<li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
+{% endfor %}</ol>
 
 <br>
 


### PR DESCRIPTION
Per suggestion of @cosden in #309, this PR will remove the job expiration date, and show all jobs that have not yet 404'd as links.

Signed-off-by: vsoch <vsochat@stanford.edu>


cc @usrse-maintainers
