### PR TITLE
Add RSE Empowerment in National Labs WG to navbar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -47,6 +47,8 @@
       link: wg/education_training
     - name: Outreach
       link: wg/outreach
+    - name: RSE Empowerment in National Labs
+      link: wg/rse-empowerment-national-labs
     - name: Website
       link: wg/website
 - name: Events


### PR DESCRIPTION
Adds the National Lab WG to the navbar drop down menu. As referenced in #979 

cc @usrse-maintainers
