### PR TITLE
Calendar entry for pre-community call planning open meet.

### DIFF
--- a/_events/repeated/community-call-planning.md
+++ b/_events/repeated/community-call-planning.md
@@ -1,0 +1,29 @@
+---
+title: Community Call Planning Meeting
+subtitle:
+location: Virtual
+expires: 2025-12-11
+event_date: "fourth Thursday each month 12:00-13:00 Eastern"
+layout: event
+time:
+  - - start 2022-01-27
+
+# Repeated events information
+repeated: true
+
+# use an rdate string instead (best for complex repeated events)
+# note that the dtstart and rdate at the end are the same
+rrule: 
+  - DTSTART;TZID=America/New_York:20220127T120000
+# second Thursday of every month
+  - RRULE:UNTIL=20251225T120000;FREQ=MONTHLY;BYDAY=+4TH
+  - RDATE;TZID=America/New_York:20220127T120000
+---
+
+Planning meeting for USRSE monthly community calls occur on the fourth Thursday of each month. 12:00-13:00 Eastern. This is a wokring meeting to
+plan for the next community call. All are welcome to join the call.
+
+Any and all suggestions for community topics are 
+welcome at [https://github.com/USRSE/monthly-community-calls/issues](https://github.com/USRSE/monthly-community-calls/issues).
+Anyone in USRSE is super welcome to lead a call on a topic of there choosing. Feel free to reach out to the organizers (currently Julia Damerow and
+Chris Hill) on USRSE slack ( "@Julia Damerow" and/or "@Chris Hill") or elsewhere if you would like to host (or help with) a call.

--- a/_events/repeated/community-call-planning.md
+++ b/_events/repeated/community-call-planning.md
@@ -15,7 +15,7 @@ repeated: true
 # note that the dtstart and rdate at the end are the same
 rrule: 
   - DTSTART;TZID=America/New_York:20220127T120000
-# second Thursday of every month
+# fourth Thursday of every month
   - RRULE:UNTIL=20251225T120000;FREQ=MONTHLY;BYDAY=+4TH
   - RDATE;TZID=America/New_York:20220127T120000
 ---

--- a/_events/repeated/community-call-planning.md
+++ b/_events/repeated/community-call-planning.md
@@ -20,8 +20,8 @@ rrule:
   - RDATE;TZID=America/New_York:20220127T120000
 ---
 
-Planning meeting for USRSE monthly community calls occur on the fourth Thursday of each month. 12:00-13:00 Eastern. This is a wokring meeting to
-plan for the next community call. All are welcome to join the call.
+Planning meetings for USRSE monthly community calls occur on the fourth Thursday of each month. 12:00-13:00 Eastern. This is a working meeting to
+plan for the next community call. All are welcome to join the call, zoom details will be posted to the Community Call channel.
 
 Any and all suggestions for community topics are 
 welcome at [https://github.com/USRSE/monthly-community-calls/issues](https://github.com/USRSE/monthly-community-calls/issues).


### PR DESCRIPTION
This PR adds a calendar entry for 4th Thursday of the month call for planning next community call.

cc @usrse-maintainers
