### PR TITLE
Carcc events

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -261,11 +261,6 @@
   name: HPC Gateway Engineer
   posted: 2021-12-17
   url: https://tufts.taleo.net/careersection/ext/jobdetail.ftl?job=21002023
-- expires: 2022-03-15
-  location: Princeton University, Princeton, NJ
-  name: Research Software Engineer
-  posted: 2021-12-15
-  url: https://main-princeton.icims.com/jobs/13881/research-software-engineer/job
 - expires: 2022-02-28
   location: Allen Institute, Seattle, WA
   name: Data Analyst I

--- a/_events/repeated/carcc-data.md
+++ b/_events/repeated/carcc-data.md
@@ -9,17 +9,13 @@ layout: event
 category: community-learning
 time:
   - - start: 2022-04-05 13:00 EDT
-
-# Repeated events information
+  
 repeated: true
-
-# use an rdate string instead (best for complex repeated events)
-# note that the dtstart and rdate at the end are the same
-rrule: 
+rrule:
   - DTSTART;TZID=America/New_York:20220405T130000
-# second thursday of every month
-  - RRULE:UNTIL=20240101T080000;FREQ=MONTHLY;BYDAY=+2ND
+  - RRULE:FREQ=MONTHLY;INTERVAL=1;WKST=MO;BYDAY=+1TU
   - RDATE;TZID=America/New_York:20220405T130000
+
 ---
 
 Do you help researchers compute with data?  The Data-Facing Track of the CaRCC People Network brings together people from research computing groups, libraries, research institutes, and other organizations who support data-enabled research.  

--- a/_events/repeated/carcc-data.md
+++ b/_events/repeated/carcc-data.md
@@ -18,6 +18,8 @@ rrule:
 
 ---
 
+*Reoccurring monthly: First Tuesday of the month, 1pm ET*
+
 Do you help researchers compute with data?  The Data-Facing Track of the CaRCC People Network brings together people from research computing groups, libraries, research institutes, and other organizations who support data-enabled research.  
 
 Topics include:

