### PR TITLE
updating action set-env to write to GITHUB_ENV

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -71,13 +71,14 @@ jobs:
              git commit -a -m "Automated deployment to update contributors $(date '+%Y-%m-%d')"
              git push origin "${BRANCH_FROM}"
           fi
-          echo "::set-env name=OPEN_PULL_REQUEST::${OPEN_PULL_REQUEST}"
-          echo "::set-env name=PULL_REQUEST_FROM_BRANCH::${BRANCH_FROM}"
-          echo "::set-env name=PULL_REQUEST_TITLE::[tributors] ${BRANCH_FROM}"
-          echo "::set-env name=PULL_REQUEST_BODY::Tributors update automated pull request."
+
+          echo "OPEN_PULL_REQUEST=${OPEN_PULL_REQUEST}" >> $GITHUB_ENV
+          echo "PULL_REQUEST_FROM_BRANCH=${BRANCH_FROM}" >> $GITHUB_ENV
+          echo "PULL_REQUEST_TITLE=[tributors] ${BRANCH_FROM}" >> $GITHUB_ENV
+          echo "PULL_REQUEST_BODY=Tributors update automated pull request." >> $GITHUB_ENV
 
       - name: Open Pull Request
-        uses: vsoch/pull-request-action@1.0.6
+        uses: vsoch/pull-request-action@1.0.12
         if: ${{ env.OPEN_PULL_REQUEST == '1' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The set-env command is now deprecated, so the next time this action runs it will fail. This PR updates the action to more properly write to the `GITHUB_ENV` file, and the pull-request-action to the latest version that also has this update.