### PR TITLE
Bump urlchecker-action to 0.0.33 in workflows/linting.yaml

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -13,11 +13,10 @@ jobs:
       uses: crate-ci/typos@592b36d23c62cb378f6097a292bc902ee73f93ef # version 1.0.4
       with:
         files: ./_posts ./pages ./README.md
-        
+
     - name: URLs-checker
-    
-      # Will be updated to 0.0.26
-      uses: urlstechie/urlchecker-action@0.0.26
+
+      uses: urlstechie/urlchecker-action@0.0.33
       with:
         # A comma-separated list of file types to cover in the URL checks
         file_types: .md,.py,.yml


### PR DESCRIPTION
## Description
Bump the version of urlchecker-action in .github/workflows/linting.yaml from 0.0.26 -> 0.0.33

## Motivation and Context
Trying to minimize false positives on url checks that are run on PRs

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
