### PR TITLE
Fix media club event end date.

### DIFF
--- a/_events/2022/2022-09-dei-media-club.md
+++ b/_events/2022/2022-09-dei-media-club.md
@@ -9,7 +9,7 @@ repeated: false
 category: dei
 time:
     - - start: 2022-09-21T19:00:00Z
-        end: 2021-09-21T20:00:00Z
+        end: 2022-09-21T20:00:00Z
 ---
 
 The next meeting of the US-RSE


### PR DESCRIPTION
## Description
Fixes the year in the media club event on #911.

## Motivation and Context
Event ends before it starts, noticed by @exoticDFT.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers