### PR TITLE
Fix #418 Enable linkedin sharing for blog post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 # DO NOT CHANGE THE LINE NUMBERS HERE without changing .circleci/circle_urls.sh
 # If you are building a simple GitHub user page (https://username.github.io) then use these settings:
 url: "https://us-rse.org"
-baseurl: ""  # for testing, also check .circleci/circle_urls.sh 
+baseurl: ""  # for testing, also check .circleci/circle_urls.sh
 title-img: /assets/img/rse_logo_background.svg  # baseurl will be prepended
 twitter-img: /assets/img/logo_600px.png  # url + baseurl will be prepended
 
@@ -127,7 +127,7 @@ share-links-active:
   twitter: true
   facebook: false
   google: false
-  linkedin: false
+  linkedin: true
 
 # How to display the link to the website in the footer
 # Remove this if you don't want a link in the footer


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #418  Enable the LinkedIn sharing for the blog post

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It will help us or visitors to share the blog post quickly in the LinkedIn platform

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ x ] I have previewed changes locally

cc @usrse-maintainers
