### PR TITLE
Add event for Mary Leung DiveRSE keynote

### DIFF
--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -14,7 +14,7 @@ time:
 
 ## DiveRSE Speaker Series Info
 
-[DiveRSE (Diverse RSE)](https://diverse-rse.github.io/) is a series of talks and related activities including discussion and panel sessions designed to support and raise awareness of equite, diversity, and inclusion (EDI) challenges and successes within the research software community.
+[DiveRSE (Diverse RSE)](https://diverse-rse.github.io/) is a series of talks and related activities including discussion and panel sessions designed to support and raise awareness of equity, diversity, and inclusion (EDI) challenges and successes within the research software community.
 
 ## Event - Normalizing inclusion by embracing difference
 

--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -14,7 +14,7 @@ time:
 
 ## DiveRSE Speaker Series Info
 
-DiveRSE (Diverse RSE) is a series of talks and related activities including discussion and panel sessions designed to support and raise awareness of EDI challenges and successes within the research software community.
+[DiveRSE (Diverse RSE)](https://diverse-rse.github.io/) is a series of talks and related activities including discussion and panel sessions designed to support and raise awareness of equite, diversity, and inclusion (EDI) challenges and successes within the research software community.
 
 ## Event - Normalizing inclusion by embracing difference
 
@@ -35,7 +35,7 @@ After registering, you will receive a confirmation email containing information 
 
 ### Abstract
 
-The Vive la différence - research software engineers workshop aims to explore ways to reframe research software engineering (RSE) placing diversity, equity, and inclusion (DEI) as a central organizing principle. RSEs work in highly inter and multi-disciplinary environments, where they must be adept at “speaking” multiple languages, e.g., programming and domain languages. RSEs may have been trained in computer science, a domain science, mathematics, or an engineering discipline. Given the technical diversity, one might expect research software communities to welcome social diversity, creating an ideal ecosystem for the placing DEI as a central organizing principle. However, while research indicates that social diversity results in greater innovation, research software itself, as a growing multidisciplinary field spanning the globe and representing a diverse spectrum of technical domains, remains largely homogeneous.
+The Vive la différence - research software engineers workshop aims to explore ways to reframe research software engineering (RSE) placing diversity, equity, and inclusion (DEI) as a central organizing principle. RSEs work in highly inter and multi-disciplinary environments, where they must be adept at "speaking" multiple languages, e.g., programming and domain languages. RSEs may have been trained in computer science, a domain science, mathematics, or an engineering discipline. Given the technical diversity, one might expect research software communities to welcome social diversity, creating an ideal ecosystem for the placing DEI as a central organizing principle. However, while research indicates that social diversity results in greater innovation, research software itself, as a growing multidisciplinary field spanning the globe and representing a diverse spectrum of technical domains, remains largely homogeneous.
 
 This session explores what it takes to achieve DEI, also known as equity, diversity, inclusion (EDI) and justice, equity, diversity, inclusion (JEDI) and how reframing DEI within RSE could increase innovation and developer productivity. We will also consider how cultivating respect and embracing difference could help to normalize inclusion.
 

--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -18,7 +18,7 @@ DiveRSE (Diverse RSE) is a series of talks and related activities including disc
 
 ## Event - Normalizing inclusion by embracing difference
 
-DiveRSE is delighted to welcome Mary Ann Leung, Ph.D., Founder and President of the Sustainable Horizons Institute, as our inaugural speaker in the DiveRSE talk series looking at diversity, equity and inclusion in the Research Software Engineering (RSE) community.
+DiveRSE is delighted to welcome Mary Ann Leung, Ph.D., Founder and President of the [Sustainable Horizons Institute](https://shinstitute.org/), as our inaugural speaker in the DiveRSE talk series looking at diversity, equity and inclusion in the Research Software Engineering (RSE) community.
 
 The series runs from March 2022 and is linked to the [“Vive la différence - research software engineers” workshop](https://www.researchsoft.org/events/2022-04/) being hosted at the Lorentz Centre in The Netherlands in April 2022.
 

--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -4,7 +4,7 @@ subtitle: DiveRSE Speaker Series
 expires: 2022-03-23
 event_date: "March 22, 2022"
 layout: event
-duration: 60
+duration: 90
 repeated: false
 category: dei 
 time:

--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -9,7 +9,7 @@ repeated: false
 category: dei 
 time:
     - - start: 2022-03-11T16:00:00Z
-        end: 2022-03-11T17:00:00Z
+        end: 2022-03-11T17:30:00Z
 ---
 
 ## DiveRSE Speaker Series Info

--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -8,8 +8,8 @@ duration: 90
 repeated: false
 category: dei 
 time:
-    - - start: 2022-03-11T16:00:00Z
-        end: 2022-03-11T17:30:00Z
+    - - start: 2022-03-11T17:00:00Z
+        end: 2022-03-11T18:30:00Z
 ---
 
 ## DiveRSE Speaker Series Info

--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -1,0 +1,44 @@
+---
+title: Normalizing inclusion by embracing difference
+subtitle: DiveRSE Speaker Series
+expires: 2022-03-23
+event_date: "March 22, 2022"
+layout: event
+duration: 60
+repeated: false
+category: dei 
+time:
+    - - start: 2022-03-11T16:00:00Z
+        end: 2022-03-11T17:00:00Z
+---
+
+## DiveRSE Speaker Series Info
+
+DiveRSE (Diverse RSE) is a series of talks and related activities including discussion and panel sessions designed to support and raise awareness of EDI challenges and successes within the research software community.
+
+## Event - Normalizing inclusion by embracing difference
+
+DiveRSE is delighted to welcome Mary Ann Leung, Ph.D., Founder and President of the Sustainable Horizons Institute, as our inaugural speaker in the DiveRSE talk series looking at diversity, equity and inclusion in the Research Software Engineering (RSE) community.
+
+The series runs from March 2022 and is linked to the [“Vive la différence - research software engineers” workshop](https://www.researchsoft.org/events/2022-04/) being hosted at the Lorentz Centre in The Netherlands in April 2022.
+
+The keynote talk explores what it takes to achieve DEI, also known as equity, diversity, inclusion (EDI) and justice, equity, diversity, inclusion (JEDI) and how reframing DEI within RSE could increase innovation and developer productivity. We will also consider how cultivating respect and embracing difference could help to normalize inclusion.
+
+Following the talk, there will be a chance to join a facilitated discussion in breakout rooms providing an excellent opportunity to chat with Research Software Engineers and researchers from around the world.
+
+This talk is being co-hosted with and supported by the [Society of Research Software Engineering](https://society-rse.org/).
+
+More information about the event can be found at  [the event webpage](https://diverse-rse.github.io/events/2022-03-22).
+
+[Register via Zoom](https://us06web.zoom.us/meeting/register/tZwvd-CprD4jH9Kt5smG4nGbp-YHoahn44Hm).
+After registering, you will receive a confirmation email containing information about joining the meeting.
+
+### Abstract
+
+The Vive la différence - research software engineers workshop aims to explore ways to reframe research software engineering (RSE) placing diversity, equity, and inclusion (DEI) as a central organizing principle. RSEs work in highly inter and multi-disciplinary environments, where they must be adept at “speaking” multiple languages, e.g., programming and domain languages. RSEs may have been trained in computer science, a domain science, mathematics, or an engineering discipline. Given the technical diversity, one might expect research software communities to welcome social diversity, creating an ideal ecosystem for the placing DEI as a central organizing principle. However, while research indicates that social diversity results in greater innovation, research software itself, as a growing multidisciplinary field spanning the globe and representing a diverse spectrum of technical domains, remains largely homogeneous.
+
+This session explores what it takes to achieve DEI, also known as equity, diversity, inclusion (EDI) and justice, equity, diversity, inclusion (JEDI) and how reframing DEI within RSE could increase innovation and developer productivity. We will also consider how cultivating respect and embracing difference could help to normalize inclusion.
+
+### Biography
+
+Mary Ann Leung is the founder and President of [Sustainable Horizons Institute](https://shinstitute.org/), a nonprofit organization dedicated to developing the computational science and engineering workforce and promoting diversity, equity, and inclusion. Her research interests span computational quantum mechanics, quantum computing, high performance computing, workforce development, diversity, and inclusion. Leung serves as an Editor for the Computing in Science and Engineering (CiSE) Magazine Diversity and Inclusion department. She performs a variety of community activities including serving on the study committee for the Congressionally mandated National Academies Assessment of the NASA University Leadership Initiative. Dr. Leung holds B.A., M.S. and PhD. degrees in Computational Physical Chemistry.

--- a/_events/2022/2022-03-dei-diverse-leung.md
+++ b/_events/2022/2022-03-dei-diverse-leung.md
@@ -20,7 +20,7 @@ DiveRSE (Diverse RSE) is a series of talks and related activities including disc
 
 DiveRSE is delighted to welcome Mary Ann Leung, Ph.D., Founder and President of the [Sustainable Horizons Institute](https://shinstitute.org/), as our inaugural speaker in the DiveRSE talk series looking at diversity, equity and inclusion in the Research Software Engineering (RSE) community.
 
-The series runs from March 2022 and is linked to the [“Vive la différence - research software engineers” workshop](https://www.researchsoft.org/events/2022-04/) being hosted at the Lorentz Centre in The Netherlands in April 2022.
+The series runs from March 2022 and is linked to the ["Vive la différence - research software engineers" workshop](https://www.researchsoft.org/events/2022-04/) being hosted at the [Lorentz Center](https://www.lorentzcenter.nl/) in The Netherlands in April 2022.
 
 The keynote talk explores what it takes to achieve DEI, also known as equity, diversity, inclusion (EDI) and justice, equity, diversity, inclusion (JEDI) and how reframing DEI within RSE could increase innovation and developer productivity. We will also consider how cultivating respect and embracing difference could help to normalize inclusion.
 


### PR DESCRIPTION
This adds the first DiveRSE event, running in conjunction with the Vive le difference workshop.

## Description
Add event for Mary Leung keynote speech.

## Motivation and Context
Advertise DEI talks geared towards RSEs.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [x] I have updated the README.md if necessary

cc @usrse-maintainers
