### PR TITLE
Remove expired Princeton job

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -84,10 +84,6 @@
 - expires: 2021-05-01
   location: Princeton University, Princeton, NJ
   name: Research Software Engineer
-  url: https://main-princeton.icims.com/jobs/12147/research-software-engineer-%28politics%29/job?hub=15
-- expires: 2021-05-01
-  location: Princeton University, Princeton, NJ
-  name: Research Software Engineer
   url: https://main-princeton.icims.com/jobs/12153/research-software-engineer-%28orfe%29/job?hub=15
 - expires: 2021-04-01
   location: ' University of Washington'


### PR DESCRIPTION
URL checker was failing on a Princeton job link. This removes the closed job ad. 

cc @usrse-maintainers
