### PR TITLE
Adding redirect to us-rse.org/usrse-map

### DIFF
--- a/pages/redirects/map.md
+++ b/pages/redirects/map.md
@@ -2,9 +2,11 @@
 layout: page
 title: USRSE Map
 permalink: /map/
+redirect: https://us-rse.org/usrse-map/
 subtitle: Where are the RSEs and groups that participate in US-RSE?
 ---
 
+<!--
 <style>
 .page-heading {
     padding-bottom: 10px !important;
@@ -28,4 +30,4 @@ subtitle: Where are the RSEs and groups that participate in US-RSE?
 
 <br/>
 <br/>
-Map made with [leafletjs](http://leafletjs.com), and [Open Streetmap](https://osm.org/), and idea from [DE-RSE](https://github.com/DE-RSE/www). Thank you!
+Map made with [leafletjs](http://leafletjs.com), and [Open Streetmap](https://osm.org/), and idea from [DE-RSE](https://github.com/DE-RSE/www). Thank you!-->


### PR DESCRIPTION
We discussed removing this page, but instead of removing the page (so the search result 404s) I think
we should redirect to our current map. This PR will make this change. I'm also leaving the logic (commented out)
so we can reuse it in the future if needed.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
