### PR TITLE
Add second CMU job

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,7 +1,12 @@
 - expires: 2022-05-01
   location: Carnegie Mellon University, School of Computer Science, Pittsburgh, PA (Hybrid/Remote)
+  name: Developer in Residence
+  posted: 2022-01-14
+  url: https://delphi.cmu.edu/about/careers/
+- expires: 2022-05-01
+  location: Carnegie Mellon University, School of Computer Science, Pittsburgh, PA (Hybrid/Remote)
   name: Research Programmer / Analyst
-  posted: 2022-01-13
+  posted: 2022-01-14
   url: https://delphi.cmu.edu/about/careers/
 - expires: 2022-02-01
   location: Data Science Institute at The University of Wisconsin-Madison, Madison, WI


### PR DESCRIPTION
There is a second RSE job as part of the CMU openings. Plus, I changed the posted date to today for the other CMU job posted yesterday so they are next to each other. 

cc @usrse-maintainers
