### PR TITLE
Update circle image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ build_jekyll: &build_jekyll
 jobs:
   build-site:
     docker:
-      - image:  cimg/ruby:2.5.1
+      - image:  cimg/ruby:3.1
     working_directory: ~/repo
     environment:
       - JEKYLL_ENV: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ build_jekyll: &build_jekyll
 jobs:
   build-site:
     docker:
-      - image: circleci/ruby:2.5.1
+      - image:  cimg/ruby:2.5.1
     working_directory: ~/repo
     environment:
       - JEKYLL_ENV: production


### PR DESCRIPTION
The old CircleCI image is deprecated. This updates it.

More info here: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034.

We should confirm in the new build from this PR that the warning about using a deprecated image has been fixed. 

cc @usrse-maintainers
