### PR TITLE
Missed a start date change!

### DIFF
--- a/_events/repeated/community-call.md
+++ b/_events/repeated/community-call.md
@@ -24,7 +24,7 @@ The USRSE monthly community calls occur on the second Thursday of each month. 12
 announcements are posted to Slack and sent to USRSE email accounts. 
 
 Community calls typically have a topical focus. They provide a forum for USRSE members
-to compare experiences aroud a topic, hang-out and chat on zoom.
+to compare experiences around a topic, hang-out and chat on zoom.
 
 Any and all suggestions for topics are 
 welcome at [https://github.com/USRSE/monthly-community-calls/issues](https://github.com/USRSE/monthly-community-calls/issues).

--- a/_events/repeated/community-call.md
+++ b/_events/repeated/community-call.md
@@ -17,7 +17,7 @@ rrule:
   - DTSTART;TZID=America/New_York:20220113T120000
 # second Thursday of every month
   - RRULE:UNTIL=20251211T120000;FREQ=MONTHLY;BYDAY=+2TH
-  - RDATE;TZID=America/New_York:20220108T120000
+  - RDATE;TZID=America/New_York:20220113T120000
 ---
 
 The USRSE monthly community calls occur on the second Thursday of each month. 12:00-13:00 Eastern. Community call topics, agenda and zoom registration


### PR DESCRIPTION
rdate typo left one sneaky Saturday community call for Jan 22. This should remove that - I hope!

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/3535328/148220592-802ea0bc-c844-4de5-8e4e-8b6db3fc1f3e.png">


cc @usrse-maintainers
