### PR TITLE
Add May 2022 Newsletter

### DIFF
--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -50,6 +50,7 @@ Thanks to a generous grant from the Alfred P. Sloan Foundation, we held our firs
 **NEW TIME**
 
 **NEW TIME**
+
 **NEW TIME**
 
 The USRSE monthly community calls are experimenting with a new time to try and better accommodate Alaska and Hawaii time zones. The calls are moving to the second Friday of each month. 14:00-15:00 Eastern starting June 2022. Community call topics, and agenda and zoom registration announcements are posted to Slack and sent to USRSE email lists.

--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -48,6 +48,7 @@ Thanks to a generous grant from the Alfred P. Sloan Foundation, we held our firs
 # **US-RSE Community Calls - NOTE NEW TIME**
 
 **NEW TIME**
+
 **NEW TIME**
 **NEW TIME**
 

--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -62,6 +62,7 @@ Community calls typically have a topical focus. They provide a forum for USRSE m
 Interested in suggesting a topic or leading a community call?  We meet two weeks prior to each community call to decide on a topic and discuss how to structure the call. Anyone is welcome to join the preparation call on [Zoom](https://mit.zoom.us/j/93471607274?pwd=aXUzNzZsWElpWnc4N2NXaWxOcVNlQT09).
 
 **NEW TIME**
+
 **NEW TIME**
 **NEW TIME**
 

--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -1,0 +1,203 @@
+---
+layout: post
+title: US-RSE May 2022 Newsletter
+subtitle: May 2022
+category: newsletter
+tags: [newsletter, survey, supercomputing, scipy]
+---
+
+In this monthly newsletter, we share recent, current, and planned activities of the US-RSE Association, and related news that we think is of interest to US-RSE members. Newsletters are also available on our [website](https://us-rse.org/newsletters/) alongside the growing resources and information on the US-RSE Association. To receive our newsletter, join US-RSE [here](https://us-rse.org/join/).
+
+In this issue:
+
+* [US-RSE Virtual Workshop 2022](#virtual-workshop)
+* [US-RSE First Community Workshop](#community-workshop)
+* [US-RSE Community Calls - note new time](#community-calls)
+* [ADSA/US-RSE Career Support Workshop](#career-workshop)
+* [US-RSE at PEARC22](#pearc)
+* [Community News](#news)
+* [RSE Stories Podcast](#podcast)
+* [DEI Working Group](#dei-wg)
+* [Interesting Events](#events)
+* [Interesting Reads or Podcasts](#reads)
+* [US-RSE Education and Training working group](#education)
+* [US-RSE Outreach](#outreach)
+* [US-RSE New Groups](#newusrse)
+* [US-RSE Financials](#financials)
+* [Get Involved](#involved)
+* [Recent Job Postings](#jobs)
+
+<a name="virtual-workshop"></a>
+# **US-RSE Virtual Workshop 2022**
+Following the success of the 2021 US-RSE Virtual Workshop, we decided to host another virtual event this year. The 2022 US-RSE Virtual Workshop will be held on two non-consecutive half days: September 14 and 16, 2022, 1-4pm ET/12-3pm CT/10am-1pm PT.
+
+The theme of the workshop is “**Make it happen! Towards a diverse and sustainable future!**” The workshop will feature talks, and breakout group sessions. It will be held via Zoom and some parts, such as the talks, will be recorded and available after the workshop via the US-RSE YouTube channel. The workshop will be free but registration will be required.
+
+Submission and application as reviewer deadline is July 17!
+
+All information related to the workshop can be found on the [workshop website](https://us-rse.org/virtual-workshop-2022/).
+
+
+<a name="community-workshop"></a>
+# **US-RSE First Community Workshop**
+
+Thanks to a generous grant from the Alfred P. Sloan Foundation, we held our first in-person US-RSE Association [Community Building Workshop](https://us-rse.org/first-community-workshop/), in Princeton, NJ on April 26-27, 2022. 50 attendees gathered to discuss and plan the best path forward to grow the US-RSE Association and develop the US RSE community. The workshop was a huge success! Mutiple groups formed to work on producing outputs around topics ranging from Career Paths and Professional Development, Regional US-RSE Groups, Hiring RSEs, and much more. Read more about the specific topics and intended outputs in the [summary on the workshop website](https://us-rse.org/first-community-workshop/2022-05-13-workshop-summary/). Discussion are continuing on slack and there are plenty of opportunities to join in the converstation.
+
+
+<a name="community-calls"></a>
+# **US-RSE Community Calls - NOTE NEW TIME**
+
+**NEW TIME**
+**NEW TIME**
+**NEW TIME**
+
+The USRSE monthly community calls are experimenting with a new time to try and better accomodate Alaska and Hawaii time zones. The calls are moving to the second Friday of each month. 14:00-15:00 Eastern starting June 2022. Community call topics, and agenda and zoom registration announcements are posted to Slack and sent to USRSE email lists.
+
+The June 2022 (**on Friday June 9th, 14:00-15:00 US Eastern time**) call will focus on starting a whitepaper on the State of RSE in the US. The call will kickoff with a quick review of some of the recent community calls that touched on this topic. In breakout groups we will try and experiment with outlining a set of key sub-topics and the structure for a whitepaper. Look forward to seeing those of you who can make on the **Friday!!**.
+
+Community calls typically have a topical focus. They provide a forum for USRSE members to compare experiences around a topic, hang-out and chat on zoom. You can find the recordings of our monthly calls [here](https://www.youtube.com/playlist?app=desktop&list=PLMgG8jy8w-8neP6gPOgifH6kh4t_RUTTH).
+
+Interested in suggesting a topic or leading a community call?  We meet two weeks prior to each community call to decide on a topic and discuss how to structure the call. Anyone is welcome to join the preparation call on [Zoom](https://mit.zoom.us/j/93471607274?pwd=aXUzNzZsWElpWnc4N2NXaWxOcVNlQT09).
+
+**NEW TIME**
+**NEW TIME**
+**NEW TIME**
+
+<a name="career-workshop"></a>
+# **Data Scientist/RSE Academic Career Support Workshop**
+
+The Academic Data Science Alliance (ADSA) and US-RSE are hosting an in-person 2-day [workshop](https://academicdatascience.org/adsa-meetings/2022-fall-workshop) on October 24-25, 2022 in Chicago focused on elucidating best practices for recruitment, career development, and retention of staff data scientists and research software engineers in academic settings. The primary outcome of this workshop will be a guide book that addresses how data scientists, research software engineers, hiring managers, and administrators can successfully create rewarding career paths for these new types of positions.  Participants will be expected to actively engage in content creation throughout the workshop and participate in writing, review, and editing of the end product(s) after the workshop has concluded.  If you are interested in participating in this workshop, please use [this form](https://form.jotform.com/221427005930042) to tell us a little about yourself and your interest and expertise in this area. Applications should be submitted by June 15, 2022.
+
+<a name="pearc"></a>
+# **US-RSE at PEARC22**
+
+If you'll be attending [PEARC22](https://pearc.acm.org/pearc22/), US-RSE members and friends will be hosting a panel titled *Building Enduring Cyberinfrastructures - The Role of Professional Research Software Engineers*. The panel will feature speakers from several software centric cyberinfrastructure initiatives and will be a participatory forum for a discussion on topics around how to sustain and grow such efforts. The date and time of the panel has not been announced by the PEARC organizers yet. If the panel fits in your schedule we would love to see you there and will have US-RSE stickers for everyone!!
+
+<a name="news"></a>
+# **Community News**
+
+* A [survey of the state of the practice for research software in the United States](https://doi.org/10.7717/peerj-cs.963) presents findings from a survey of 1,149 researchers, primarily from the United States, about sustainability challenges they face in developing and using research software.
+* The [FAIR4RS Working Group](https://www.rd-alliance.org/groups/fair-4-research-software-fair4rs-wg) has released a [survey on the FAIR4RS adoption guidelines](https://doi.org/10.5281/zenodo.6374598) already available, which lists more than 30 guidelines/tools. This will assist in implementation of [version 1.0 of the FAIR Principles for Research Software (FAIR4RS Principles)](https://doi.org/10.15497/RDA00068). Another [FAIR4RS report](https://doi.org/10.5281/zenodo.6258366) provides examples of adoption of the FAIR4RS Principles by a range of organisations.
+
+
+<a name="podcast"></a>
+# **RSE Stories Podcast**
+
+The [Research Software Engineer Stories podcast](http://us-rse.org/rse-stories/) has four new episodes posted. Check them out below!
+
+RSE Stories is looking for a new co-host and other volunteers to help with production. You don’t need to commit to anything: start with one episode and go from there. Interested? Reach out to Vanessa via Slack.
+
+* Daniel Sabanes Bove: [Statistical Engineering](https://us-rse.org/rse-stories/2022/daniel-sabanes-bove/)
+* Jay Lofstead: [SC22 Mini-series: Inclusivity Committee](https://us-rse.org/rse-stories/2022/jay-lofstead/)
+* Megan Phinney: [The Really Cool Pen](https://us-rse.org/rse-stories/2022/megan-phinney/)
+* Rowland Mosbergen: [The Master Connector](https://us-rse.org/rse-stories/2022/rowland-mosbergen/)
+
+
+<a name="dei-mc"></a>
+# **DEI Working Group**
+
+The first [RSE Stories Podcast](https://us-rse.org/rse-stories/) [SC22 mini-series podcast](https://us-rse.org/rse-stories/2022/jay-lofstead/) episode has been published! In it, our very own Miranda Mundt interviews Jay Lofstead about [SC22's Inclusivity Committee](https://sc22.supercomputing.org/attend/inclusivity/)!
+
+Want to know more or get involved with the DEI working group? Visit our [webpage](https://us-rse.org/wg/dei/) for more details!
+
+<a name="events"></a>
+# **Interesting Events**
+
+Some other events coming up may be of interest to RSEs:
+* The [Sixth Annual Conference for Research Software Engineering](https://rsecon2022.society-rse.org/) in the UK will take place September 6-8 in Newcastle. Community awards are still open for submission!
+* [Gateways 2022](https://sciencegateways.org/gateways2022) will take place October 18-20, 2022 in San Diego, CA with tutorials online in the two weeks before. Deadline for submissions is extended to June 20, 2022.
+* [HICSS 56](https://hicss.hawaii.edu/) will take place January 3-6, 2023 in Maui, HI. Its deadline is coming up on June 15, 2022. Among others, the [Software Technology Track](https://hicss.hawaii.edu/tracks-56/software-technology/) offers interesting minitracks such as [Software Sustainability - Strategies for Long-lasting and Usable Software](https://hicss.hawaii.edu/tracks-56/software-technology/#software-sustainability-strategies-for-long-lasting-and-usable-software-minitrack) and [Smart (City) and Data Streaming Application Development](https://hicss.hawaii.edu/tracks-56/software-technology/#smart-city-and-data-streaming-application-development-challenges-and-experiences-minitrack).
+* The [Collegeville Workshop on Scientific Software: Software Design](https://bssw.io/events/2022-collegeville-workshop-on-scientific-software-software-design) will take place July 26-28, 2022 at St. John's University and online. Deadlines for different submissions are from June 24, 2022.
+* The IDEAS Productivity project, in partnership with the DOE Computing Facilities of the ALCF, OLCF, and NERSC, and the DOE Exascale Computing Project (ECP), organizes the webinar series on Best Practices for HPC Software Developers. The next webinar, [Normalizing Inclusion by Embracing Difference](https://www.exascaleproject.org/event/embracingdifference/), will take place June 15, 1-2:30pm ET.
+
+
+<a name="reads"></a>
+# **Interesting Reads or Podcasts**
+
+Items you may have missed on the blog and Slack:
+
+* An interview with Paul Richmond, former president of the [Society of RSE](https://society-rse.org), was published in Nature, entitled "[Why science needs more research software engineers](https://doi.org/10.1038/d41586-022-01516-2)"
+* [ACM ByteCast Episode 25 with Margo Seltzer](https://acmbytecast.podbean.com/e/episode-25-margo-seltzer/)
+* Chase Million: [A practical guide to research software project estimation](https://github.com/MillionConcepts/software_project_management)
+
+
+<a name="education"></a>
+# **US-RSE Education and Training Working Group**
+The Education and Training Working Group is in the process of organizing a Speaker and Tutorial series for the US-RSE Community. These will include technical talks and the occasional tutorial on Software Engineering topics, tools, and best practices. Keep an eye out for an announcement of our first talk! If you have any input, know someone with a good tutorial or talk, or would like to be involved in organizing these events, you can reach out to the Education and Training Working Group through the #education-training channel on the USRSE Slack.
+
+<a name="outreach"></a>
+# **US-RSE Outreach**
+
+Upcoming Outreach opportunities with US-RSE:
+
+* We plan to submit a proposal for a [Birds of a Feather session at SciPy 2022](https://www.scipy2022.scipy.org/bof-sessions) about US-RSE. It will be a moderated panel discussion. If you are interested in representing US-RSE on the panel, please fill out [this form](https://forms.gle/Mx4qW1zH518Ev2Cm6). Note that the SciPy organizing committee has added options to participate virtually, so please consider joining and adding your voice to the BoF even if you are not attending the conference in person!
+* The [Research Software Engineers in eScience workshop](https://us-rse.org/rse-escience-2022/) will take place as part of eScience 2022, Salt Lake City, Utah, October 11-14, 2022. This workshop will present RSE contributions to scientific research through a series of talks that explore scientific project needs, how access to RSEs made the project successful, and how this work can be applied to future scientific research efforts. The workshop will be of interest to existing RSEs, potential RSEs, domain scientists, and software developers who want to understand the lessons from both good and bad research software engineering experiences.
+Submissions of abstracts and short papers (not part of the proceedings) are open until July 11!
+
+
+<a name="newusrse"></a>
+# **New groups**
+
+The new financial sustainability working group is moving forward. The goal of this group will be to examine and develop a range of ideas to move US-RSE to a stable financial model. Please feel free to reach out to Chris Hill if you are interested in participating in this working group. The group will meet at least monthly and will look at everything from sponsorship, individual and institutional membership models, more logo items, philanthropic partners and beyond!
+
+A draft write-up of financial sustainability discussions from the Princeton community building workshop is [here](https://docs.google.com/document/d/16JtwhNIX4gKc1qDmcgD7qdOqYE2MUwRANtdAsXUfsFQ). The discussions span everything from membership fees and sponsors to plans for logo items. If you have thoughts on these or other financial sustainability topics please feel free to join in discussions in the working group slack channel [#wg-financial-sustainability](https://usrse.slack.com/archives/C03BBT8FXFY).
+
+The working group on regional and local RSE groups starts to reach out to different regional groups and is working on creating a document with plans and tips. If you are interested, have a look at the regional channels and the [Slack post](https://usrse.slack.com/archives/C8ZB01CGH/p1652658941234569) whether we overlooked a regional group or whether there is interest to join or create a new one.
+
+<a name="financials"></a>
+# **See how we are doing financially**
+
+We organize US-RSE financials transparently via the [Open Collective](https://opencollective.com/usrse) project. You can see all budgets, expenses, and contributions on [this site](https://opencollective.com/usrse). Anyone can go to the site and see the current accounts, income and expenses and ….. (if the mood takes you and you are able) **[make a tax-deductible gift to US-RSE](https://opencollective.com/usrse#category-CONTRIBUTE)**!
+
+<a name="involved"></a>
+# **Get Involved**
+
+There are lots of ways to get involved with the US-RSE community. Of course, you can [join us on Slack](https://us-rse.org/join) or volunteer for an interview with the RSE Stories podcast. But we’re also looking for ideas and help in many other places. See our [list of projects](https://docs.google.com/document/d/1jjVD0WkeeWZJI6yqSKyMdIjtClzolsxv75RkpLju17I/edit?usp=sharing) and let us know how you’d like to help. Help with things like the Website Committee, Social Media, Community Engagement, Fundraising and Newsletter are all needed and welcome.
+
+As always we thank everyone who is already contributing for their help in shaping and growing the organization. In 2021 we added nearly 300 new members. There are still many more RSEs and friends of RSEs we would like to help connect and support. If you are interested in helping in any way please feel free to join in.
+
+[US-RSE Working Groups](https://us-rse.org/about/working-groups/):
+
+* [Education & Training](https://us-rse.org/wg/education_training/)
+* [Diversity, Equity, and Inclusion](https://us-rse.org/wg/dei/)
+* [Outreach](https://us-rse.org/wg/outreach/)
+* [Website](https://us-rse.org/wg/website/)
+
+<a name="jobs"></a>
+# **Recent Job Postings**
+
+These opportunities were recently posted to the [RSE Careers page](https://us-rse.org/jobs/):
+1.  [Postdoctoral Research Scholar - Extensible molecular analysis tools for reproducible science](http://apply.interfolio.com/107631): Arizona State University, Tempe, AZ _Posted: Jun 01, 2022_
+2.  [Scientific Software Engineer, Hit Discovery](https://grnh.se/b12d84713us): Schrödinger, New York City, NY _Posted: May 31, 2022_
+3.  [Software Engineer](https://jobs.hr.wisc.edu/en-us/job/513718/software-engineer): Center for High Throughput Computing, University of Wisconsin-Madison, Madison, WI _Posted: May 19, 2022_
+4.  [Senior Research Software Engineer](https://data.org/careers/senior-research-software-engineer/): data.org, Remote _Posted: May 16, 2022_
+5.  [Machine Learning Infrastructure Engineer](https://boards.greenhouse.io/schrdinger/jobs/5068535003): Schrödinger, New York, NY _Posted: May 10, 2022_
+6.  [Machine Learning Research Engineer](https://boards.greenhouse.io/schrdinger/jobs/4344938003): Schrödinger, New York, NY _Posted: May 10, 2022_
+7.  [Force Fields Scientist, Desmond/Materials Science Development](https://boards.greenhouse.io/schrdinger/jobs/4904081003): Schrödinger, New York City, NY _Posted: May 10, 2022_
+8.  [Senior Data Engineer](https://northeastern.wd1.myworkdayjobs.com/careers/job/Boston-MA-Main-Campus/Senior-Data-Engineer_R105388): Media Cloud/Northeastern, Boston, MA _Posted: May 04, 2022_
+9.  [Visiting Scholar for Chapel Programming Language Team](https://hpe.wd5.myworkdayjobs.com/Jobsathpe/job/Seattle-Washington-United-States-of-America/Visiting-Scholar-for-Chapel-Programming-Language-Team_1123949): Hewlett Packard Enterprise, Can be remote _Posted: Apr 28, 2022_
+10.  [Software Developer - Data Analytics](https://erp-hprdext.erp.slac.stanford.edu/psp/hprdext/EMPLOYEE/HRMS/c/HRS_HRAM_FL.HRS_CG_SEARCH_FL.GBL?Page=HRS_APP_JBPST_FL&Action=U&FOCUS=Applicant&SiteId=1&JobOpeningId=4867&PostingSeq=1): SLAC National Accelerator Laboratory, Menlo Park, CA _Posted: Apr 27, 2022_
+11.  [Software Developer - Data Management](https://erp-hprdext.erp.slac.stanford.edu/psp/hprdext/EMPLOYEE/HRMS/c/HRS_HRAM_FL.HRS_CG_SEARCH_FL.GBL?Page=HRS_APP_JBPST_FL&Action=U&FOCUS=Applicant&SiteId=1&JobOpeningId=4889&PostingSeq=1): SLAC National Accelerator Laboratory, Menlo Park, CA _Posted: Apr 27, 2022_
+12.  [Software Developer III - Data Acquisition and Analysis](https://erp-hprdext.erp.slac.stanford.edu/psp/hprdext/EMPLOYEE/HRMS/c/HRS_HRAM_FL.HRS_CG_SEARCH_FL.GBL?Page=HRS_APP_JBPST_FL&Action=U&FOCUS=Applicant&SiteId=1&JobOpeningId=4869&PostingSeq=1): SLAC National Accelerator Laboratory, Menlo Park, CA _Posted: Apr 27, 2022_
+13.  [Research Software Engineer](https://main-princeton.icims.com/jobs/14490/research-software-engineer/job): Princeton University, Princeton, NJ _Posted: Apr 08, 2022_
+14.  [Junior Specialist with Data Science Focus](https://aprecruit.ucsf.edu/JPF03809): University of California, San Francisco _Posted: Apr 07, 2022_
+15.  [HPC Applications Engineer](https://jobs.lbl.gov/jobs/4251): Lawrence Berkeley National Laboratory, Berkeley, CA _Posted: Mar 31, 2022_
+16.  [Scientific Software Engineering Center Engineering Lead](https://escience.washington.edu/uw-scientific-software-engineering-center/): University of Washington, Seattle, WA _Posted: Mar 31, 2022_
+
+### Other Job Boards
+
+The following boards might also be of interest.
+
+1.  [Software Carpentries Job Opportunities](https://carpentries.topicbox.com/groups/opportunities)
+2.  [Academic Data Science Alliance Jobs](https://academicdatascience.org/jobs)
+3.  [Society of Research Software Engineering Vacancies](https://society-rse.org/careers/vacancies/)
+
+
+
+### Have an RSE-related job posting?
+
+Please read our [job posting policy](/jobs/policy/) first, then fill out this [google form](https://docs.google.com/forms/d/e/1FAIpQLSfYK64R1c0rj-ERldGLxuqedLIbsYPZXj9uBplDRYNmnND10Q/viewform?usp=sf_link) to request additions to the job board.
+
+
+
+**This newsletter is a joint effort of members of the US-RSE Association.**

--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -64,6 +64,7 @@ Interested in suggesting a topic or leading a community call?  We meet two weeks
 **NEW TIME**
 
 **NEW TIME**
+
 **NEW TIME**
 
 <a name="career-workshop"></a>

--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -134,7 +134,7 @@ The Education and Training Working Group is in the process of organizing a Speak
 
 Upcoming Outreach opportunities with US-RSE:
 
-* We plan to submit a proposal for a [Birds of a Feather session at SciPy 2022](https://www.scipy2022.scipy.org/bof-sessions) about US-RSE. It will be a moderated panel discussion. If you are interested in representing US-RSE on the panel, please fill out [this form](https://forms.gle/Mx4qW1zH518Ev2Cm6). Note that the SciPy organizing committee has added options to participate virtually, so please consider joining and adding your voice to the BoF even if you are not attending the conference in person!
+* We submitted a proposal for a [Birds of a Feather session at SciPy 2022](https://www.scipy2022.scipy.org/bof-sessions) about US-RSE. This will be a moderated panel discussion.
 * The [Research Software Engineers in eScience workshop](https://us-rse.org/rse-escience-2022/) will take place as part of eScience 2022, Salt Lake City, Utah, October 11-14, 2022. This workshop will present RSE contributions to scientific research through a series of talks that explore scientific project needs, how access to RSEs made the project successful, and how this work can be applied to future scientific research efforts. The workshop will be of interest to existing RSEs, potential RSEs, domain scientists, and software developers who want to understand the lessons from both good and bad research software engineering experiences.
 Submissions of abstracts and short papers (not part of the proceedings) are open until July 11!
 

--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -55,7 +55,7 @@ Thanks to a generous grant from the Alfred P. Sloan Foundation, we held our firs
 
 The USRSE monthly community calls are experimenting with a new time to try and better accommodate Alaska and Hawaii time zones. The calls are moving to the second Friday of each month. 14:00-15:00 Eastern starting June 2022. Community call topics, and agenda and zoom registration announcements are posted to Slack and sent to USRSE email lists.
 
-The June 2022 (**on Friday June 9th, 14:00-15:00 US Eastern time**) call will focus on starting a whitepaper on the State of RSE in the US. The call will kickoff with a quick review of some of the recent community calls that touched on this topic. In breakout groups we will try and experiment with outlining a set of key sub-topics and the structure for a whitepaper. Look forward to seeing those of you who can make on the **Friday!!**.
+The June 2022 (**on Friday June 9th, 14:00-15:00 US Eastern time**) call will focus on starting a whitepaper on the State of RSE in the US. The call will kickoff with a quick review of some of the recent community calls that touched on this topic. In breakout groups we will try and experiment with outlining a set of key sub-topics and the structure for a whitepaper. Look forward to seeing those of you who can make on the **Friday!!**
 
 Community calls typically have a topical focus. They provide a forum for USRSE members to compare experiences around a topic, hang-out and chat on zoom. You can find the recordings of our monthly calls [here](https://www.youtube.com/playlist?app=desktop&list=PLMgG8jy8w-8neP6gPOgifH6kh4t_RUTTH).
 

--- a/_posts/newsletters/2022-06-02-newsletter.md
+++ b/_posts/newsletters/2022-06-02-newsletter.md
@@ -51,7 +51,7 @@ Thanks to a generous grant from the Alfred P. Sloan Foundation, we held our firs
 **NEW TIME**
 **NEW TIME**
 
-The USRSE monthly community calls are experimenting with a new time to try and better accomodate Alaska and Hawaii time zones. The calls are moving to the second Friday of each month. 14:00-15:00 Eastern starting June 2022. Community call topics, and agenda and zoom registration announcements are posted to Slack and sent to USRSE email lists.
+The USRSE monthly community calls are experimenting with a new time to try and better accommodate Alaska and Hawaii time zones. The calls are moving to the second Friday of each month. 14:00-15:00 Eastern starting June 2022. Community call topics, and agenda and zoom registration announcements are posted to Slack and sent to USRSE email lists.
 
 The June 2022 (**on Friday June 9th, 14:00-15:00 US Eastern time**) call will focus on starting a whitepaper on the State of RSE in the US. The call will kickoff with a quick review of some of the recent community calls that touched on this topic. In breakout groups we will try and experiment with outlining a set of key sub-topics and the structure for a whitepaper. Look forward to seeing those of you who can make on the **Friday!!**.
 


### PR DESCRIPTION
This adds the May newsletter (just a couple days late). We could adjust the post date to say May, but I think this is fine. 

As always some careful review is requested but the new method is hopefully going to cut down on markdown issues.

cc @usrse-maintainers
