### PR TITLE
add supercomputing to whitelist

### DIFF
--- a/.github/workflows/clean-expired-jobs.yml
+++ b/.github/workflows/clean-expired-jobs.yml
@@ -30,7 +30,7 @@ jobs:
         print_all: false
         retry_count: 3
         timeout: 10
-        white_listed_patterns: sc19.supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu
+        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu
         white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
     - name: Push Fixes

--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -24,7 +24,7 @@ jobs:
         timeout: 10
 
         # White listed patterns (seem to have SSL issues but work in browser)
-        white_listed_patterns: sc19.supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu
+        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu
 
         # White list the following files
         white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -5,8 +5,6 @@
 - {expires: 2021-01-31, location: 'General Fusion, Burnaby, BC, Canada (remote work
     possible)', name: Research Software Engineer (High Performance Computing Administrator),
   url: 'https://generalfusion.com/careers/'}
-- {expires: 2021-04-01, location: 'Microsoft, Redmond, WA', name: 'Senior Geospatial
-    Applications Engineer, AI for Earth', url: 'https://careers.microsoft.com/us/en/job/876975/Senior-Geospatial-Applications-Engineer-AI-for-Earth'}
 - {expires: 2021-04-01, location: 'Oak Ridge National Laboratory, Oak Ridge, TN',
   name: Environmental Informatics Research Professional, url: 'https://jobs.ornl.gov/job/Oak-Ridge-Environmental-Informatics-Research-Professional-TN-37831/697442500/'}
 - {expires: 2021-01-06, location: 'University of Alabama, Tuscaloosa, AL (remote work


### PR DESCRIPTION
I suspect this is an enduring issue since we had already whitelisted sc19, so I'm updating that pattern to be more broad and encompass any super computing links. Criteria for this PR to be merged are all tests passing, as the urlchecker failing is the bug we are trying to fix.

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
