### PR TITLE
Possible update of (c) date

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="site-footer-inside">
       <p class="site-info"> 
-      © US-RSE  •  2021-2022
+      © US-RSE  •  2021-{{ 'now' | date: "%Y" }}
       </p>
       <div class="social-links">
         {% if site.email %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="site-footer-inside">
       <p class="site-info"> 
-      © US-RSE  •  2021 
+      © US-RSE  •  2021-2022
       </p>
       <div class="social-links">
         {% if site.email %}


### PR DESCRIPTION
Suggested change for footer (c) US-RSE 2021-2022

or we could use 

 (c) US-RSE 2022

!!!

cc @usrse-maintainers
