### PR TITLE
Add Treasurer role

### DIFF
--- a/pages/community/steering-committee.md
+++ b/pages/community/steering-committee.md
@@ -13,7 +13,7 @@ subtitle: The US-RSE Association is community driven and organized.
 * Julia Damerow, Arizona State University (Election Chair)
 * Charles Ferenbaugh, Los Alamos National Laboratory
 * Sandra Gesing, University of Notre Dame (Vice-Chair)
-* Chris Hill, MIT
+* Chris Hill, MIT (Treasurer)
 * Daniel S. Katz, University of Illinois at Urbana-Champaign
 * Christina Maimone, Northwestern University
 * Lance Parsons, Princeton University


### PR DESCRIPTION
As we move forward towards being a fiscal organization, Chris Hill (@christophernhill) has been elected to be the inaugural US-RSE Treasurer. 

This PR adds this new role to the SC page. 

cc @usrse-maintainers
