### PR TITLE
Fixing view bug in rendering of events without location

### DIFF
--- a/pages/resources/events-training.md
+++ b/pages/resources/events-training.md
@@ -5,7 +5,7 @@ permalink: /events-training/
 ---
 
 {% for event in site.events %}{% if event.repeated == true %}
-<h3><a target="_blank" href="{{ site.url }}{{ event.url }}" target="_blank">{{ event.title }}: <em>{{ event.location }}</em></a>:</h3>
+<h3><a target="_blank" href="{{ site.url }}{{ event.url }}" target="_blank">{{ event.title }}{% if event.location %}: <em>{{ event.location }}</em>{% endif %}</a>:</h3>
 <div style="margin:0px; padding:0px;"><em>{{ event.event_date }}</em></div>
 {{ event.content }}
 <br>
@@ -13,7 +13,7 @@ permalink: /events-training/
 
 {% assign sorted = (site.events | sort: 'expires') %}
 {% for event in sorted %}{% if event.repeated == false %}{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}{% capture expires %}{{ event.expires | date: '%s'}}{% endcapture %}{% if expires > nowunix %}
-<h3><a target="_blank" href="{{ site.url }}{{ event.url }}" target="_blank">{{ event.title }}: <em>{{ event.location }}</em></a>:</h3>
+<h3><a target="_blank" href="{{ site.url }}{{ event.url }}" target="_blank">{{ event.title }}{% if event.location %}: <em>{{ event.location }}</em>{% endif %}</a>:</h3>
 <div style="margin:0px; padding:0px;"><em>{{ event.event_date }}</em></div>
 {{ event.content }}
 <br>


### PR DESCRIPTION
Currently, if an event doesn't have a location, there is an extra trailing ":" that looks a little off:

![image](https://user-images.githubusercontent.com/814322/104411087-06bbf980-5527-11eb-9040-88e12644afa2.png)

This PR should fix that, only rendering that content if the location is defined for the event.

<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->
cc @usrse-maintainers
