### PR TITLE
Switch to the hamburger menu when the viewport is wider.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -5726,7 +5726,7 @@ a.navbar-item:focus,a.navbar-item:focus-within,a.navbar-item:hover,a.navbar-item
     }
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1200px) {
     .navbar,.navbar-menu,.navbar-start,.navbar-end {
         align-items: stretch;
         display: flex;


### PR DESCRIPTION
## Description
Switch to "mobile" hamburger mode more eagerly.

## Motivation and Context
The top menu is now wider so it is easy to end up with a browser window width that does not yet have the hamburger but that cuts off the right-hand end of the top menu. This adjusts the threshold so that the transition to the hamburger menu occurs sooner.

## Checklist:
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers