### PR TITLE
Fixing workshop tags

### DIFF
--- a/_posts/2020-04-09-virtual-workshop.md
+++ b/_posts/2020-04-09-virtual-workshop.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Virtual US-RSE Workshop
-tags: [workshop]
+tags: [virtual workshop]
 ---
 
 We are excited to announce that the US-RSE Association will host a virtual workshop on April 22 and 23, 2020!  

--- a/_posts/newsletters/2020-04-13-newsletter.md
+++ b/_posts/newsletters/2020-04-13-newsletter.md
@@ -3,7 +3,7 @@ layout: post
 title: US-RSE Newsletter
 subtitle: April 2020 Newsletter
 category: newsletter
-tags: [newsletter, workshops, jobs]
+tags: [newsletter, workshop, jobs]
 ---
 
 In this bi-monthly newsletter, we share recent, current, and planned activities of the US-RSE Association. Newsletters are also available on our [website](https://us-rse.org/newsletters/) alongside the growing resources and information on the US-RSE Association. A sign-up option for our newsletter is available [here](https://us-rse.org/join/).

--- a/_posts/newsletters/2020-07-14-newsletter.md
+++ b/_posts/newsletters/2020-07-14-newsletter.md
@@ -3,7 +3,7 @@ layout: post
 title: US-RSE Newsletter
 subtitle: July 2020 Newsletter
 category: newsletter
-tags: [newsletter, workshops, governance]
+tags: [newsletter, workshop, governance]
 ---
 
 


### PR DESCRIPTION
The previous workshop in April 2020 should be labeled as a virtual workshop, and any
post or newsletter that needs a workshop tag should have "workshop" instead of "workshops"

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
