### PR TITLE
adding governance page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ navbar-links:
     - RSE Map: "https://usrse.github.io/usrse-map"
     - Steering Committee: "steering-committee"
     - Code of Conduct: "code-of-conduct"
+    - Governance: "governance"
   Resources:
     - Calendar: "calendar"
     - Community Blogs: "https://usrse.github.io/blog"

--- a/pages/community/governance.md
+++ b/pages/community/governance.md
@@ -1,0 +1,31 @@
+---
+layout: page
+title: Governance
+permalink: /governance/
+subtitle: The US-RSE Association Governance
+---
+
+<div id="governance" style="display:none"></div>
+
+<br><br>
+
+<p>This document is served from <a href="https://github.com/USRSE/documents/blob/master/governance.md" target="_blank">USRSE/documents</a> on GitHub. You can make contributions or suggestions for changes there.
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/showdown.min.js"></script>
+
+<script>
+$(document).ready(function(){
+
+    url = "https://raw.githubusercontent.com/USRSE/documents/master/governance.md"
+    $.get(url, function(data) {
+
+        var converter = new showdown.Converter(),
+                 html = converter.makeHtml(data);
+
+        $('#governance').html(html)
+        $('#governance').show();
+    });
+
+});
+</script>


### PR DESCRIPTION
This will add a rendering of the USRSE/documents governance page, a link under Community alongside Code of Conduct.  This will close #408.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

cc @usrse-maintainers
