### PR TITLE
whitelisting zoom.us

### DIFF
--- a/.github/workflows/clean-expired-jobs.yml
+++ b/.github/workflows/clean-expired-jobs.yml
@@ -30,7 +30,7 @@ jobs:
         print_all: false
         retry_count: 3
         timeout: 10
-        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu
+        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us
         white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
     - name: Push Fixes

--- a/.github/workflows/urlchecker.yml
+++ b/.github/workflows/urlchecker.yml
@@ -24,7 +24,7 @@ jobs:
         timeout: 10
 
         # White listed patterns (seem to have SSL issues but work in browser)
-        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu
+        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us
 
         # White list the following files
         white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/


### PR DESCRIPTION
The URL checker is [failing](https://github.com/USRSE/usrse.github.io/runs/1653952428?check_suite_focus=true) (for the cleaning expired jobs script, currently) because of an expired zoom.us link. I suspect we'd want to not remove them from the original text, so it's best to whitelist, both for the cleaning expired jobs run and the standard url checker. This PR will make this small change.

- Fixes #349 

Signed-off-by: vsoch <vsochat@stanford.edu>

cc @usrse-maintainers