--- a/_events/repeated/carcc-data.md
+++ b/_events/repeated/carcc-data.md
@@ -1,0 +1,39 @@
+---
+title: CaRCC People Network Data-Facing Calls
+subtitle:
+location: Online
+url: https://carcc.org/people-network/data-facing-track/
+expires: 2024-01-01
+event_date: "Reoccurring monthly: First Tuesday of the month, 1pm ET"
+layout: event
+category: community-learning
+time:
+  - - start: 2022-04-05 13:00 EDT
+
+# Repeated events information
+repeated: true
+
+# use an rdate string instead (best for complex repeated events)
+# note that the dtstart and rdate at the end are the same
+rrule: 
+  - DTSTART;TZID=America/New_York:20220405T130000
+# second thursday of every month
+  - RRULE:UNTIL=20240101T080000;FREQ=MONTHLY;BYDAY=+2ND
+  - RDATE;TZID=America/New_York:20220405T130000
+---
+
+Do you help researchers compute with data?  The Data-Facing Track of the CaRCC People Network brings together people from research computing groups, libraries, research institutes, and other organizations who support data-enabled research.  
+
+Topics include:
+
+* Data science support
+* Bioinformatics, statistics, GIS, and other support
+* Data visualization
+* Data management and curation
+* Data workflows
+* Data transfer and networks
+* Data collection and production
+* Working with big data
+* And more, as determined by our members!
+
+See the [Track page](https://carcc.org/people-network/data-facing-track/) for upcoming call topics and connection instructions.

--- a/_events/repeated/carcc-researcher.md
+++ b/_events/repeated/carcc-researcher.md
@@ -21,6 +21,8 @@ rrule:
   - RDATE;TZID=America/New_York:20220414T130000
 ---
 
+*Reoccurring monthly: Second Thursday of the month, 1pm ET*
+
 Do you help researchers using IT tools to further their research goals?  Are you involved in research computing and/or data science training?  Do you consult with researchers on more effectively doing their research with advanced computing resources? Compute with data?
 
 The Researcher-Facing Track of the [CaRCC People Network](https://carcc.org/people-network/) brings together people from research computing groups, libraries, research institutes, and other organizations who support researchers in every phase of the research lifecycle. 

--- a/_events/repeated/carcc-researcher.md
+++ b/_events/repeated/carcc-researcher.md
@@ -1,0 +1,39 @@
+---
+title: CaRCC People Network Researcher-Facing Calls
+subtitle:
+location: Online
+url: https://carcc.org/people-network/researcher-facing-track/
+expires: 2024-01-01
+event_date: "Reoccurring monthly: Second Thursday of the month, 1pm ET"
+layout: event
+category: community-learning
+time:
+  - - start: 2022-04-14 13:00 EDT
+
+# Repeated events information
+repeated: true
+
+# use an rdate string instead (best for complex repeated events)
+# note that the dtstart and rdate at the end are the same
+rrule: 
+  - DTSTART;TZID=America/New_York:20220414T130000
+# second thursday of every month
+  - RRULE:UNTIL=20240101T080000;FREQ=MONTHLY;BYDAY=+2ND
+  - RDATE;TZID=America/New_York:20220414T130000
+---
+
+Do you help researchers using IT tools to further their research goals?  Are you involved in research computing and/or data science training?  Do you consult with researchers on more effectively doing their research with advanced computing resources? Compute with data?
+
+The Researcher-Facing Track of the [CaRCC People Network](https://carcc.org/people-network/) brings together people from research computing groups, libraries, research institutes, and other organizations who support researchers in every phase of the research lifecycle. 
+
+Topics include:
+
+* Research computing facilitation
+* Outreach to all disciplines, esp. those under-represented, to aid with research computing resources
+* Education and training
+* The art and practice of facilitation
+* Increasing communications, collaborations, and team-building
+* Research computing UX and user-facing tech
+* And more, as determined by our members!
+
+See the [Track page](https://carcc.org/people-network/researcher-facing-track/) for upcoming call topics and connection instructions.

--- a/_events/repeated/carcc-researcher.md
+++ b/_events/repeated/carcc-researcher.md
@@ -17,8 +17,7 @@ repeated: true
 # note that the dtstart and rdate at the end are the same
 rrule: 
   - DTSTART;TZID=America/New_York:20220414T130000
-# second thursday of every month
-  - RRULE:UNTIL=20240101T080000;FREQ=MONTHLY;BYDAY=+2ND
+  - RRULE:FREQ=MONTHLY;INTERVAL=1;WKST=MO;BYDAY=+2TH
   - RDATE;TZID=America/New_York:20220414T130000
 ---
 

--- a/_events/repeated/carcc-systems.md
+++ b/_events/repeated/carcc-systems.md
@@ -1,0 +1,37 @@
+---
+title: CaRCC People Network Systems-Facing Calls
+subtitle:
+location: Online
+url: https://carcc.org/people-network/systems-facing-track/
+expires: 2024-01-01
+event_date: "Reoccurring monthly: Third Thursday of the month, 1pm ET"
+layout: event
+category: community-learning
+time:
+  - - start: 2022-04-21 13:00 EDT
+
+# Repeated events information
+repeated: true
+
+# use an rdate string instead (best for complex repeated events)
+# note that the dtstart and rdate at the end are the same
+rrule: 
+  - DTSTART;TZID=America/New_York:20220421T130000
+# second thursday of every month
+  - RRULE:UNTIL=20240101T080000;FREQ=MONTHLY;BYDAY=+2ND
+  - RDATE;TZID=America/New_York:20220421T130000
+---
+
+The Systems-Facing track of the CaRCC People Network will focus on aspects relevant to the execution of research computing and data systems.
+
+Topics include:
+
+* Architecture (hardware solutions, cloud integration, VMs, container integration, …)
+* Storage systems (file systems, SAN, NAS, NVMe, Burstbuffer, …)
+* Networking (data transfer solutions, Infiniband, campus-wide, …)
+* Cluster management and configuration (scheduling, accounting and reporting, …)
+* Accelerators (GPU, FPGA, …)
+* Security (auditing, compliance, policies, procedures, …)
+* User environment (Modules, CUDA, …)
+
+See the [Track page](https://carcc.org/people-network/systems-facing-track/) for upcoming call topics and connection instructions.

--- a/_events/repeated/carcc-systems.md
+++ b/_events/repeated/carcc-systems.md
@@ -17,8 +17,7 @@ repeated: true
 # note that the dtstart and rdate at the end are the same
 rrule: 
   - DTSTART;TZID=America/New_York:20220421T130000
-# second thursday of every month
-  - RRULE:UNTIL=20240101T080000;FREQ=MONTHLY;BYDAY=+2ND
+  - RRULE:FREQ=MONTHLY;INTERVAL=1;WKST=MO;BYDAY=+3TH
   - RDATE;TZID=America/New_York:20220421T130000
 ---
 

--- a/_events/repeated/carcc-systems.md
+++ b/_events/repeated/carcc-systems.md
@@ -21,6 +21,8 @@ rrule:
   - RDATE;TZID=America/New_York:20220421T130000
 ---
 
+*Reoccurring monthly: Third Thursday of the month, 1pm ET*
+
 The Systems-Facing track of the CaRCC People Network will focus on aspects relevant to the execution of research computing and data systems.
 
 Topics include:


### PR DESCRIPTION
Repeating CaRCC call events -- they list our community calls, so we're listing their potentially relevant calls.

Previewed locally, but the calendar doesn't work locally, so I'm not sure if the repeating events are correct.  But I copied details from another repeating event, so hopefully OK.