### PR TITLE
Removing job postings that are no longer active.

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -126,11 +126,6 @@
     science
   posted: 2022-06-01
   url: http://apply.interfolio.com/107631
-- expires: 2022-12-31
-  location: "Schr\xF6dinger, New York City, NY"
-  name: Scientific Software Engineer, Hit Discovery
-  posted: 2022-05-31
-  url: https://grnh.se/b12d84713us
 - expires: 2022-08-01
   location: Hewlett Packard Enterprise, Can be remote
   name: Visiting Scholar for Chapel Programming Language Team
@@ -152,8 +147,3 @@
   name: Research Software Engineer / Project Scientist
   posted: 2022-02-01
   url: https://recruit.ucdavis.edu/JPF04614
-- expires: 2022-12-31
-  location: Pittsburgh, PA (Hybrid/Remote)
-  name: Research Programmer / Analyst
-  posted: 2021-12-10
-  url: https://cmu.wd5.myworkdayjobs.com/en-US/CMU/job/Pittsburgh-PA/Research-Programmer-Analyst---Machine-Learning-Department_2016450-1

--- a/_data/related-jobs.yml
+++ b/_data/related-jobs.yml
@@ -43,8 +43,3 @@
   name: Infrastructure/Simulation Intelligence Ops Engineer (Senior+)
   posted: 2022-04-25
   url: https://simulation.science/careers/#infra
-- expires: 2023-04-27
-  location: Texas Tech University, Lubbock, TX
-  name: Associate Managing Director
-  posted: 2022-04-28
-  url: https://apptrkr.com/3027866


### PR DESCRIPTION
## Description

I removed three job postings (including one from "related") whose URLs all go to web pages that say things like "The job posting you are looking for has expired."

## Motivation and Context

To avoid wasted time and disappointment caused by following links to job postings that aren't open anymore.

Thanks to Jordan Perr-Sauer on Slack for pointing out one of these and for inspiring me to check the others.

cc @usrse-maintainers
