### PR TITLE
Turn on Verbose Option for URL Checker Workflow

### DIFF
--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -24,14 +24,14 @@ jobs:
         python3 scripts/clean_jobs.py
 
     - name: Run URLs-checker
-      uses: urlstechie/urlchecker-action@0.2.1
+      uses: urlstechie/urlchecker-action@0.0.25
       with:
         file_types: .md,.py,.yml
         print_all: false
         retry_count: 3
         timeout: 10
-        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov
-        white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
+        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov
+        exclude_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
     - name: Push Fixes
       env:

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -15,7 +15,7 @@ jobs:
         files: ./_posts ./pages ./README.md
         
     - name: URLs-checker
-      uses: mrmundt/urlchecker-action@verbose-option
+      uses: urlstechie/urlchecker-action@0.0.25
       with:
         # A comma-separated list of file types to cover in the URL checks
         file_types: .md,.py,.yml

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -32,8 +32,8 @@ jobs:
         # Google Forms is having enormous timeouts
         timeout: 10
 
-        # White listed patterns (seem to have SSL issues but work in browser)
-        white_listed_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov
+        # Exclude these patterns from the checker
+        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov
 
-        # White list the following files
-        white_listed_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
+        # Exclude these files from the checker
+        exclude_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -15,13 +15,16 @@ jobs:
         files: ./_posts ./pages ./README.md
         
     - name: URLs-checker
-      uses: urlstechie/urlchecker-action@0.2.1
+      uses: mrmundt/urlchecker-action@verbose-option
       with:
         # A comma-separated list of file types to cover in the URL checks
         file_types: .md,.py,.yml
 
         # Choose whether to include file with no URLs in the prints.
         print_all: false
+
+        # More verbose summary at the end of a run
+        verbose: true
 
         # How many times to retry a failed request (defaults to 1)
         retry_count: 3


### PR DESCRIPTION
The urlchecker was updated to include a `verbose` option that shows files and the URLs that failed on each file in the end summary.

## Description
This PR updates the version of the urlchecker-action being used (and changes options to match new terminology), as well as turning on the verbose output for the PR linting workflow.

## Motivation and Context
Because the USRSE has so many files to check with a bunch of URLs, it can be difficult to find the file(s) in which the failing URL is located from the log printout. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
