### PR TITLE
Minor edits to virtual workshop event description.

### DIFF
--- a/_events/2021/2021-05-virtual-workshop.md
+++ b/_events/2021/2021-05-virtual-workshop.md
@@ -8,6 +8,6 @@ repeated: false
 
 Following the success of the 2020 US-RSE Virtual Workshop, we decided to keep the event this year virtual due to the ongoing pandemic. **The 2021 US-RSE Virtual Workshop will be held on two non-consecutive half days: May 24 and 27, 2021**, 1-4pm ET/12-3pm CT/10am-1pm PT.
 
-The theme of the workshop is “A Path forward for Research Software Engineers.” The workshop will feature talks, community events, and working group sessions. It will be held via Zoom and some parts, such as the talks, will be recorded and available after the workshop via the US-RSE YouTube channel. The workshop will be free but registration will be required.
+The theme of the workshop is “A Path Forward for Research Software Engineers.” The workshop will feature talks, community events, and working group sessions. It will be held via Zoom and some parts, such as the talks, will be recorded and available after the workshop via the US-RSE YouTube channel. The workshop will be free but registration will be required.
 
-Fore more information please see the [2021 US-RSE Virtual Workshop website](https://us-rse.org/virtual-workshop-2021/).
+For more information please see the [2021 US-RSE Virtual Workshop website](https://us-rse.org/virtual-workshop-2021/).


### PR DESCRIPTION
## Description

Corrects a couple of guessed minor typos on https://us-rse.org/events/2021/2021-05-virtual-workshop

## Motivation and Context

It makes the announcement look more proof-read.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers