### PR TITLE
Test Job Posting Workflow

### DIFF
--- a/.github/workflows/jobs-slack-poster.yml
+++ b/.github/workflows/jobs-slack-poster.yml
@@ -6,6 +6,7 @@ on:
       - '_data/jobs.yml'
     branches:
       - main
+      - test/jobs-bot
 
 jobs:
   slack-poster:

--- a/.github/workflows/jobs-slack-poster.yml
+++ b/.github/workflows/jobs-slack-poster.yml
@@ -1,4 +1,4 @@
-name: Post Jobs to USRSE Slack
+name: Post New Jobs to Slack
 
 on:
   push:

--- a/.github/workflows/label-job-prs.yml
+++ b/.github/workflows/label-job-prs.yml
@@ -1,0 +1,22 @@
+name: Label Job PRs
+
+on:
+  pull_request:
+    paths:
+      - '_data/jobs.yml'
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  bump-labeled:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: jobs

--- a/.github/workflows/label-job-prs.yml
+++ b/.github/workflows/label-job-prs.yml
@@ -1,22 +1,30 @@
-name: Label Job PRs
+name: Post Jobs to USRSE Slack
 
 on:
-  pull_request:
+  push:
     paths:
       - '_data/jobs.yml'
-    types:
-      - opened
-      - labeled
-      - unlabeled
-      - synchronize
     branches:
       - main
 
 jobs:
-  bump-labeled:
+  slack-poster:
     runs-on: ubuntu-latest
+    name: Run Jobs Slack Poster
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: jobs
+          fetch-depth: 2
+
+      - id: updater
+        name: Job Updater
+        uses: rseng/jobs-updater@main
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        with:
+          filename: "_data/jobs.yml"
+          key: "url"
+
+      - run: echo ${{ steps.updater.outputs.fields }}
+        name: Show New Jobs
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The site is built with [Jekyll](https://jekyllrb.com/) and hosted on GitHub.
 ## How do I contribute?
 
 We encourage the community to contribute to the content of the website.  
-To do this: fork the repository, make your proposed changes, test locally (see below), and then create a pull request against `master`. For more details about opening pull requests and issues, see our [Contributing Guide](.github/CONTRIBUTING.md).
+To do this: fork the repository, make your proposed changes, test locally (see below), and then create a pull request
+against `main`. For more details about opening pull requests and issues, see our [Contributing Guide](.github/CONTRIBUTING.md).
 
 ### 1. How do I update the map?
 
@@ -33,8 +34,11 @@ can open a pull request to update the date. An example posting is shown below. T
 job would appear on the site until the first of July, 2019.
 
 ```yaml
-- {expires: 2019-07-01, posted: 2019-02-01, location: 'Princeton, NJ',
-    name: 'Research Software Engineer', url: 'https://main-princeton.icims.com/jobs'}
+- expires: 2019-07-01
+  location: 'Princeton, NJ'
+  name: 'Research Software Engineer'
+  posted: 2019-02-01
+  url: 'https://main-princeton.icims.com/jobs'
 ```
 
 And don't forget to write your new job at the top of the [_data/jobs.yml](_data/jobs.yml) file!
@@ -42,6 +46,10 @@ For testing, we look to see that all fields are defined, the url exists, and
 that the "expires" and "posted" fields load as a `datetime.date` object in
 Python. If you copy the format above, you should be ok.
 
+Once your job(s) are merged to `main` a [GitHub Action](.github/workflows/jobs-slack-poster.yml) will automatically
+cross-post your job(s) to the USRSE Slack `#jobs` channel!
+
+![example post image](https://raw.githubusercontent.com/rseng/jobs-updater/main/img/example.png)
 
 ### 3. How do I add an event?
 
@@ -412,7 +420,7 @@ nice features to make it less error prone, discussed next.
 
 ### GitHub CI
 
-## URLChecker and Spelling
+#### URLChecker and Spelling
 
 The [URLschecker](https://github.com/urlstechie/URLs-checker) is a GitHub action
 that @vsoch worked on to contribute retry and some other nice features for the 
@@ -430,7 +438,7 @@ typos ./pages ./_posts ./README.md --write-changes
 If there is a word that needs to be ignored, see [instructions](https://github.com/crate-ci/typos#false-positives) 
 for adding a `_typos.toml` file to indicate false positives.
 
-## Clean Expired Jobs
+#### Clean Expired Jobs
 
 The workflow [clean-expired-jobs.yml](.github/workflows/clean-expired-jobs.yml) is run nightly,
 and uses the same function from the urlchecker to check for expired links in jobs.yml,
@@ -438,7 +446,15 @@ and given an expired link, remove it from the file if the url check fails. In th
 that a link is not expired and the check fails, we would want to know about this
 (and the test will fail).
 
-### Greetings
+#### Post New Jobs to Slack
+
+The workflow [jobs-slack-poster.yml](.github/workflows/jobs-slack-poster.yml) is run on any push
+to `main` with changes to `_data/jobs.yml`. If new jobs are found, it will post the Job URL to
+the USRSE Slack `#jobs` channel. It utilizes the [Jobs updater](https://github.com/rseng/jobs-updater)
+Github Action by @vsoch and @jhkennedy to parse the `_data/jobs.yml` file for new jobs and post them
+the USRSE Slack.
+
+#### Greetings
 This simple greetings action greets first time users (for issues).
 The logic of this is determined by the [greetings.yml](.github/workflows/greetings.yml)
 workflow. 

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,4 +1,9 @@
 - expires: 2021-12-31
+  location: Remote
+  name: Senior Research Software Engineer
+  posted: 2021-11-03
+  url: https://foo.bar/jobs/8675309/
+- expires: 2021-12-31
   location: Seattle (or Pittsburgh)
   name: Senior Software Manager for Data-intensive Astronomical Research Program
   posted: 2021-11-03


### PR DESCRIPTION
@vsoch this should test the Slack job posting workflow. 

It's 2 commits ahead of USRSE/usrse.github.io#563 (and jhkennedy/usrse.github.io@label-jobs) with [a diff](https://github.com/jhkennedy/usrse.github.io/compare/label-jobs...test-workflow) that looks like:
```diff
diff --git a/.github/workflows/jobs-slack-poster.yml b/.github/workflows/jobs-slack-poster.yml
index 930bb67..d6e0d66 100644
--- a/.github/workflows/jobs-slack-poster.yml
+++ b/.github/workflows/jobs-slack-poster.yml
@@ -6,6 +6,7 @@ on:
       - '_data/jobs.yml'
     branches:
       - main
+      - test/jobs-bot
 
 jobs:
   slack-poster:
diff --git a/_data/jobs.yml b/_data/jobs.yml
index c0f17b6..dae17da 100644
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,8 @@
+- expires: 2021-12-31
+  location: Remote
+  name: Senior Research Software Engineer
+  posted: 2021-11-03
+  url: https://foo.bar/jobs/8675309/
 - expires: 2021-12-31
   location: Seattle (or Pittsburgh)
   name: Senior Software Manager for Data-intensive Astronomical Research Program
```