### PR TITLE
Add July 2021 Newsletter

### DIFF
--- a/_posts/newsletters/2021-07-27-newsletter.md
+++ b/_posts/newsletters/2021-07-27-newsletter.md
@@ -152,6 +152,7 @@ Items you may have missed on the blog and Slack:
 
 * Vanessa Sochat - [Chef Autamus](https://us-rse.org/blog/2021/vsoch/chef-autamus/) and [RFC Jekyll](https://us-rse.org/blog/2021/vsoch/rfc-jekyll/)
 * Collegeville Workshop 2021 had the theme "Software Teams". White papers, teatime themes, and recordings are available [here](https://collegeville.github.io/CW21/).
+* [GitHub now will provide citation information for repositories that contain a CITATION.cff file](https://twitter.com/natfriedman/status/1420122675813441540?s=20)
 
 
 <a name="outreach"></a>

--- a/_posts/newsletters/2021-07-27-newsletter.md
+++ b/_posts/newsletters/2021-07-27-newsletter.md
@@ -1,0 +1,165 @@
+---
+layout: post
+title: US-RSE Newsletter
+subtitle: July 2021 Newsletter
+category: newsletter
+tags: [newsletter, survey, mission, sc21, agm]
+---
+
+In this bi-monthly newsletter, we share recent, current, and planned activities of the US-RSE Association, and related news that we think is of interest to US-RSE members. Newsletters are also available on our [website](https://us-rse.org/newsletters/) alongside the growing resources and information on the US-RSE Association. A sign-up option for our newsletter is available [here](https://us-rse.org/join/).
+
+In this issue:
+
+* [US-RSE Updated Mission Statement](#mission)
+* [Election of Steering Committee Members and Second Annual General Meeting](#agm)
+* [US-RSE DEI-WG Speaker Series features The National Center for Women & Information Technology (NCWIT)](#dei-speaker)
+* [US-RSE Community Calls](#communitycall)
+* [US-RSE Community Building Workshop](#workshop)
+* [Podcast](#podcast)
+* [RSE-HPC-2021 workshop at SC21](#sc21)
+* [International RSE Survey](#survey-international)
+* [Research Study on Research Computing and Data Workforce](#survey-workforce)
+* [Research Study on Testing Research Software](#survey-testing)
+* [RSEs Working in Industrial Organizations](#industry)
+* [Recent Job Postings](#jobs)
+* [Community News](#news)
+* [Interesting Events](#events)
+* [Interesting Reads](#reads)
+* [US-RSE Outreach](#outreach)
+* [Get Involved](#involved)
+
+<a name="mission"></a>
+# **US-RSE Updated Mission Statement**
+
+Led by the DEI working group and unanimously approved by the US-RSE Steering Committee, we have added a fourth element to our formal [organizational mission](https://us-rse.org/mission/):
+
+> 4\. Diversity, Equity, and Inclusion
+>
+>We will actively promote, encourage, and improve diversity throughout the broader US Research Software Engineer Community consistent with our full DEI mission statement. We will ensure we provide an inclusive environment with equitable treatment for all and we will prioritize a program of Diversity, Equity, and Inclusion (DEI) activities for our organization, led by a dedicated team of active community members.
+
+This is expanded upon in the [full DEI mission statement](https://us-rse.org/dei-mission/). We are excited to add this additional element to our organization mission to help direct our actions. Thank you to everyone who contributed to the development of this important effort.
+
+<a name="agm"></a>
+# **Election of Steering Committee Members and Second Annual General Meeting**
+
+In December 2020 we elected half of the US-RSE Steering committee, and this December, we will hold an election for the remaining five seats, so that in the future we will have a full set of two-year-term positions with half being contested each year. Watch Slack and your email for details on the election process and timeline in the coming weeks! We encourage interested members to think about running for election, and to ask any questions you might have on the [#election](https://usrse.slack.com/archives/C01BC66Q16E) channel on Slack.
+
+We will hold our second US-RSE Annual General Meeting (AGM) on December 10th, 2021, 1-3 pm ET, for all our members. This will be an opportunity to hear from US-RSE leadership about events in 2021 and future plans for the Association. Candidates running for the US-RSE Steering Committee will be given an opportunity to introduce themselves. Questions or discussion topics can be submitted prior to the meeting. All members are invited and encouraged to attend, and the meeting will be recorded and made available shortly afterwards for those who can’t make it.
+
+<a name="dei-speaker"></a>
+# **US-RSE DEI-WG Speaker Series features The National Center for Women & Information Technology (NCWIT)**
+
+The US-RSE Diversity, Equity, and Inclusion Working Group (DEI-WG) is proud to present the next event in the US-RSE DEI-WG Speaker Series: [The National Center for Women & Information Technology (NCWIT)](https://ncwit.org/)
+
+This presentation explores why diversity matters to innovation, how implicit biases play out in technical work cultures, and what actions individuals can take to create more inclusive technical cultures. Attendees will learn key features of strategic, research-based approaches to address the biases and barriers that limit diverse participation in computing.
+
+Date/Time: Thursday, July 29, 2021 2-3:30 pm PT (5-6:30 pm ET)
+
+[Registration Link](https://princeton.zoom.us/meeting/register/tJUvf-mgqDgpEtVQF2X9MA9zd-LIrJZ9w6Jq)
+
+<a name="communitycall"></a>
+# **US-RSE Community Calls**
+
+The video for the July Community Call on "Publication Credit for RSEs" is available at [https://youtu.be/hRh82FKGr4k](https://youtu.be/hRh82FKGr4k).
+
+The next community call will take place on August 12, 2021. You can vote on a topic on [GitHub](https://github.com/USRSE/monthly-community-calls/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc+label%3A0%2Fproposed) by giving the topic you would like to see in the next community call a thumbs up!
+
+<a name="workshop"></a>
+# **US-RSE Community Building Workshop**
+
+Due to COVID-19, the [US-RSE Community Building Workshop](https://us-rse.org/first-community-workshop/) has been delayed and is now scheduled for April 26-27, 2022 in Princeton NJ. As a reminder, or if you are new to US-RSE, thanks to a generous grant by The Alfred P. Sloan Foundation, US-RSE is able to host this in-person workshop as a way to bring together a set of active and motivated community members to plan the best path forward to grow the US-RSE Association. More information on how to participate will be available closer to the workshop. Given the growth of the US-RSE Association (it will be over 2 years since the workshop was initially scheduled!), we’ll be reevaluating and restarting the application process. Space is limited and we are committed to ensuring a broadly diverse participant group, both in terms of traditional diversity measures as well as research domain and institutional representation. We expect great things to come from this workshop as we’ll be working together to plan activities and generate content for the community and the us-rse.org website that promotes and supports current/future RSEs in alignment with the mission of the US-RSE Association.
+
+<a name="podcast"></a>
+# **Podcast**
+
+The Research Software Engineer Stories podcast has three new episodes. Check them out below!
+
+After 21 terrific episodes, co-host Peter Schmidt recorded his final RSE story recently.  A special thank you to Peter for his wonderful contributions! However, this also means that RSE Stories is looking for a new co-host and other volunteers to help with production. You don’t need to commit to anything: start with one episode and go from there. Interested? Reach out to Vanessa via Slack (@v).
+
+* [Kalina Borkiewicz: ](http://us-rse.org/rse-stories/2021/kalina-borkiewicz/)[A Life of Its Own](http://us-rse.org/rse-stories/2021/kalina-borkiewicz/)
+* [Kate Court: ](http://us-rse.org/rse-stories/2021/kate-court/)[Going in with enthusiasm](http://us-rse.org/rse-stories/2021/kate-court/)
+* [Vanessa Sochat: Dinosaur ](http://us-rse.org/rse-stories/2021/vanessa-sochat/)
+
+<a name="sc21"></a>
+# **Deadline is approaching: RSE-HPC-2021 workshop at SC21**
+
+[Research Software Engineers in HPC: Creating Community, Building Careers, Addressing Challenges (RSE-HPC-2021)](https://us-rse.org/rse-hpc-2021/) is a workshop that will be held in conjunction with SC21, in St. Louis, MO and virtually, Monday, 15 November, 2021.
+
+This workshop will bring together RSEs and allies involved in HPC, from all over the world, to grow the RSE community by establishing and strengthening professional networks of current RSEs and RSE leaders. We’ll discuss the current activities and plans of national RSE organizations, discuss the needs of RSEs and RSE groups, and write a report on ways RSE organizations can help address these.
+
+We encourage prospective participants to submit position papers (limit of 2 pages, not counting references; no format prescribed) on topics related to RSE issues.  Papers and discussion topics should be submitted using the [submission website](https://submissions.supercomputing.org/?page=Submit&id=SC21WorkshopRSEHPC2021Submission&site=sc21).  The deadline for submissions is Friday, August 6, 2021, at 11:59 PM AoE (UTC-12).  For more information, see the workshop website or contact the organizers at [sc-ws-rse-hpc@info.supercomputing.org](mailto:sc-ws-rse-hpc@info.supercomputing.org).
+
+<a name="survey-international"></a>
+# **International RSE Survey**
+
+Keep an eye out for the next International RSE Survey in the next few weeks. Last run in 2018, this survey is a multi-lingual worldwide effort led by Simon Hettrick to better understand Research Software Engineers. The results of the survey will be incredibly valuable and US-RSE plans to use the US-specific results to help direct our organizational activities and focus. Please take the time to participate and spread the word to your RSE colleagues. We will send mail with a link when it is available.  
+
+<a name="survey-workforce"></a>
+# **Research Study on Research Computing and Data Workforce**
+
+The Campus Research Computing Consortium (CaRCC) Professionalization Working Group and Northwestern University invite members of the Research Computing and Data (RCD) community (including research software engineers!) to participate in a [research study](https://carcc.org/rcd-professionalization/rcdprof-census/research-study-on-research-computing-and-data-workforce/) of the Research Computing and Data (RCD) workforce in the United States.
+
+[The study](https://carcc.org/rcd-professionalization/rcdprof-census/research-study-on-research-computing-and-data-workforce/) aims to provide the first large data set on the composition of the RCD workforce in terms of demographics, job responsibilities, job types, compensation, and perceptions of the RCD field. The study is limited to the United States due to varying data privacy laws and research requirements internationally. The survey results will be widely shared with the community.
+
+The survey takes approximately 20 minutes to complete.[ Take the Survey](https://northwestern.az1.qualtrics.com/jfe/form/SV_8345y1KCls4nNci).
+
+<a name="survey-testing"></a>
+# **Research Study on Testing Research Software**
+
+Jeffrey Carver, Upulee Kanewala, and Nasir Eisty are conducting [a research study](http://carver.cs.ua.edu/Studies/TestingStudy/) titled "Testing Research Software". They wish to assess current practices, identify challenges, and inform the community of potential improvements of testing practice within the research software domain.
+
+The survey takes approximately 15 minutes to complete. [Take the Survey](http://unf.co1.qualtrics.com/jfe/form/SV_3C5RkDcB4PAudXo).
+
+<a name="industry"></a>
+# **RSEs Working in Industrial Organizations**
+
+We are interested in better understanding our members who work in industry and determining how to grow this segment of our membership. If you work in industry and would be willing to talk with us for a bit, please fill out [this short form](https://forms.gle/BbUgrxxoHCGh4Buw5) to provide contact information. We will follow-up to ask a few more questions; you are not committing yourself or your organization to do anything more.
+
+<a name="jobs"></a>
+# **Recent Job Postings**
+
+These opportunities were recently posted to the [RSE Careers page](https://us-rse.org/jobs/):
+
+1. [Director of Research Administration Information Systems](https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/job/South-Street-Landing/Director-of-Research-Administration-Information-Systems_REQ171590): Brown University, Providence, RI
+2. [Web and Interface Application Lead Engineer](https://osu.wd1.myworkdayjobs.com/en-US/OSUCareers/job/Columbus-Campus/Web---Interface-App-Lead-Engineer_R17290): Ohio Supercomputer Center / The Ohio State University, Columbus, OH or remote
+3. [Research Facilitator](https://www.lib.ncsu.edu/jobs/ehra/ResearchFacilitator): North Carolina State University, Raleigh, NC
+4. [Research Software Engineer](https://lnkd.in/eNrNKsS): Princeton University, Princeton, NJ (Some geographic flexibility may be possible within the US)
+5. [Software Engineer](https://careers.purdue.edu/job/West-Lafayette-Software-Engineer-IN-47906/746526900/): Purdue University, West Lafayette, IN
+6. [Bioinformatics Staff Scientist (Ph.D.) or Software Engineer: API interoperability](https://careers.iscb.org/jobs/view/7598): Scripps Research, San Diego, CA or remote in US
+7. [Research Software Engineer](https://main-princeton.icims.com/jobs/12728/research-software-engineer/job): Princeton University, Princeton, NJ
+8. [Neutron Data and Computing Program Manager](https://jobs.ornl.gov/job/Oak-Ridge-Neutron-Data-and-Computing-Program-Manager-TN-37830/724194700/): Oak Ridge National Laboratory, Oak Ridge, TN
+9. [Software Engineer](https://recruit.ap.ucsb.edu/JPF01941): Benioff Ocean Initiative at University of California, Santa Barbara, CA (currently remote)
+
+<a name="news"></a>
+# Community News
+
+* Daniel S. Katz and Neil Chue Hong are editing a special issue of PeerJ CS on software citation, indexing and discoverability, so if you are doing any work in this area, please consider submitting it to this [special issue](https://peerj.com/special-issues/84-software); the deadline is July 30.
+* DHTech, a community of people doing technical work in Digital Humanities, are conducting a survey to gauge the interest for a technical mentorship program. If you work in Digital Humanities, please consider filling out the survey! More information can be found [on the DHTech website](https://dh-tech.github.io/mentorship-survey).
+* Sandra Gesing was a co-organizer for the workshop "[Best Practices for FAIR Research Software](https://esip.figshare.com/articles/presentation/Best_Practices_for_FAIR_Research_Software_-_ESIP_2021_Summer_Meeting/15042624/1)" at the [ESIP Summer Meeting](https://2021esipsummermeeting.sched.com/event/jMO2/best-practices-for-fair-research-software). The organizers will suggest further sessions on the topic at the [18th RDA Plenary Meeting](https://www.rd-alliance.org/plenary-meetings/next-plenary) in November 2021.
+* Members of the US-RSE Association led the panel[ "Research Software Engineer (RSE) Careers - State of the Profession, Opportunities, and Challenges in Academia"](https://pearc21.sched.com/event/kN61/research-software-engineer-rse-careers-state-of-the-profession-opportunities-and-challenges-in-academia) at the Practice and Experience in Advanced Research Computing conference ([PEARC21](https://pearc.acm.org/pearc21/)) on July 20, 2021. The panel included Ian Cosden, Sandra Gesing, Christina Maimone, Kenton McHenry, and Alan Sussman, and it was moderated by Daniel S. Katz.  [Read more](https://us-rse.org/2021-07-20-pearc21-panel/).
+
+<a name="events"></a>
+# **Interesting Events**
+
+Some other events coming up may be of interest to RSEs:
+
+* [SeptembRSE](https://septembrse.society-rse.org/) will take place from September 6th - 30th, 2021. The entire conference online and the organizers embrace the flexibility achievable for online events to spread all of the sessions out so that they will occupy the whole of September. All sessions will be streamed, recorded and published so that the material can be  explored throughout September at a time that is best for everyone. The programme consists of keynotes, talks, posters, walkthroughs, workshops, panels, discussions, and networking sessions. It is also planned to run some blended sessions with local RSE groups who are interested in mixing screenings of SeptembRSE events with local talks and networking.
+
+<a name="reads"></a>
+# **Interesting Reads**
+
+Items you may have missed on the blog and Slack:
+
+* Vanessa Sochat - [Chef Autamus](https://us-rse.org/blog/2021/vsoch/chef-autamus/) and [RFC Jekyll](https://us-rse.org/blog/2021/vsoch/rfc-jekyll/)
+* Collegeville Workshop 2021 had the theme "Software Teams". White papers, teatime themes, and recordings are available [here](https://collegeville.github.io/CW21/).
+
+
+<a name="outreach"></a>
+# **US-RSE Outreach**
+
+Do you have a meeting, event, or community that might be interested in hearing more about US-RSE? We are happy to come talk to your group! Send an email to [contact@us-rse.org](mailto:contact@us-rse.org) or reach out via @sc on slack.
+
+<a name="involved"></a>
+# **Get Involved**
+
+There are lots of ways to get involved with the US-RSE community. Of course, you can [join us on Slack](https://us-rse.org/join) or volunteer for an interview with the [RSE Stories podcast](https://us-rse.org/rse-stories/about/). But we’re also looking for ideas and help in many other places. See our [list of projects](https://docs.google.com/document/d/1jjVD0WkeeWZJI6yqSKyMdIjtClzolsxv75RkpLju17I/edit?usp=sharing) and let us know how you’d like to help. Help with things like the Website Committee, Social Media, and Community Engagement are all needed.


### PR DESCRIPTION
This adds the July 2021 newsletter. Once live, it will be emailed. 

Please give it a careful look for formatting errors. I caught a few, but one or two usually sneaks through in the process of converting from google docs to markdown. 



cc @usrse-maintainers
