### PR TITLE
Fix styling in header for Safari

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -33,16 +33,17 @@
                 {% endfor %}
                 {% endif %}
             </div>
-            <a type="button" style="margin:auto 5px" class="btn btn-warning btn-sm" href="{{ site.baseurl }}/support">
+            <a type="button" style="margin:auto 5px; -webkit-appearance: none;" class="btn btn-warning btn-sm" href="{{ site.baseurl }}/support">
                 Support
             </a>
-            
-            <a type="button" style="margin:auto 5px" class="btn btn-warning btn-sm" href="{{ site.baseurl }}/join">
+
+            <a type="button" style="margin:auto 5px; -webkit-appearance: none;" class="btn btn-warning btn-sm" href="{{ site.baseurl }}/join">
                   Join
-            </a>    
-                  <a href="{{ site.baseurl }}/search" type="button" style="padding-left: 20px;">
-                    <i style="margin-top:15px; ;color:white; font-size:25px" class="fa fa-search"></i>
-                </a>
+            </a>
+
+            <a href="{{ site.baseurl }}/search" type="button" style="padding-left: 20px; -webkit-appearance: none;">
+                <i style="margin-top:15px; ;color:white; font-size:25px" class="fa fa-search"></i>
+            </a>
 
         </div>
     </div>


### PR DESCRIPTION
<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail. -->
Fix for the header buttons (top right) on Safari: added the `-webkit-appearance: none` to the inline style attributes for the buttons. _And I also "fixed" the indentation so the `<a />`'s line up_ 😄 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes [533](https://github.com/USRSE/usrse.github.io/issues/533).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
