### PR TITLE
Post new jobs to USRSE Slack

### DIFF
--- a/.github/workflows/jobs-slack-poster.yml
+++ b/.github/workflows/jobs-slack-poster.yml
@@ -1,4 +1,4 @@
-name: Post Jobs to USRSE Slack
+name: Post New Jobs to Slack
 
 on:
   push:

--- a/.github/workflows/label-job-prs.yml
+++ b/.github/workflows/label-job-prs.yml
@@ -1,0 +1,22 @@
+name: Label Job PRs
+
+on:
+  pull_request:
+    paths:
+      - '_data/jobs.yml'
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  bump-labeled:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: jobs

--- a/.github/workflows/label-job-prs.yml
+++ b/.github/workflows/label-job-prs.yml
@@ -1,22 +1,30 @@
-name: Label Job PRs
+name: Post Jobs to USRSE Slack
 
 on:
-  pull_request:
+  push:
     paths:
       - '_data/jobs.yml'
-    types:
-      - opened
-      - labeled
-      - unlabeled
-      - synchronize
     branches:
       - main
 
 jobs:
-  bump-labeled:
+  slack-poster:
     runs-on: ubuntu-latest
+    name: Run Jobs Slack Poster
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: jobs
+          fetch-depth: 2
+
+      - id: updater
+        name: Job Updater
+        uses: rseng/jobs-updater@main
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        with:
+          filename: "_data/jobs.yml"
+          key: "url"
+
+      - run: echo ${{ steps.updater.outputs.fields }}
+        name: Show New Jobs
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The site is built with [Jekyll](https://jekyllrb.com/) and hosted on GitHub.
 ## How do I contribute?
 
 We encourage the community to contribute to the content of the website.  
-To do this: fork the repository, make your proposed changes, test locally (see below), and then create a pull request against `master`. For more details about opening pull requests and issues, see our [Contributing Guide](.github/CONTRIBUTING.md).
+To do this: fork the repository, make your proposed changes, test locally (see below), and then create a pull request
+against `main`. For more details about opening pull requests and issues, see our [Contributing Guide](.github/CONTRIBUTING.md).
 
 ### 1. How do I update the map?
 
@@ -33,8 +34,11 @@ can open a pull request to update the date. An example posting is shown below. T
 job would appear on the site until the first of July, 2019.
 
 ```yaml
-- {expires: 2019-07-01, posted: 2019-02-01, location: 'Princeton, NJ',
-    name: 'Research Software Engineer', url: 'https://main-princeton.icims.com/jobs'}
+- expires: 2019-07-01
+  location: 'Princeton, NJ'
+  name: 'Research Software Engineer'
+  posted: 2019-02-01
+  url: 'https://main-princeton.icims.com/jobs'
 ```
 
 And don't forget to write your new job at the top of the [_data/jobs.yml](_data/jobs.yml) file!
@@ -42,6 +46,10 @@ For testing, we look to see that all fields are defined, the url exists, and
 that the "expires" and "posted" fields load as a `datetime.date` object in
 Python. If you copy the format above, you should be ok.
 
+Once your job(s) are merged to `main` a [GitHub Action](.github/workflows/jobs-slack-poster.yml) will automatically
+cross-post your job(s) to the USRSE Slack `#jobs` channel!
+
+![example post image](https://raw.githubusercontent.com/rseng/jobs-updater/main/img/example.png)
 
 ### 3. How do I add an event?
 
@@ -412,7 +420,7 @@ nice features to make it less error prone, discussed next.
 
 ### GitHub CI
 
-## URLChecker and Spelling
+#### URLChecker and Spelling
 
 The [URLschecker](https://github.com/urlstechie/URLs-checker) is a GitHub action
 that @vsoch worked on to contribute retry and some other nice features for the 
@@ -430,7 +438,7 @@ typos ./pages ./_posts ./README.md --write-changes
 If there is a word that needs to be ignored, see [instructions](https://github.com/crate-ci/typos#false-positives) 
 for adding a `_typos.toml` file to indicate false positives.
 
-## Clean Expired Jobs
+#### Clean Expired Jobs
 
 The workflow [clean-expired-jobs.yml](.github/workflows/clean-expired-jobs.yml) is run nightly,
 and uses the same function from the urlchecker to check for expired links in jobs.yml,
@@ -438,7 +446,15 @@ and given an expired link, remove it from the file if the url check fails. In th
 that a link is not expired and the check fails, we would want to know about this
 (and the test will fail).
 
-### Greetings
+#### Post New Jobs to Slack
+
+The workflow [jobs-slack-poster.yml](.github/workflows/jobs-slack-poster.yml) is run on any push
+to `main` with changes to `_data/jobs.yml`. If new jobs are found, it will post the Job URL to
+the USRSE Slack `#jobs` channel. It utilizes the [Jobs updater](https://github.com/rseng/jobs-updater)
+Github Action by @vsoch and @jhkennedy to parse the `_data/jobs.yml` file for new jobs and post them
+the USRSE Slack.
+
+#### Greetings
 This simple greetings action greets first time users (for issues).
 The logic of this is determined by the [greetings.yml](.github/workflows/greetings.yml)
 workflow. 


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

*Edit: I've updated this description for the new strategy, and preserved the description of the old strategy at the bottom.*

This uses GitHub Actions to post new jobs to USRSE Slack

## Description

This adds a new GitHub Actions Workflow that parses `_data/jobs.yml` for new jobs on any push `main` which edits the `_data/jobs.yml` file. It uses the [Jobs Updater Action](https://github.com/rseng/jobs-updater) by @vsoch and I  to do the parsing and posting. 

For rseng/jobs-updater#2 (current with rseng/jobs-updater@main), I went ahead and added a slack integration to one of the workspaces I admin to test it out. 

To test, I fast-forward merged this to the`main` branch of jhkennedy/jobs-updater, then
 * A direct commit (or squash commit) to main, as in jhkennedy/jobs-updater@b5058f2, successfully ran:
   https://github.com/jhkennedy/jobs-updater/actions/runs/1415394588
 * A merge commit from jhkennedy/jobs-updater#3 successfully ran:
   https://github.com/jhkennedy/jobs-updater/actions/runs/1415407801
 
Both were successfully posted to my slack workspace:
![image](https://user-images.githubusercontent.com/7882693/140014699-1e0b1ed4-f2d2-450b-8dd0-5a5b06db53fe.png)


## Motivation and Context

There's been some discussion in USRSE slack about having PRs adding job postings  be echoed in the `#jobs` channel, so they are automagically cross-posted.

TODOs for the this all to work (either before or after merging this PR):
  - [ ] A USRSE slack admin create a Webhook App   with an "Incoming Webhooks" URL, see:
       https://github.com/rseng/jobs-updater#1-slack-setup
  - [ ] A repository maintainer add a `SLACK_WEBHOOK` repository secret containing the incoming webhook URL created above

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [x] I have updated the README.md if necessary

cc @usrse-maintainers

---

## Old description from original attempt

This adds a new GitHub Actions Workflow to affix a `jobs` label to any PR to `main` which edits the `_data/jobs.yml` file. It uses the [actions-ecosystem-add-labels](https://github.com/marketplace/actions/actions-ecosystem-add-labels) action to add the label. 

### Motivation and Context

There's been some discussion in USRSE slack about having PRs adding job postings  be echoed in the `#jobs` channel, so they are automagically cross-posted.

This could be setup with GitHub Actions + a "jobs" label on those PRs + http://slack.github.com/ integration.
How I'd envision it working is:
* PR to USRSE/usrse.github.io adding a Job
* *This proposed GitHub Action* applies a "jobs" label to jobs PRs
* Slack integration to  USRSE/usrse.github.io PRs with a `+filter label:jobs`
