### PR TITLE
Fix #425 remove unnecessary dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,14 @@
 source 'https://rubygems.org'
 
-gem "github-pages", '193', group: :jekyll_plugins
+gem 'html-proofer'
+gem 'jekyll', '~> 4.1.1'
 
-# enable tzinfo-data for local build
-# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
-gem 'jekyll-paginate'
-gem 'faraday', '0.15.4'
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem 'jekyll-paginate'
+  gem 'jekyll-sitemap'
+end

--- a/pages/search.html
+++ b/pages/search.html
@@ -22,8 +22,8 @@ excluded_in_search: true
 				{% unless post.excluded_in_search %}
 					{% if added %},{% endif %}
 					{% assign added = false %}
-					"{{ post.url | slugify }}": {
-						"id": "{{ post.url | slugify }}",
+					"{{ post.url }}": {
+						"id": "{{ post.url }}",
 						"title": "{{ post.title | xml_escape }}",
 						"categories": "{{ post.categories | join: ", " | xml_escape }}",
 						"url": " {{ post.url | xml_escape }}",


### PR DESCRIPTION
Fix #425 

* `slugify` is removed to as avoid warning `Empty 'slug' generated for '/'`.


<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove the unnecessary dependencies that came from using the `github-pages` gem.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally

cc @usrse-maintainers
