### PR TITLE
Adding information for October 14th International RSE day events

### DIFF
--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -16,7 +16,7 @@ of the days events.
 _First International RSE Day Virtual Workshop Events Oct 14, 11:00 AM Eastern - 4:45 PM Eastern._
 
 An NSF-funded workshop titled “Building the research innovation workforce: a workshop
-to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community [https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf](https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
+to identify new insights and directions to advance the research computing community” recently found that collaborations between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community [https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf](https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
 
 But what do successful RSE, CI professional, and researcher teams and stakeholder interactions look like? How are they funded and how did people get started in this career?
 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -27,7 +27,7 @@ Join us for a panel discussion and talks to introduce teams of researchers, RSEs
 October 14th US-RSE Schedule
 Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM Eastern
 
-| Time (EST)  | Event |  Event Description                         |
+| Time (EDT)  | Event |  Event Description                         |
 | ----        | ------|------------------------------------------- |
 | 11:00 AM - 11:10 AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
 | 11:10 AM - 12:00 noon | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -13,7 +13,7 @@ of the days events.
 
 **Background**
 
-_First International RSE Day Virtual Workshop Events Oct 14, 11:00 AM Eastern - 4:30 PM Eastern._
+_First International RSE Day Virtual Workshop Events Oct 14, 11:00 AM Eastern - 4:45 PM Eastern._
 
 An NSF-funded workshop titled “[Building the research innovation workforce: a workshop
 to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community [https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf](https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -23,10 +23,13 @@ Join us for a panel discussion and talks to introduce teams of researchers, RSEs
 October 14th US-RSE Schedule
 Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 
-| Time (EST)  | Event Description |
-| ----        | -------------------------------------------------- |
-| 11AM - 12PM | Kickoff Panel     |
-|             |                   |
+| Time (EST)  | Event |  Event Description                         |
+| ----        | ------|------------------------------------------- |
+| 11AM - 11:10AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
+| 11:10AM - 12PM | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
+|             |                   |                                |
+| 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
+| 12:20 - 12:45 | Q&A               |                                |
 
 
 **Registration details**  

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -27,9 +27,10 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | ----        | ------|------------------------------------------- |
 | 11AM - 11:10AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
 | 11:10AM - 12PM | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
-|             |                   |                                |
 | 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
 | 12:20 - 12:45 | Q&A               |                                |
+| 13:00 - 13:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
+| 13:20 - 13:45 | Q&A               |                                |
 
 
 **Registration details**  

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -7,7 +7,7 @@ repeated: false
 ---
 
 On October 14th between 11:00 AM and 4:45 PM Eastern time we will be hosting a series of online
-talks and panels with discussion to celebrate the First International RSE Day. Events 
+talks and panels with discussion to celebrate the [First International RSE Day](https://researchsoftware.org/council/intl-rse-day.html). Events 
 begin on the hour between 11:00 AM and 4:00 PM Eastern; feel free to join us for some or all
 of the days events.
 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -37,7 +37,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 1:20 PM - 1:45 PM | Q&A               |                                |
 | 2:00 PM - 2:20 PM | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
 | 2:20 PM - 2:45 PM | Q&A               |                                |
-| 15:00 - 15:20 | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
+| 3:00 PM - 3:20 PM | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
 | 15:20 - 15:45 | Q&A               |                                |
 | 16:00 - 16:20 | TBD, TACC     | Title TBD                      |
 | 16:20 - 16:45 | Q&A               |                                |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -36,7 +36,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 1:00 PM - 1:20 PM | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
 | 1:20 PM - 1:45 PM | Q&A               |                                |
 | 2:00 PM - 2:20 PM | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
-| 14:20 - 14:45 | Q&A               |                                |
+| 2:20 PM - 2:45 PM | Q&A               |                                |
 | 15:00 - 15:20 | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
 | 15:20 - 15:45 | Q&A               |                                |
 | 16:00 - 16:20 | TBD, TACC     | Title TBD                      |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -7,11 +7,11 @@ repeated: false
 ---
 
 On October 14th between 11AM and 4:30PM Eastern time we will be hosting a series of online
-talks and panles with discusion to celebrate the First International RSE Day.
+talks and panels with discussion to celebrate the First International RSE Day.
 
 **Background**
 
-First International RSE Day Virtual Workshop Events Oct 14, 11AM Eastern - 4:30PM Eastern.
+_First International RSE Day Virtual Workshop Events Oct 14, 11AM Eastern - 4:30PM Eastern._
 
 An NSF-funded workshop titled “Building the research innovation workforce: a workshop
 to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community (https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
@@ -35,7 +35,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 13:20 - 13:45 | Q&A               |                                |
 | 14:00 - 14:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
 | 14:20 - 14:45 | Q&A               |                                |
-| 15:00 - 15:20 | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratorie                     |
+| 15:00 - 15:20 | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
 | 15:20 - 15:45 | Q&A               |                                |
 | 16:00 - 16:20 | TBD, TACC     | Title TBD                      |
 | 16:20 - 16:45 | Q&A               |                                |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -7,7 +7,9 @@ repeated: false
 ---
 
 On October 14th between 11AM and 4:30PM Eastern time we will be hosting a series of online
-talks and panels with discussion to celebrate the First International RSE Day.
+talks and panels with discussion to celebrate the First International RSE Day. Events 
+begin on the hour between 11AM and 4PM Eastern, feel free to join us for some or all
+of the days events.
 
 **Background**
 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -38,7 +38,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 2:00 PM - 2:20 PM | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
 | 2:20 PM - 2:45 PM | Q&A               |                                |
 | 3:00 PM - 3:20 PM | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
-| 15:20 - 15:45 | Q&A               |                                |
+| 3:20 PM - 3:45 PM | Q&A               |                                |
 | 16:00 - 16:20 | TBD, TACC     | Title TBD                      |
 | 16:20 - 16:45 | Q&A               |                                |
 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -6,7 +6,7 @@ layout: event
 repeated: false
 ---
 
-On October 14th between 11AM and 4:30PM Eastern time we will be hosting a series of online
+On October 14th between 11:00 AM and 4:30 PM Eastern time we will be hosting a series of online
 talks and panels with discussion to celebrate the First International RSE Day. Events 
 begin on the hour between 11:00 AM and 4:00 PM Eastern; feel free to join us for some or all
 of the days events.

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -9,11 +9,24 @@ repeated: false
 On October 14th between 11AM and 4:30PM Eastern time we will be hosting a series of online
 talks and panles with discusion to celebrate the First International RSE Day.
 
-Background
+**Background**
 
+First International RSE Day Virtual Workshop Events Oct 14, 11AM Eastern - 4:30PM Eastern.
 
-Schedule
+An NSF-funded workshop titled “Building the research innovation workforce: a workshop
+to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community (https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
 
+But what do successful RSE, CI professional, and researcher teams and stakeholder interactions look like? How are they funded and how did people get started in this career?
+
+Join us for a panel discussion and talks to introduce teams of researchers, RSEs, and CI professionals and learn about their experiences in the research computing community.
+
+October 14th US-RSE Schedule
+Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
+
+| Time (EST)  | Event Description |
+| ----        | -------------------------------------------------- |
+| 11AM - 12PM | Kickoff Panel     |
+|             |                   |
 
 
 **Registration details**  

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -13,7 +13,7 @@ of the days events.
 
 **Background**
 
-_First International RSE Day Virtual Workshop Events Oct 14, 11AM Eastern - 4:30PM Eastern._
+_First International RSE Day Virtual Workshop Events Oct 14, 11:00 AM Eastern - 4:30 PM Eastern._
 
 An NSF-funded workshop titled “Building the research innovation workforce: a workshop
 to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community [https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf](https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -8,7 +8,7 @@ repeated: false
 
 On October 14th between 11AM and 4:30PM Eastern time we will be hosting a series of online
 talks and panels with discussion to celebrate the First International RSE Day. Events 
-begin on the hour between 11AM and 4PM Eastern, feel free to join us for some or all
+begin on the hour between 11:00 AM and 4:00 PM Eastern; feel free to join us for some or all
 of the days events.
 
 **Background**

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -34,7 +34,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
 | 12:20 PM - 12:45 PM | Q&A               |                                |
 | 1:00 PM - 1:20 PM | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
-| 13:20 - 13:45 | Q&A               |                                |
+| 1:20 PM - 1:45 PM | Q&A               |                                |
 | 14:00 - 14:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
 | 14:20 - 14:45 | Q&A               |                                |
 | 15:00 - 15:20 | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -35,7 +35,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 12:20 PM - 12:45 PM | Q&A               |                                |
 | 1:00 PM - 1:20 PM | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
 | 1:20 PM - 1:45 PM | Q&A               |                                |
-| 14:00 - 14:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
+| 2:00 PM - 2:20 PM | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
 | 14:20 - 14:45 | Q&A               |                                |
 | 15:00 - 15:20 | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
 | 15:20 - 15:45 | Q&A               |                                |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -15,7 +15,7 @@ of the days events.
 
 _First International RSE Day Virtual Workshop Events Oct 14, 11:00 AM Eastern - 4:45 PM Eastern._
 
-An NSF-funded workshop titled “[Building the research innovation workforce: a workshop
+An NSF-funded workshop titled “Building the research innovation workforce: a workshop
 to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community [https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf](https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
 
 But what do successful RSE, CI professional, and researcher teams and stakeholder interactions look like? How are they funded and how did people get started in this career?

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -1,0 +1,20 @@
+---
+title: October 2021 International RSE Day Virtual Events
+expires: 2021-10-14
+event_date: "October 14, 2021"
+layout: event
+repeated: false
+---
+
+On October 14th between 11AM and 4:30PM Eastern time we will be hosting a series of online
+talks and panles with discusion to celebrate the First International RSE Day.
+
+Background
+
+
+Schedule
+
+
+
+**Registration details**  
+Information on how to register for the Zoom meeting will be sent via email and posted in the #general channel on Slack.

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -31,7 +31,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | ----        | ------|------------------------------------------- |
 | 11:00 AM - 11:10 AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
 | 11:10 AM - 12:00 noon | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
-| 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
+| 12:00 noon - 12:20 PM | Nicole Brewer, Purdue     | Title TBD                      |
 | 12:20 PM - 12:45 PM | Q&A               |                                |
 | 1:00 PM - 1:20 PM | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
 | 1:20 PM - 1:45 PM | Q&A               |                                |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -40,7 +40,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 3:00 PM - 3:20 PM | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
 | 3:20 PM - 3:45 PM | Q&A               |                                |
 | 16:00 - 16:20 | TBD, TACC     | Title TBD                      |
-| 16:20 - 16:45 | Q&A               |                                |
+| 4:20 PM - 4:45 PM | Q&A               |                                |
 
 
 **Registration details**  

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -20,6 +20,8 @@ But what do successful RSE, CI professional, and researcher teams and stakeholde
 
 Join us for a panel discussion and talks to introduce teams of researchers, RSEs, and CI professionals and learn about their experiences in the research computing community.
 
+**Schedule**
+
 October 14th US-RSE Schedule
 Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 
@@ -29,8 +31,14 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 11:10AM - 12PM | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
 | 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
 | 12:20 - 12:45 | Q&A               |                                |
-| 13:00 - 13:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
+| 13:00 - 13:20 | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
 | 13:20 - 13:45 | Q&A               |                                |
+| 14:00 - 14:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
+| 14:20 - 14:45 | Q&A               |                                |
+| 15:00 - 15:20 | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratorie                     |
+| 15:20 - 15:45 | Q&A               |                                |
+| 16:00 - 16:20 | TBD, TACC     | Title TBD                      |
+| 16:20 - 16:45 | Q&A               |                                |
 
 
 **Registration details**  

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -6,7 +6,7 @@ layout: event
 repeated: false
 ---
 
-On October 14th between 11:00 AM and 4:30 PM Eastern time we will be hosting a series of online
+On October 14th between 11:00 AM and 4:45 PM Eastern time we will be hosting a series of online
 talks and panels with discussion to celebrate the First International RSE Day. Events 
 begin on the hour between 11:00 AM and 4:00 PM Eastern; feel free to join us for some or all
 of the days events.

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -33,7 +33,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 11:10 AM - 12:00 noon | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
 | 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
 | 12:20 PM - 12:45 PM | Q&A               |                                |
-| 13:00 - 13:20 | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
+| 1:00 PM - 1:20 PM | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
 | 13:20 - 13:45 | Q&A               |                                |
 | 14:00 - 14:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |
 | 14:20 - 14:45 | Q&A               |                                |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -16,7 +16,7 @@ of the days events.
 _First International RSE Day Virtual Workshop Events Oct 14, 11AM Eastern - 4:30PM Eastern._
 
 An NSF-funded workshop titled “Building the research innovation workforce: a workshop
-to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community (https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
+to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community [https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf](https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
 
 But what do successful RSE, CI professional, and researcher teams and stakeholder interactions look like? How are they funded and how did people get started in this career?
 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -32,7 +32,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 11:00 AM - 11:10 AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
 | 11:10 AM - 12:00 noon | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
 | 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
-| 12:20 - 12:45 | Q&A               |                                |
+| 12:20 PM - 12:45 PM | Q&A               |                                |
 | 13:00 - 13:20 | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |
 | 13:20 - 13:45 | Q&A               |                                |
 | 14:00 - 14:20 | Ian Cosden, Princeton     | Building the Princeton Research Software Engineering Group                      |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -29,7 +29,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 
 | Time (EST)  | Event |  Event Description                         |
 | ----        | ------|------------------------------------------- |
-| 11AM - 11:10AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
+| 11:00 AM - 11:10 AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
 | 11:10AM - 12PM | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
 | 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
 | 12:20 - 12:45 | Q&A               |                                |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -30,7 +30,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | Time (EST)  | Event |  Event Description                         |
 | ----        | ------|------------------------------------------- |
 | 11:00 AM - 11:10 AM | Introduction, Blake Joyce/Ian Cosden   | Brief welcome.  |
-| 11:10AM - 12PM | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
+| 11:10 AM - 12:00 noon | Kickoff Panel     | Speakers introduce themselves and their RSE journey. |
 | 12:00 - 12:20 | Nicole Brewer, Purdue     | Title TBD                      |
 | 12:20 - 12:45 | Q&A               |                                |
 | 13:00 - 13:20 | Rubern Lara and Mehmet Belgin, Georgia Tech     | Title TBD                     |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -39,7 +39,7 @@ Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
 | 2:20 PM - 2:45 PM | Q&A               |                                |
 | 3:00 PM - 3:20 PM | Reed Milewicz, Sandia      | Building and Sustaining an RSE Department at Sandia National Laboratory                      |
 | 3:20 PM - 3:45 PM | Q&A               |                                |
-| 16:00 - 16:20 | TBD, TACC     | Title TBD                      |
+| 4:00 PM - 4:20 PM | TBD, TACC     | Title TBD                      |
 | 4:20 PM - 4:45 PM | Q&A               |                                |
 
 

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -25,7 +25,7 @@ Join us for a panel discussion and talks to introduce teams of researchers, RSEs
 **Schedule**
 
 October 14th US-RSE Schedule
-Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM EST
+Start: 8 Pacific / 9 Mountain / 10 Central / 11 AM Eastern
 
 | Time (EST)  | Event |  Event Description                         |
 | ----        | ------|------------------------------------------- |

--- a/_events/2021/2021-10-intnl-rse-day.md
+++ b/_events/2021/2021-10-intnl-rse-day.md
@@ -15,7 +15,7 @@ of the days events.
 
 _First International RSE Day Virtual Workshop Events Oct 14, 11:00 AM Eastern - 4:30 PM Eastern._
 
-An NSF-funded workshop titled “Building the research innovation workforce: a workshop
+An NSF-funded workshop titled “[Building the research innovation workforce: a workshop
 to identify new insights and directions to advance the research computing community” recently found that collaboration between research software engineers, cyberinfrastructure professionals, and researchers were key to the research computing community [https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf](https://www.rcac.purdue.edu/files/ciworkforce2020/report.pdf). 
 
 But what do successful RSE, CI professional, and researcher teams and stakeholder interactions look like? How are they funded and how did people get started in this career?


### PR DESCRIPTION
## Description
Adding information for October 14th International RSE day events

## Motivation and Context
To appear in events pages so we can send out email, link from other places etc... to let everyone know. 

## Checklist:
- [ x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
