### PR TITLE
Add/career panel info

### DIFF
--- a/_events/2021/2021-02-career-panel.md
+++ b/_events/2021/2021-02-career-panel.md
@@ -6,7 +6,7 @@ layout: event
 repeated: false
 ---
 
-We've teamed up with [The Academic Data Science Alliance (ADSA)](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
+We've teamed up with [The Academic Data Science Alliance (ADSA)](https://academicdatascience.org/) to host an Early Career Panel on Research Software Engineering and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
 The event is primarily focused on students of all levels, postdocs, and those early in their careers, but all are welcome to attend.
 
 Registration is free! Please visit [https://academicdatascience.org/cdn/early-career-panel](https://academicdatascience.org/cdn/early-career-panel) for more information and a link to register.

--- a/_events/2021/2021-02-career-panel.md
+++ b/_events/2021/2021-02-career-panel.md
@@ -6,7 +6,7 @@ layout: event
 repeated: false
 ---
 
-We've teamed up with [The Academic Data Science Alliance (ADSA](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
+We've teamed up with [The Academic Data Science Alliance (ADSA)](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
 The event is primarily focused on students of all levels, postdocs, and those early in their careers, but all are welcome to attend.
 
 Registration is free! Please visit [https://academicdatascience.org/cdn/early-career-panel](https://academicdatascience.org/cdn/early-career-panel) for more information and a link to register.

--- a/_events/2021/2021-02-career-panel.md
+++ b/_events/2021/2021-02-career-panel.md
@@ -1,0 +1,12 @@
+---
+title: "ADSA/US-RSE Early Career Panel"
+expires: 2021-02-23
+event_date: "February 23, 2021"
+layout: event
+repeated: false
+---
+
+We've teamed up with [The Academic Data Science Alliance (ADSA](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
+The event is primarily focused on students of all levels, postdocs, and those early in their careers, but all are welcome to attend.
+
+Registration is free! Please visit [https://academicdatascience.org/cdn/early-career-panel](https://academicdatascience.org/cdn/early-career-panel) for more information and a link to register.

--- a/_events/2021/2021-02-career-panel.md
+++ b/_events/2021/2021-02-career-panel.md
@@ -1,7 +1,7 @@
 ---
 title: "ADSA/US-RSE Early Career Panel"
-expires: 2021-02-23
-event_date: "February 24, 2021"
+expires: 2021-02-24
+event_date: "February 23, 2021"
 layout: event
 repeated: false
 ---

--- a/_events/2021/2021-02-career-panel.md
+++ b/_events/2021/2021-02-career-panel.md
@@ -1,7 +1,7 @@
 ---
 title: "ADSA/US-RSE Early Career Panel"
 expires: 2021-02-23
-event_date: "February 23, 2021"
+event_date: "February 24, 2021"
 layout: event
 repeated: false
 ---

--- a/_posts/2021-02-05-career-panel.md
+++ b/_posts/2021-02-05-career-panel.md
@@ -5,7 +5,7 @@ tags: [events]
 posted_by: Ian Cosden
 ---
 
-We've teamed up with [The Academic Data Science Alliance (ADSA](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
+We've teamed up with [The Academic Data Science Alliance (ADSA)](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
 The event is primarily focused on students of all levels, postdocs, and those early in their careers, but all are welcome to attend.
 
 Registration is free! Please visit [https://academicdatascience.org/cdn/early-career-panel](https://academicdatascience.org/cdn/early-career-panel) for more information and a link to register.

--- a/_posts/2021-02-05-career-panel.md
+++ b/_posts/2021-02-05-career-panel.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: RSE Early Career Panel Event
+tags: [events]
+posted_by: Ian Cosden
+---
+
+We've teamed up with [The Academic Data Science Alliance (ADSA](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
+The event is primarily focused on students of all levels, postdocs, and those early in their careers, but all are welcome to attend.
+
+Registration is free! Please visit [https://academicdatascience.org/cdn/early-career-panel](https://academicdatascience.org/cdn/early-career-panel) for more information and a link to register.

--- a/_posts/2021-02-05-career-panel.md
+++ b/_posts/2021-02-05-career-panel.md
@@ -5,7 +5,7 @@ tags: [events]
 posted_by: Ian Cosden
 ---
 
-We've teamed up with [The Academic Data Science Alliance (ADSA)](https://academicdatascience.org/) to host an Early Career Panel on Research Software and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
+We've teamed up with [The Academic Data Science Alliance (ADSA)](https://academicdatascience.org/) to host an Early Career Panel on Research Software Engineering and Data Science careers in academia on February 23, 2021 at 2ET/11PT.  
 The event is primarily focused on students of all levels, postdocs, and those early in their careers, but all are welcome to attend.
 
 Registration is free! Please visit [https://academicdatascience.org/cdn/early-career-panel](https://academicdatascience.org/cdn/early-career-panel) for more information and a link to register.


### PR DESCRIPTION
This adds two essentially identical pages about the upcoming US-RSE/ADSA career panel: 
* a post in the main news feed
* an event page

I'm not sure this is the best way to do it, and I'm open for suggestions. I've had need for looking back at the events archive to remember/count things we've done...so I'd like to capture it there. But we get more traffic on the front page so having a post about organizing the event seems useful there as well. 

cc @usrse-maintainers
