### PR TITLE
Adding link to RSE stories podcast from external and resources!

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -77,8 +77,11 @@
 - name: External
   dropdown:
     - name: RSE Map
-      link: "https://usrse.github.io/usrse-map"
+      link: "https://us-rse.org/usrse-map"
+      external: true
+    - name: RSE Stories Podcast
+      link: "https://us-rse.org/rse-stories"
       external: true
     - name: Community Blogs
-      link: "https://usrse.github.io/blog"
+      link: "https://us-rse.org/blog"
       external: true

--- a/pages/resources/rses.md
+++ b/pages/resources/rses.md
@@ -8,6 +8,7 @@ subtitle: Resources for RSEs
 _These resources can be helpful to establish RSE positions, groups, or further understanding of research software engineering._
 
  - [How to start an RSE Group](https://www.software.ac.uk/blog/2019-08-19-how-do-you-start-rse-group){:target="_blank"} as a leader
+ - [Research Software Engineer Stories Podcast](https://us-rse.org/rse-stories) to hear diverse stories of growth and discovery from our community.
  - [Community Documents](https://github.com/USRSE/usrse.github.io/wiki){:target="_blank"}
  - [RSE Starter Pack](http://rseng.github.io/starter-pack/#/){:target="_blank"} getting started to create an RSE community as an RSE
  - [The Story of the Research Software Engineer](https://www.youtube.com/watch?v=trAfA9VWLTQ){:target="_blank"} video introduction to Research Software Engineering


### PR DESCRIPTION
@mrmundt made a great point that it was hard to find the podcast on the site - and we should add it to External and resources! So that is what this PR does - adds it alongside the map and community blog, and then on the resources for RSEng page.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
