### PR TITLE
On the calendar, align day names to the right.

### DIFF
--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -25,6 +25,12 @@ layout: page
   </div>
 </div>
 
+<style>
+.fc-day {
+  text-align: right !important;
+}
+</style>
+
 <script src='https://cdn.jsdelivr.net/npm/luxon@1.24.1/build/global/luxon.min.js'></script>
 <script src="https://cdn.jsdelivr.net/npm/rrule@2.6.4/dist/es5/rrule.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.5.1/main.min.js"></script>


### PR DESCRIPTION
## Description
On the event calendar, this moves the day names more directly above the day numbers.

## Motivation and Context
Fixes #545.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers