### PR TITLE
Add resources and link to suggestion form to dei wg page

### DIFF
--- a/pages/wg/dei.md
+++ b/pages/wg/dei.md
@@ -10,8 +10,13 @@ set_last_modified: true
 
 The US-RSE Diversity, Equity, and Inclusion (DEI) working group is dedicated to supporting DEI through education, outreach, and more as described in [our mission statement]({{ site.baseurl }}/about/dei-mission). Those interested in contributing to this goal are encouraged to join in our bi-weekly Zoom meetings.
 
+# Getting involved
+
 To get involved with the DEI working group, visit the [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channel on the US-RSE slack, or contact the <a href="mailto:wg-dei@us-rse.org">DEI working group list</a>.
 
+Suggestions for media, other resources (such as guides), speakers, and 
+future activities can also be submitted through this form:
+[Diversity, Equity, and Inclusion (DEI) Suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdtCVAmJnUQCKnIXdn93xN5e9_zCQkrVdQsnPOiSBIcptma6w/viewform)
 
 # Work Products
 
@@ -40,6 +45,10 @@ a curated collection of resources for improving diversity, equity,
 and inclusion specifically within the research software engineering community.
 The list of resources can be found here:
 [RSE-specific DEI resources](https://docs.google.com/spreadsheets/d/e/2PACX-1vRwwTmM29KHDXd7s5clv1EcwITxPMNi7yIyaBUS_rwvJw87yHqgMDJU-kANFZQ1W2y3sz9GHoizmh7v/pubhtml?gid=0&single=true)
+
+Please feel free to suggest additional media
+and other resources through this form:
+[Diversity, Equity, and Inclusion (DEI) Suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdtCVAmJnUQCKnIXdn93xN5e9_zCQkrVdQsnPOiSBIcptma6w/viewform)
 
 ## US-RSE Spanish Webpage Translation
 

--- a/pages/wg/dei.md
+++ b/pages/wg/dei.md
@@ -33,6 +33,14 @@ The US-RSE DEI working group hosts monthly DEI Media Club discussions in which w
 
 These are announced via the [`#events`](https://usrse.slack.com/messages/events) and [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channels on the US-RSE slack, as well as in monthly newsletters, and are hosted virtually via Zoom.
 
+## Resources for DEI in RSE
+
+As part of its efforts, the US-RSE DEI working group is developing
+a curated collection of resources for improving diversity, equity,
+and inclusion specifically within the research software engineering community.
+The list of resources can be found here:
+[RSE-specific DEI resources](https://docs.google.com/spreadsheets/d/e/2PACX-1vRwwTmM29KHDXd7s5clv1EcwITxPMNi7yIyaBUS_rwvJw87yHqgMDJU-kANFZQ1W2y3sz9GHoizmh7v/pubhtml?gid=0&single=true)
+
 ## US-RSE Spanish Webpage Translation
 
 The US-RSE DEI working group is spearheading an effort to translate the US-RSE webpage into Spanish in order to broaden accessibility to a wider audience. This is an ongoing effort. To get involved, visit the [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channel on the US-RSE slack.


### PR DESCRIPTION
## Description

On the DEI working group page, adds a "resources" heading under "work products" with a link to the existing spreadsheet of resources (published as html).


Also adds a new "getting involved" header at the top, with existing language about getting involved, as well as a sentence about and a link to the suggestions form.  


## Motivation and Context
"Resources" fixes https://github.com/USRSE/dei-wg/issues/7
Link to suggestion form fixes https://github.com/USRSE/dei-wg/issues/17

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
