### PR TITLE
Add job post from Sylabs

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,8 @@
+- expires: 2022-04-14
+  location: Sylabs, Inc., Remote
+  name: Software Engineer
+  posted: 2022-02-14
+  url: https://app.trinethire.com/companies/22680-sylabs-inc/jobs/56951-software-engineer-remote
 - expires: 2022-06-01
   location: Princeton University, Princeton, NJ
   name: Senior Research Software Engineer


### PR DESCRIPTION
Add job posted via the job board Google Form (response 61).  Some discussion occurred on #job-post-team and two people liked it.  It's about working on a tool used by researchers (Singularity).

cc @usrse-maintainers
