### PR TITLE
process RSE related job postings from a separate file

### DIFF
--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -42,14 +42,14 @@ jobs:
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@users.noreply.github.com"
 
-        git add _data/jobs.yml
+        git add _data/jobs.yml _data/related-jobs.yml
 
         set +e
         git status | grep modified
         if [ $? -eq 0 ]; then
             set -e
             printf "Changes\n"
-            git commit -m "Automated push to update jobs.yml $(date '+%Y-%m-%d')" || exit 0
+            git commit -m "Automated push to update jobs files $(date '+%Y-%m-%d')" || exit 0
             git push origin main
         else
             set -e

--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ lookup (we use geolocation of a named location) please [open an issue](https://g
 
 ### 2. How do I add a job?
 
-We maintain a list of current and previous job postings in [_data/jobs.yml](_data/jobs.yml).
-You can add a new job to this list, and so that newer jobs appear at the top, we ask
-that you **add the new entry to the top of the list.**
+We maintain a list of current and previous job
+postings in [_data/jobs.yml](_data/jobs.yml) and
+[_data/related-jobs.yml](_data/related-jobs.yml).  If a job posting
+is not clearly an RSE role but is sufficiently adjacent to RSE that
+some RSEs would be qualified and potentially interested, place it in
+[_data/related-jobs.yml](_data/related-jobs.yml).
+You can add a new job to these lists, and so that newer jobs appear at the
+top of the corresponding section, we ask that you **add the new entry
+to the top of the list.**
 Specifically, we ask that you provide a name, location (can be Remote), an expiration date, and a url to the posting.
 The expiration date is not shown on the page, however it will determine when the job doesn't appear 
 anymore. We suggest setting a timeframe such as a month, and if you want to extend it, you
@@ -41,13 +47,14 @@ job would appear on the site until the first of July, 2019.
   url: 'https://main-princeton.icims.com/jobs'
 ```
 
-And don't forget to write your new job at the top of the [_data/jobs.yml](_data/jobs.yml) file!
+And don't forget to write your new job at the top of the appropriate file!
 For testing, we look to see that all fields are defined, the url exists, and
 that the "expires" and "posted" fields load as a `datetime.date` object in
 Python. If you copy the format above, you should be ok.
 
 Once your job(s) are merged to `main` a [GitHub Action](.github/workflows/jobs-slack-poster.yml) will automatically
 cross-post your job(s) to the USRSE Slack `#jobs` channel!
+*NOTE:* jobs added in the "Related" section are not posted to Slack or Twitter.
 
 ![example post image](https://raw.githubusercontent.com/rseng/jobs-updater/main/img/example.png)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For testing, we look to see that all fields are defined, the url exists, and
 that the "expires" and "posted" fields load as a `datetime.date` object in
 Python. If you copy the format above, you should be ok.
 
-Once your job(s) are merged to `main` a [GitHub Action](.github/workflows/jobs-slack-poster.yml) will automatically
+Once your job(s) are merged to `main` a [GitHub Action](.github/workflows/jobs-poster.yml) will automatically
 cross-post your job(s) to the USRSE Slack `#jobs` channel!
 *NOTE:* jobs added in the "Related" section are not posted to Slack or Twitter.
 

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ the USRSE Slack `#jobs` channel. It utilizes the [Jobs updater](https://github.c
 Github Action by @vsoch and @jhkennedy to parse the `_data/jobs.yml` file for new jobs and post them
 the USRSE Slack. For the action:
 
- - unique: determines the field in the jobs.yaml that determines uniqueness (defaults to url)
+ - unique: determines the field in the jobs.yml that determines uniqueness (defaults to url)
  - keys: a comma separated list of fields to include. All except for url will have a prefix, so it's recommended to put the url last.
 
 The other fields are intuitive. Example output (in the console that might go to Slack or Twitter)

--- a/_data/related-jobs.yml
+++ b/_data/related-jobs.yml
@@ -1,0 +1,5 @@
+- expires: 2022-03-09
+  location: Baltimore, MD
+  name: Staff Scientist/Facility Head
+  posted: 2022-03-01
+  url: https://hr.nih.gov/jobs/search/scientific/job-54901

--- a/_includes/joblist.html
+++ b/_includes/joblist.html
@@ -1,12 +1,26 @@
-<ol>{% for job in sorted_jobs %}
-{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
-{% capture expires %}{{ job.expires | date: '%s'}}{% endcapture %}
-{% capture posted %}{{ job.posted | date: '%b %d, %Y'}}{% endcapture %}
+{% capture jobs_data %}
+  {% for job in sorted_jobs %}
+  {% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
+  {% capture expires %}{{ job.expires | date: '%s'}}{% endcapture %}
+  {% capture posted %}{{ job.posted | date: '%b %d, %Y'}}{% endcapture %}
 
-{% if expires > nowunix %}
-  {% if posted != '' %}
-    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}&emsp;<em>Posted:&nbsp;{{ posted }}</em></li>
-  {% else %}
-    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
-  {% endif %}
-{% endif %}{% endfor %}</ol>
+  {% if expires > nowunix %}
+    {% if posted != '' %}
+      <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}&emsp;<em>Posted:&nbsp;{{ posted }}</em></li>
+    {% else %}
+      <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
+    {% endif %}
+  {% endif %}{% endfor %}
+{% endcapture %}
+
+{% comment %}
+This accounts for the way whitespace appears in
+jobs_data when the there are no unexpired entries.
+It looks awkward but I'm not aware of a cleaner way to handle it.
+{% endcomment %}
+{% assign n = jobs_data | strip | size %}
+{% if n > 0 %}
+{{ include.section_heading }}
+<ol> {{ jobs_data }} </ol>
+<br>
+{% endif %}

--- a/_includes/joblist.html
+++ b/_includes/joblist.html
@@ -1,0 +1,12 @@
+<ol>{% for job in sorted_jobs %}
+{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
+{% capture expires %}{{ job.expires | date: '%s'}}{% endcapture %}
+{% capture posted %}{{ job.posted | date: '%b %d, %Y'}}{% endcapture %}
+
+{% if expires > nowunix %}
+  {% if posted != '' %}
+    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}&emsp;<em>Posted:&nbsp;{{ posted }}</em></li>
+  {% else %}
+    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
+  {% endif %}
+{% endif %}{% endfor %}</ol>

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -24,10 +24,7 @@ permalink: /jobs/
 
 {% assign board_size = site.data.related-jobs | size %}
 {% if board_size > 0 %}
-### RSE Related Jobs
-
-The following jobs are not strongly RSE roles but are likely to be
-"RSE-adjacent" - working closely with RSEs.
+### Related Openings
 
 {% assign sorted_jobs = site.data.related-jobs | sort: "posted" | reverse %}
 <ol>{% for job in sorted_jobs %}

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -26,7 +26,8 @@ permalink: /jobs/
 {% if board_size > 0 %}
 ### RSE Related Jobs
 
-The following are RSE-adjacent jobs
+The following jobs are not strongly RSE roles but are likely to be
+"RSE-adjacent" - working closely with RSEs.
 
 {% assign sorted_jobs = site.data.related-jobs | sort: "posted" | reverse %}
 <ol>{% for job in sorted_jobs %}

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -7,18 +7,7 @@ permalink: /jobs/
 ## Current RSE openings
 
 {% assign sorted_jobs = site.data.jobs | sort: "posted" | reverse %}
-<ol>{% for job in sorted_jobs %}
-{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
-{% capture expires %}{{ job.expires | date: '%s'}}{% endcapture %}
-{% capture posted %}{{ job.posted | date: '%b %d, %Y'}}{% endcapture %}
-
-{% if expires > nowunix %}
-  {% if posted != '' %}
-    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}&emsp;<em>Posted:&nbsp;{{ posted }}</em></li>
-  {% else %}
-    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
-  {% endif %}
-{% endif %}{% endfor %}</ol>
+{% include joblist.html %}
 
 <br>
 
@@ -27,18 +16,7 @@ permalink: /jobs/
 ### Related Openings
 
 {% assign sorted_jobs = site.data.related-jobs | sort: "posted" | reverse %}
-<ol>{% for job in sorted_jobs %}
-{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
-{% capture expires %}{{ job.expires | date: '%s'}}{% endcapture %}
-{% capture posted %}{{ job.posted | date: '%b %d, %Y'}}{% endcapture %}
-
-{% if expires > nowunix %}
-  {% if posted != '' %}
-    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}&emsp;<em>Posted:&nbsp;{{ posted }}</em></li>
-  {% else %}
-    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
-  {% endif %}
-{% endif %}{% endfor %}</ol>
+{% include joblist.html %}
 
 <br>
 {% endif %}

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -4,22 +4,11 @@ title: RSE Opportunities
 permalink: /jobs/
 ---
 
-## Current RSE openings
-
 {% assign sorted_jobs = site.data.jobs | sort: "posted" | reverse %}
-{% include joblist.html %}
-
-<br>
-
-{% assign board_size = site.data.related-jobs | size %}
-{% if board_size > 0 %}
-### Related Openings
+{% include joblist.html section_heading="## Current RSE openings" %}
 
 {% assign sorted_jobs = site.data.related-jobs | sort: "posted" | reverse %}
-{% include joblist.html %}
-
-<br>
-{% endif %}
+{% include joblist.html section_heading="### Related Openings" %}
 
 {% assign board_size = site.data.job-boards.boards | size %}
 {% if board_size > 0 %}
@@ -30,10 +19,10 @@ The following boards might also be of interest.
 
 <ol>{% for board in site.data.job-boards.boards %}
     <li><a href="{{ board.url }}" target="_blank">{{ board.name }}</a></li>
-{% endfor %}</ol>
+    {% endfor %}</ol>
 <br>
 {% endif %}
 
 
-### Have an RSE-related job posting?  
-Please read our [job posting policy]({{ site.baseurl }}/jobs/policy/) first, then fill out this [google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the job board.
+### Have an RSE-related job posting?
+Please read our [job posting policy]({{ site.baseurl }}/jobs/policy/) first, then fill out this [Google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the job board.

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -43,6 +43,7 @@ The following are RSE-adjacent jobs
 {% endif %}{% endfor %}</ol>
 
 <br>
+{% endif %}
 
 {% assign board_size = site.data.job-boards.boards | size %}
 {% if board_size > 0 %}

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -22,8 +22,31 @@ permalink: /jobs/
 
 <br>
 
+{% assign board_size = site.data.related-jobs | size %}
+{% if board_size > 0 %}
+### RSE Related Jobs
+
+The following are RSE-adjacent jobs
+
+{% assign sorted_jobs = site.data.related-jobs | sort: "posted" | reverse %}
+<ol>{% for job in sorted_jobs %}
+{% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}
+{% capture expires %}{{ job.expires | date: '%s'}}{% endcapture %}
+{% capture posted %}{{ job.posted | date: '%b %d, %Y'}}{% endcapture %}
+
+{% if expires > nowunix %}
+  {% if posted != '' %}
+    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}&emsp;<em>Posted:&nbsp;{{ posted }}</em></li>
+  {% else %}
+    <li><a href="{{ job.url }}" target="_blank">{{ job.name }}</a>: {{ job.location }}</li>
+  {% endif %}
+{% endif %}{% endfor %}</ol>
+
+<br>
+
 {% assign board_size = site.data.job-boards.boards | size %}
 {% if board_size > 0 %}
+
 ### Other Job Boards
 
 The following boards might also be of interest.

--- a/scripts/clean_jobs.py
+++ b/scripts/clean_jobs.py
@@ -52,7 +52,10 @@ def clean_jobs(file):
         if job["expires"] < now:
             removal_date = job["expires"] + timedelta(days=60)
             if removal_date < now:
-                print("Skipping %s, expired and hasn't been updated in 60 days." % job["name"])
+                print(
+                    "Skipping %s, expired and hasn't been updated in 60 days."
+                    % job["name"]
+                )
                 continue
 
         # We don't check urls that are not expired, the urlchecker action should

--- a/scripts/count_jobs.py
+++ b/scripts/count_jobs.py
@@ -50,13 +50,13 @@ def checkout(commit):
         sys.exit(result.stderr.decode("utf-8"))
 
 
-def clone_repo(git_path, branch="master", dest=None):
+def clone_repo(git_path, branch="main", dest=None):
     """
     Clone and name a git repository.
 
     Args:
         - git_path (str) : https path to git repository.
-        - branch   (str) : name of the branch to use. Default="master"
+        - branch   (str) : name of the branch to use. Default="main"
         - dest     (str) : fullpath to clone repository to. Defaults to tmp.
 
     Returns:

--- a/scripts/count_jobs.py
+++ b/scripts/count_jobs.py
@@ -3,7 +3,6 @@
 #   - finding all git changes for the _data/jobs.yml file
 #   - checkout out each commit and creating a global record of all jobs
 #   - printing to the screen
-
 # Copyright @vsoch, 2020
 
 import os
@@ -90,9 +89,8 @@ def delete_repo(base_path):
         - base_path (str) : base path of the cloned git repository.
 
     Returns:
-        (str) message/ code describing whether the operation was successfully excuted.
+        (str) message/ code describing whether the operation was successfully executed.
     """
-    # clone repo
     result = subprocess.run(
         ["rm", "-R", "-f", base_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )

--- a/scripts/count_jobs.py
+++ b/scripts/count_jobs.py
@@ -162,7 +162,7 @@ def main():
     # Change directory to the repo to get list of commits
     os.chdir(repo)
 
-    jobs = [count_jobs("_data/jobs.yml"), count_jobs("_data/related-jobs.yml")]
+    jobs = [*count_jobs("_data/jobs.yml"), *count_jobs("_data/related-jobs.yml")]
 
     # If user provided an output file:
     if outfile and jobs:

--- a/scripts/count_jobs.py
+++ b/scripts/count_jobs.py
@@ -6,14 +6,11 @@
 # Copyright @vsoch, 2020
 
 import os
-import json
 import yaml
 import subprocess
 import shlex
-import shutil
 import sys
 import tempfile
-from time import sleep
 
 here = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
## Description
This PR implements the handling of RSE-related jobs in the main `/jobs` page via the inclusion of a separate file.

## Motivation and Context
We have received a number of submissions for the jobs page which are either related to or adjacent to RSEs.  They might be interesting to some readers of the page but are not RSE roles in their own right.  Rather than rejecting these submissions, we'd like to include them on the page but not announce them through Twitter or the Slack Jobs Bot.

This is an alternative solution to #675 in that it uses a separate file rather than a tag on job entries.  The consensus in several discussions amongst #job-post-team members is that this approach should be easier to manage in the long run.

## Checklist:
- [X] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [X] I have previewed changes locally
- [X] I have updated the README.md if necessary

cc @usrse-maintainers
