### PR TITLE
Added DEI Speaker Series March event

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -97,7 +97,8 @@
   posted: 2022-02-07
   url: https://main-princeton.icims.com/jobs/14134/manager%2c-research-software-engineering/job
 - expires: 2022-12-03
-  location: Center for Computation and Visualization, Brown University, Providence, RI
+  location: Center for Computation and Visualization, Brown University, Providence,
+    RI
   name: Research Software Engineer
   posted: 2022-02-07
   url: https://brown.wd5.myworkdayjobs.com/en-US/staff-careers-brown/jobs/details/Research-Software-Engineer_REQ176069

--- a/_events/2022/2022-03-dei-speaker-series.md
+++ b/_events/2022/2022-03-dei-speaker-series.md
@@ -1,7 +1,7 @@
 ---
 title: Allies, Collaboration & Automation - Working towards inclusive Engagement in Research Computing
 subtitle: US-RSE DEI-WG Speaker Series
-expires: 2021-03-11
+expires: 2021-03-12
 event_date: "March 11, 2021"
 layout: event
 duration: 60
@@ -21,8 +21,7 @@ The US-RSE DEI-WG is working to bring to the US-RSE community quarterly visits f
 ## Event
 
 The US-RSE Diversity, Equity, and Inclusion Working Group (DEI-WG) is proud to
-present this speaker series event in conjunction with the international DiveRSE initiative
-to support EDI within the research software engineering community. This event will take
+present this speaker series event in conjunction with the international DiveRSE initiative taking place alongside the Lorentz workshop - [Vive la différence - research software engineers](https://www.researchsoft.org/lorentz/) - in support of EDI within the research software engineering community. This event will take
 place **Friday, March 11th at 11AM Pacific/ 2PM Eastern / 7PM GMT**
 
 ### Abstract
@@ -38,4 +37,4 @@ This talk is open to all career and interest levels and will present the viewpoi
 
 ### Biography
 
-Cristin Merritt and Wil Mayers are technical and program solution specialists with Alces Flight.  Located in the United Kingdom, Cristin and Wil’s day jobs are to solve HPC problems and provide long-term solutions for their clients with a focus on compute and storage environments and sustainability.  Both Cristin and Wil are active within DEI initiatives in tech in both the UK and US, having served on the SC’21 Inclusivity Volunteer Committee in St. Louis, and are active members of Women in HPC (WHPC) and the UK Society of Research Software Engineering.  Most recently, Cristin has accepted the position of chair for EDIA for the upcoming RSECon22 planned for Newcastle, UK in September of this year.
+Cristin Merritt and Wil Mayers are technical and program solution specialists with [Alces Flight](https://alces-flight.com/).  Located in the United Kingdom, Cristin and Wil’s day jobs are to solve HPC problems and provide long-term solutions for their clients with a focus on compute and storage environments and sustainability.  Both Cristin and Wil are active within DEI initiatives in tech in both the UK and US, having served on the SC’21 Inclusivity Volunteer Committee in St. Louis, and are active members of [Women in HPC](https://womeninhpc.org/) (WHPC) and the UK Society of Research Software Engineering.  Most recently, Cristin has accepted the position of chair for EDIA for the upcoming RSECon22 planned for Newcastle, UK in September of this year.

--- a/_events/2022/2022-03-dei-speaker-series.md
+++ b/_events/2022/2022-03-dei-speaker-series.md
@@ -9,7 +9,7 @@ repeated: false
 category: dei
 time:
     - - start: 2021-03-11T19:00:00Z
-        end: 2021-03-11T12:00:00Z
+        end: 2021-03-11T20:00:00Z
 ---
 
 

--- a/_events/2022/2022-03-dei-speaker-series.md
+++ b/_events/2022/2022-03-dei-speaker-series.md
@@ -1,0 +1,41 @@
+---
+title: Allies, Collaboration & Automation - Working towards inclusive Engagement in Research Computing
+subtitle: US-RSE DEI-WG Speaker Series
+expires: 2021-03-11
+event_date: "March 11, 2021"
+layout: event
+duration: 60
+repeated: false
+category: dei
+time:
+    - - start: 2021-03-11T19:00:00Z
+        end: 2021-03-11T12:00:00Z
+---
+
+
+## US-RSE DEI-WG Speaker Series Info
+
+The US-RSE DEI-WG is working to bring to the US-RSE community quarterly visits from RSE professionals with vested interests or research into DEI in the RSE community at large. Our community pledges to continually educate ourselves through research on best practices focused on diversity, equity, and inclusion. The US-RSE is committed to providing an inclusive environment with equitable treatment for all and to promoting and encouraging diversity throughout the RSE community. We encourage everyone to suggest speakers and topics and are open to different formats and timelines of the events. Feedback is much appreciated.
+
+
+## Event
+
+The US-RSE Diversity, Equity, and Inclusion Working Group (DEI-WG) is proud to
+present this speaker series event in conjunction with the international DiveRSE initiative
+to support EDI within the research software engineering community. This event will take
+place **Friday, March 11th at 11AM Pacific/ 2PM Eastern / 7PM GMT**
+
+### Abstract
+
+The role of a Research Software Engineer (RSE) is to transform research concepts and methods into practical computing workflows, blending established and innovative software techniques that incorporate technical sustainability and excellence.  But to tread this path successfully it takes allies, collaborators, and process repeatability to make things happen.  So how does an RSE build up this kind of ecosystem of success?  This talk details how you can develop a diverse pool of resources and how sometimes reaching outside of the task you’ve been given can result in the breakthrough you need.
+
+- Learn how to include others without overwhelming yourself
+- Understand the importance of establishing barriers and touchpoints
+-	Get insight into how to build up allies and mentors (as well as be one)
+
+This talk is open to all career and interest levels and will present the viewpoints both from just starting out to taking your experience and using it to help others build successful RSE ecosystems of their own.
+
+
+### Biography
+
+Cristin Merritt and Wil Mayers are technical and program solution specialists with Alces Flight.  Located in the United Kingdom, Cristin and Wil’s day jobs are to solve HPC problems and provide long-term solutions for their clients with a focus on compute and storage environments and sustainability.  Both Cristin and Wil are active within DEI initiatives in tech in both the UK and US, having served on the SC’21 Inclusivity Volunteer Committee in St. Louis, and are active members of Women in HPC (WHPC) and the UK Society of Research Software Engineering.  Most recently, Cristin has accepted the position of chair for EDIA for the upcoming RSECon22 planned for Newcastle, UK in September of this year.


### PR DESCRIPTION
The allcontributors-auto-detect action isn't passing for me at [line 51](https://github.com/nicole-brewer/usrse.github.io/blob/1f6aaf3f6eecb93da93b7e4db231ab7d31b99f49/.github/workflows/update-contributors.yaml#L51). I don't really understand what it is checking for. 

But the preview of the new event page looks good to me: https://23-303766687-gh.circle-artifacts.com/0/usrse.github.io/events/2022/2022-03-dei-speaker-series/index.html

cc @usrse-maintainers
