### PR TITLE
put events in primary callouts on main page

### DIFF
--- a/_data/callouts/home.yml
+++ b/_data/callouts/home.yml
@@ -1,14 +1,15 @@
 style: is-light
 items:
-  - title: Events
-    subtitle: Browse our upcoming workshops, training, and other community events.
-    link: /events
+  - title: US-RSE Virtual Workshop
+    subtitle: Engage with the community on all things RSE through presentations and discussions,<br>September 14 & 16, 2022, 1-4pm ET
+    link: /virtual-workshop-2022/
+    link_name: Get the Details
+  - title: Research Software Engineers in eScience
+    subtitle: Connect with other RSEs at eScience 2022 in Salt Lake City, October 11-14
+    link: /rse-escience-2022/
     link_name: Learn More
-  - title: About
-    subtitle: Learn about US-RSE, including our community goals, Code of Conduct, and Mission Statement.
-    link: /about
+  - title: Research Software Engineers in HPC
+    subtitle: Join the discussion at this SC22 workshop in Dallas on November 13
+    link: /rse-hpc-2022/
     link_name: Learn More
-  - title: News
-    subtitle: Read our latest newsletters or catch up with the community blog.
-    link: /news
-    link_name: Learn More
+    


### PR DESCRIPTION
Putting upcoming events more prominently on the homepage