### PR TITLE
Adding Education and Training post

### DIFF
--- a/_posts/2022-08-01-education-training.md
+++ b/_posts/2022-08-01-education-training.md
@@ -31,17 +31,17 @@ The [Education and Training Working Group](https://us-rse.org/wg/education_train
 
 To address the needs of RSEs who would like to learn more about different science domains, we also discussed the possibility of adding additional “Domain Days” to the series. During these events we would invite domain scientists to talk about their domain and answer questions about what an RSE would need to know to work in that domain - such as open questions of interest, necessary math skills, or the words and phrases most commonly heard in that domain. These would either be interview or panel style events. We also had the idea that the Q&A portion of these events might make good short podcasts that could be released in the future.
 
-We also thought it could be beneficial to host a series of “Coffee Hour” talks, which would be a space for graduate students to give talks on their research and get feedback. We then decided that this activity would be outside the scope of the Education and Training working group, and might be a good fit for the Outreach working group.
+We also thought it could be beneficial to host a series of “Coffee Hour” talks, which would be a space for graduate students to give talks on their research and get feedback. We then decided that this activity would be outside the scope of the Education and Training Working Group, and might be a good fit for the Outreach Working Group.
 
 ### Planning the RSE Education and Training Tutorial and Seminar Series
 
-Building on the discussion at the workshop, the Education and Training Working Group is organizing the Tutorial and Seminar series described above. The group has worked to identify topics and speakers that are of most interest to the US-RSE community. After an initial ranking of the proposed ideas by the active members of the US-RSE working group, we solicited input from the US-RSE community. Based on this information we invited Angela Herring from Los Alamos National Lab to be the first speaker. She will give a talk on Agile Project Management for Research Software. A more formal announcement will be released with the exact date and time.
+Building on the discussion at the workshop, the Education and Training Working Group is organizing the Tutorial and Seminar series described above. The group has worked to identify topics and speakers that are of most interest to the US-RSE community. After an initial ranking of the proposed ideas by the active members of the working group, we solicited input from the US-RSE community. Based on this information we invited Angela Herring from Los Alamos National Lab to be the first speaker. She will give a talk on Agile Project Management for Research Software. A more formal announcement will be released with the exact date and time.
 
-If you are interested in getting involved in planning the series, have any input, or know someone with a good tutorial or talk, or would like to be involved in organizing these events, you can reach out to the Education and Training Working Group through the #education-training channel on the US-RSE Slack. The working group has monthly meetings and welcomes new members.
+If you are interested in getting involved in planning the series, have any input, or know someone with a good tutorial or talk, or would like to be involved in organizing these events, you can reach out to the Education and Training Working Group through the #wg-education_training channel on the US-RSE Slack. The working group has monthly meetings and welcomes new members.
 
 ### Possible Future Work and Getting Involved
 
-While the Education and Training working group is picking up the task of putting together a Tutorial and Seminar series, and possibly incorporating Domain Days into that, we uncovered a few other great ideas that are worth pursuing if you would like to get involved.
+While the Education and Training Working Group is picking up the task of putting together a Tutorial and Seminar series, and possibly incorporating Domain Days into that, we uncovered a few other great ideas that are worth pursuing if you would like to get involved.
 
 There was a lot of interest in creating some sort of resource for those coming from a CS background who want to become RSEs. We discussed the possibility of putting together a curriculum that combines research, math, data science, and domain skills, whether that be a list of formal courses taught in a university, or informal resources that could be combined to address these topics.
 
@@ -49,4 +49,4 @@ There was a lot of interest in creating some sort of resource for those coming f
 
 To create future RSE bootcamps, the [INTERSECT](https://intersect-training.github.io/) project is having its first content creation workshop this August and plans to host additional events over the coming months/years. Those interested in contributing can [fill out the interest form](https://intersect-training.github.io/participate/).
 
-Finally, if you are interested in joining the [Education and Training working group](https://us-rse.org/wg/education_training/), you can reach out to us on the #wg-education_training channel on the US-RSE Slack, or send email to [Jeff Carver](carver@cs.ua.edu).
+Finally, if you are interested in joining the [Education and Training Working Group](https://us-rse.org/wg/education_training/), you can reach out to us on the #wg-education_training channel on the US-RSE Slack, or send email to [Jeff Carver](carver@cs.ua.edu).

--- a/_posts/2022-08-01-education-training.md
+++ b/_posts/2022-08-01-education-training.md
@@ -49,4 +49,4 @@ There was a lot of interest in creating some sort of resource for those coming f
 
 To create future RSE bootcamps, the [INTERSECT](https://intersect-training.github.io/) project is having its first content creation workshop this August and plans to host additional events over the coming months/years. Those interested in contributing can [fill out the interest form](https://intersect-training.github.io/participate/).
 
-Finally, if you are interested in joining the [Education and Training Working Group](https://us-rse.org/wg/education_training/), you can reach out to us on the #wg-education_training channel on the US-RSE Slack, or send email to [Jeff Carver](carver@cs.ua.edu).
+Finally, if you are interested in joining the [Education and Training Working Group](https://us-rse.org/wg/education_training/), you can reach out to us on the #wg-education_training channel on the US-RSE Slack, or send email to [Jeff Carver](mailto:carver@cs.ua.edu).

--- a/_posts/2022-08-01-education-training.md
+++ b/_posts/2022-08-01-education-training.md
@@ -1,0 +1,52 @@
+---
+layout: post
+title: Education and Training for Research Software Engineers
+tags: [election, dei, 2022 community workshop]
+posted_by: Lauren Milechin (MIT), Jeffrey C. Carver (University of Alabama), Patrick Clemins (Vermont EPSCoR, University of Vermont), Julia Damerow (Arizona State University), Angela Herring (Los Alamos National Laboratory), Miranda Mundt (Sandia National Laboratories), Lance Parsons (Princeton University), Alan Sussman (National Science Foundation), Alicja Tadych (Princeton University)
+---
+
+*This post is the result of work from attendees of the [2022 Community Building Workshop](https://us-rse.org/first-community-workshop/) and members of the [Education and Training Working Group](https://us-rse.org/wg/education_training/).*
+
+At the recent [US-RSE Community Building Workshop](https://us-rse.org/first-community-workshop/) the authors of this  post met in a breakout session to discuss the Education and Training (E&T) needs of the Research Software Engineer community and what US-RSE could do to address those needs. The discussion included representatives from academia, national labs, and funding agencies who were RSEs themselves, RSE managers, and others who work with RSEs.
+
+This post summarizes the discussion, the progress made towards a future Education and Training Seminar Series, and what we will be doing to organize the series moving forward. We also mention a few other ideas worth pursuing that came up during discussion. This is a starting point reflecting the voices and experiences of the folks in the room, and we welcome input from the greater US-RSE community.
+
+## What we Discussed
+
+We began with a group discussion that focused on what the Education and Training needs are for RSEs. We concluded that there are usually two entry-points to being a Research Software Engineer: a domain scientist or engineer who becomes more involved in software development, and software engineers who work on research software, who may work in one or many domains throughout their career. Each entry path has a very different background, and so could benefit from additional training in different areas.
+
+### What are the E&T needs of RSEs?
+
+Those coming from a particular domain could most benefit from training in Software Engineering, in particular in software architecture and best practices. It is often difficult to find relevant resources for this group of people either because existing resources are targeted at trained software engineers or because of a lack of knowledge of what resources would be relevant. It would therefore be useful to have a list of resources that have been vetted that could be used for training new staff and students. One participant commented that this was her biggest E&T challenge: she can pair new CS students and graduates with domain scientists to learn those skills, but finding material appropriate for domain scientists to learn software engineering topics was difficult.
+
+We identified four main areas that may be lacking in Software Engineers entering the RSE field: (1) research skills, such as how to operate in a research environment, reproducibility, and experimental design, (2) data science, including data analytics and statistics, (3) certain math topics not often included in a Computer Science curriculum, such as numerical methods and math modeling, and finally, (4) domain specific skills. We established that it is often sufficient or best for the specific domain skills to be taught by a domain scientist on the team.
+
+We discussed the possibility of putting together a formal program or informal collection of resources that would teach computer science and computer science-adjacent students and new staff at different levels the necessary skills in research, math, and data science. Suggestions were given for existing curricula, such as one in Computational Engineering, that could be a model for a future formal Certificate or Master’s program, as well as the possibility of piecing together existing informal materials that could address these skills.
+
+Through discussion we found that the biggest need was for training in Software Engineering, and assembling a formal or informal program for Computer Scientists was a big task outside the scope of what we could accomplish during this meeting. Assembling a similar set of resources for Domain Scientists looking to improve their Software Engineering skills is a task that is already the focus of the [INTERSECT](https://intersect-training.github.io/) (INnovative Training Enabled by a Research Software Engineering Community of Trainers) program, which is having its [first workshop](https://intersect-training.github.io/workshop22/) to assemble material this August. We decided that an approachable task that would also be of the most value to the community would be to put together a seminar and tutorial series covering Software Engineering topics, tools, and best practices.
+
+### E&T Tutorial and Seminar Series
+
+The [Education and Training Working Group](https://us-rse.org/wg/education_training/) had recently started organizing such a tutorial and seminar series. The working group was early in the planning process and were focused on finding a first set of topics and people to present on those topics. Some participants in the breakout session mentioned that their institutions had internal seminar series and tutorials that had been taught locally, which could potentially be shared with the greater US-RSE community. We collected these from the participants, giving the working group a rich set of options to start with.
+
+To address the needs of RSEs who would like to learn more about different science domains, we also discussed the possibility of adding additional “Domain Days” to the series. During these events we would invite domain scientists to talk about their domain and answer questions about what an RSE would need to know to work in that domain - such as open questions of interest, necessary math skills, or the words and phrases most commonly heard in that domain. These would either be interview or panel style events. We also had the idea that the Q&A portion of these events might make good short podcasts that could be released in the future.
+
+We also thought it could be beneficial to host a series of “Coffee Hour” talks, which would be a space for graduate students to give talks on their research and get feedback. We then decided that this activity would be outside the scope of the Education and Training working group, and might be a good fit for the Outreach working group.
+
+### Planning the RSE Education and Training Tutorial and Seminar Series
+
+Building on the discussion at the workshop, the Education and Training Working Group is organizing the Tutorial and Seminar series described above. The group has worked to identify topics and speakers that are of most interest to the US-RSE community. After an initial ranking of the proposed ideas by the active members of the US-RSE working group, we solicited input from the US-RSE community. Based on this information we invited Angela Herring from Los Alamos National Lab to be the first speaker. She will give a talk on Agile Project Management for Research Software. A more formal announcement will be released with the exact date and time.
+
+If you are interested in getting involved in planning the series, have any input, or know someone with a good tutorial or talk, or would like to be involved in organizing these events, you can reach out to the Education and Training Working Group through the #education-training channel on the US-RSE Slack. The working group has monthly meetings and welcomes new members.
+
+### Possible Future Work and Getting Involved
+
+While the Education and Training working group is picking up the task of putting together a Tutorial and Seminar series, and possibly incorporating Domain Days into that, we uncovered a few other great ideas that are worth pursuing if you would like to get involved.
+
+There was a lot of interest in creating some sort of resource for those coming from a CS background who want to become RSEs. We discussed the possibility of putting together a curriculum that combines research, math, data science, and domain skills, whether that be a list of formal courses taught in a university, or informal resources that could be combined to address these topics.
+
+“Coffee Hour” talks where graduate students can present their research and receive feedback is also an idea worth pursuing. This opportunity could introduce graduate students to the RSE field and could be a great outreach opportunity, as well as a valuable resource to potential future RSEs.
+
+To create future RSE bootcamps, the [INTERSECT](https://intersect-training.github.io/) project is having its first content creation workshop this August and plans to host additional events over the coming months/years. Those interested in contributing can [fill out the interest form](https://intersect-training.github.io/participate/).
+
+Finally, if you are interested in joining the [Education and Training working group](https://us-rse.org/wg/education_training/), you can reach out to us on the #wg-education_training channel on the US-RSE Slack, or send email to [Jeff Carver](carver@cs.ua.edu).

--- a/_posts/2022-08-01-education-training.md
+++ b/_posts/2022-08-01-education-training.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Education and Training for Research Software Engineers
-tags: [election, dei, 2022 community workshop]
+tags: [education, training, tutorials, seminar series]
 posted_by: Lauren Milechin (MIT), Jeffrey C. Carver (University of Alabama), Patrick Clemins (Vermont EPSCoR, University of Vermont), Julia Damerow (Arizona State University), Angela Herring (Los Alamos National Laboratory), Miranda Mundt (Sandia National Laboratories), Lance Parsons (Princeton University), Alan Sussman (National Science Foundation), Alicja Tadych (Princeton University)
 ---
 

--- a/_posts/2022-08-01-education-training.md
+++ b/_posts/2022-08-01-education-training.md
@@ -2,12 +2,12 @@
 layout: post
 title: Education and Training for Research Software Engineers
 tags: [education, training, tutorials, seminar series]
-posted_by: Lauren Milechin (MIT), Jeffrey C. Carver (University of Alabama), Patrick Clemins (Vermont EPSCoR, University of Vermont), Julia Damerow (Arizona State University), Angela Herring (Los Alamos National Laboratory), Miranda Mundt (Sandia National Laboratories), Lance Parsons (Princeton University), Alan Sussman (National Science Foundation), Alicja Tadych (Princeton University)
+posted_by: Lauren Milechin
 ---
 
-*This post is the result of work from attendees of the [2022 Community Building Workshop](https://us-rse.org/first-community-workshop/) and members of the [Education and Training Working Group](https://us-rse.org/wg/education_training/).*
+A [2022 Community Workshop](https://us-rse.org/first-community-workshop/) post by - *Lauren Milechin (MIT), Jeffrey C. Carver (University of Alabama), Patrick Clemins (Vermont EPSCoR, University of Vermont), Julia Damerow (Arizona State University), Angela Herring (Los Alamos National Laboratory), Miranda Mundt (Sandia National Laboratories), Lance Parsons (Princeton University), Alan Sussman (National Science Foundation), Alicja Tadych (Princeton University)*
 
-At the recent [US-RSE Community Building Workshop](https://us-rse.org/first-community-workshop/) the authors of this  post met in a breakout session to discuss the Education and Training (E&T) needs of the Research Software Engineer community and what US-RSE could do to address those needs. The discussion included representatives from academia, national labs, and funding agencies who were RSEs themselves, RSE managers, and others who work with RSEs.
+At the recent [US-RSE Community Building Workshop](https://us-rse.org/first-community-workshop/) the authors of this  post met to discuss the Education and Training (E&T) needs of the Research Software Engineer community and what US-RSE could do to address those needs. The discussion included representatives from academia, national labs, and funding agencies who were RSEs themselves, RSE managers, and others who work with RSEs.
 
 This post summarizes the discussion, the progress made towards a future Education and Training Seminar Series, and what we will be doing to organize the series moving forward. We also mention a few other ideas worth pursuing that came up during discussion. This is a starting point reflecting the voices and experiences of the folks in the room, and we welcome input from the greater US-RSE community.
 


### PR DESCRIPTION
## Description
Adding new post summarizing the outcomes of the Education and Training breakout group at the April 2022 US-RSE Community Workshop.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
