### PR TITLE
Allow multiple taglines, select according to current day.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,15 @@ choosing. You are not required to include a title, and it will default to a gene
 "YouTube video player."
 
 
+### How do the taglines under the landing page title work?
+
+A list of possible taglines is stored in `_config.yml`,
+search for the current tagline to find them.
+You may edit the list, each line starts with a `- `.
+One tagline is selected when the static site is built.
+As subsequent builds are done, others will get their turn.
+
+
 ## Tests
 
 Tests are run during continuous integration to catch any errors and to preview

--- a/_config.yml
+++ b/_config.yml
@@ -25,9 +25,8 @@ paginate_path: "/news/page:num/"
 excerpt_length: 500
 
 hero_line_one: The United States Research Software Engineer Association
-hero_line_two: [
-	"A community of people who make research software happen."
-]
+hero_line_two:
+- A community of people who make research software happen.
 
 # social media
 twitter: us_rse

--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,9 @@ paginate_path: "/news/page:num/"
 excerpt_length: 500
 
 hero_line_one: The United States Research Software Engineer Association
-hero_line_two: A community of people who make research software happen.
+hero_line_two: [
+	"A community of people who make research software happen."
+]
 
 # social media
 twitter: us_rse

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -5,6 +5,9 @@
                 <div class="col-md-4">
                   <img id="hero-image" src="{{ site.baseurl }}{{ site.icon }}">
                 </div>
+                <!-- From the configured list of taglines in hero_line_two,
+                     choose one by index. The current day number, modulo
+                     the number of taglines, decides which line to use. -->
                 {% assign tagline_size = site.hero_line_two | size %}
                 {% assign tagline_index = site.time | date: '%j' | modulo: tagline_size %}
                 <div class="col-md-8">

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -5,9 +5,11 @@
                 <div class="col-md-4">
                   <img id="hero-image" src="{{ site.baseurl }}{{ site.icon }}">
                 </div>
+                {% assign tagline_size = site.hero_line_two | size %}
+                {% assign tagline_index = site.time | date: '%j' | modulo: tagline_size %}
                 <div class="col-md-8">
                     <h1 class="title is-2 hero-text" style="padding-top:50px">{{ site.hero_line_one }}</h1>
-                    <p class="subtitle is-4 is-italic hero-text">{{ site.hero_line_two }}</p>
+                    <p class="subtitle is-4 is-italic hero-text">{{ site.hero_line_two[tagline_index] }}</p>
                     {% if page.hero_link %}
                         <a href="{{ page.hero_link | relative_url }}" class="button is-info is-large">{{ page.hero_link_text }}</a>{% endif %}
                 </div>


### PR DESCRIPTION
## Description
Rather than having a fixed tagline, select one according to the current day from those in the configured `hero_line_two` list.

Occurs in building the site so doesn't rely on any JavaScript but should still change fairly frequently when we add jobs or events or whatever.

## Motivation and Context
Assists #522.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers