### PR TITLE
fix email links

### DIFF
--- a/_posts/2021-11-12-sc-candidates.md
+++ b/_posts/2021-11-12-sc-candidates.md
@@ -27,7 +27,7 @@ Candidates are listed in alphabetical order.
 
 ## Nicole Brewer
 
-[Email](brewer36@purdue.edu), [CV](https://github.com/nicole-brewer/cv/blob/master/cv.pdf)
+[Email](mailto:brewer36@purdue.edu), [CV](https://github.com/nicole-brewer/cv/blob/master/cv.pdf)
 
 **Why do you want to be on the US-RSE Steering Committee?**
 
@@ -51,7 +51,7 @@ that kind of clarity and sense of belonging to the next person.
 
 ## Jeffrey Carver
 
-[Email](carver@cs.ua.edu), [Website](http://carver.cs.ua.edu/)
+[Email](mailto:carver@cs.ua.edu), [Website](http://carver.cs.ua.edu/)
 
 **Why do you want to be on the US-RSE Steering Committee?**
 
@@ -95,7 +95,7 @@ US-RSE SC decisions.
 
 ## Ian Cosden
 
-[Email](icosden@princeton.edu), [LinkedIn](https://www.linkedin.com/in/ian-cosden-1907958/)
+[Email](mailto:icosden@princeton.edu), [LinkedIn](https://www.linkedin.com/in/ian-cosden-1907958/)
 
 **Why do you want to be on the US-RSE Steering Committee?**
 
@@ -154,7 +154,7 @@ locally and in the broader community.
 
 ## Charles Ferenbaugh
 
-[Email](cferenba@lanl.gov), [LinkedIn](https://www.linkedin.com/in/charles-ferenbaugh-b2822a225/)
+[Email](mailto:cferenba@lanl.gov), [LinkedIn](https://www.linkedin.com/in/charles-ferenbaugh-b2822a225/)
 
 **Why do you want to be on the US-RSE Steering Committee?**
 
@@ -183,7 +183,7 @@ at SC20 and SC21.
 
 ## Sandra Gesing
 
-[Email](sandra.gesing@nd.edu), [Website](http://sandra-gesing.com/)
+[Email](mailto:sandra.gesing@nd.edu), [Website](http://sandra-gesing.com/)
 
 **Why do you want to be on the US-RSE Steering Committee?**
 
@@ -227,7 +227,7 @@ meeting in person.
 
 ## Rinku Gupta
 
-[Email](rgupta@anl.gov),
+[Email](mailto:rgupta@anl.gov),
 [LinkedIn](https://www.linkedin.com/in/rinku-gupta-38b4b319/),
 [LinkedIn](https://www.anl.gov/profile/rinku-k-gupta)
 
@@ -270,7 +270,7 @@ US-RSE community for RSE empowerment.
 
 ## Christina Maimone
 
-[Email](christina.maimone@northwestern.edu), [LinkedIn](https://www.linkedin.com/in/christina-maimone-302a3a40/)
+[Email](mailto:christina.maimone@northwestern.edu), [LinkedIn](https://www.linkedin.com/in/christina-maimone-302a3a40/)
 
 **Why do you want to be on the US-RSE Steering Committee?**
 
@@ -315,7 +315,7 @@ Journal of Open Source Software ([JOSS](https://joss.theoj.org/)).
 
 ## Chen Zhang
 
-[Email](zhangc@ornl.gov), [LinkedIn](https://www.linkedin.com/in/chen-z-5a081725/)
+[Email](mailto:zhangc@ornl.gov), [LinkedIn](https://www.linkedin.com/in/chen-z-5a081725/)
 
 **Why do you want to be on the US-RSE Steering Committee?**
 


### PR DESCRIPTION
correct email links to candidates to include `mailto:`

<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
correct email links to candidates to include `mailto:`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this change, the email links are incorrectly rendered as, e.g., https://us-rse.org/2021-11-12-sc-candidates/carver@cs.ua.edu

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
