### PR TITLE
testing fixing the researchsoftware.org links

### DIFF
--- a/_posts/international/2020-07-20-2nd-Intl-RSE-Leaders-Call.md
+++ b/_posts/international/2020-07-20-2nd-Intl-RSE-Leaders-Call.md
@@ -5,7 +5,7 @@ tags: [international, workshop]
 posted_by: Daniel S. Katz (for Stephan Druskat)
 ---
 
-![Group spelling out RSE](https://research-software.org/img/derse.png)
+![Group spelling out RSE](https://researchsoftware.org/img/derse.png)
 Photo by Antonia Cozacu, Jan Philipp Dietrich, de-RSE e.V. (CC BY 4.0).
 
 In 2018, the first International RSE Leaders Workshop, organized by the UK RSE Association, took place at the Alan Turing Institute in London, UK.
@@ -27,4 +27,4 @@ Software Engineering community in their own region or country, or within a speci
 important than seniority.
 
 Apply for participation by 30 July at [https://bit.ly/intl-rse-leaders-2020-application](https://bit.ly/intl-rse-leaders-2020-application).
-For more information, visit the [workshop website](https://research-software.org/2020-workshop.html).
+For more information, visit the [workshop website](https://researchsoftware.org/2020-workshop.html).


### PR DESCRIPTION
This PR will test fixing the researchsoftware.org link. It looks like whatever strategy is used for redirecting research-software.org to researchsotware.org, the certificates were not working. They might be working now, but I think it's still worth changing to the more official domain to avoid this bug in the future.

Signed-off-by: vsoch <vsochat@stanford.edu>

<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the CHANGELOG and (if necessary) the README.md

cc @usrse-maintainers
