### PR TITLE
Create 2022-10-13-community-call.md

### DIFF
--- a/_events/2022/2022-10-13-community-call.md
+++ b/_events/2022/2022-10-13-community-call.md
@@ -1,0 +1,22 @@
+---
+title: October 2022 Community Call - Int'l RSE Day 
+expires: 2022-10-13
+event_date: "October 13, 2022"
+layout: event
+duration: 60
+repeated: false
+category: community-call
+time:
+    - - start: 2022-10-13T17:00:00Z
+        end: 2022-10-13T18:00:00Z
+---
+
+This month’s community call will be dedicated to the International RSE Day! Because of that it will be held on Thursday, October 13 at 12pm ET instead of Friday.
+
+The topic of the call will be to review the outcomes of the Princeton Community Building Workshop that was held earlier this year and to discuss next steps. 
+You might have already read some of the blog posts from workshop working groups. 
+If you want to hear more about what was discussed or want to get involved, join us for an hour of community building and interaction!
+
+#### Registration details
+Information on how to register for the Zoom meeting will be sent via email
+and posted in the #general channel on Slack.


### PR DESCRIPTION
Somehow we missed adding this event to the webpage! Even though it's long past, I don't want to lose it. The event archive on the webpage is my main source of historical event information that I (and maybe others?) often refer to. 