### PR TITLE
Minor fixes for Working Group links

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -48,7 +48,7 @@ full_width: true
        <p>Working groups, including Diversity, Equity, and Inclusion (DEI) and a website committee, bring together community members with common interests.</p>
       </div>
        <div class="grid-item-buttons">
-<a href="{{ site.baseurl }}/about/working-groups/" class="">Learn More</a>
+<a href="{{ site.baseurl }}/wg/working-groups/" class="">Learn More</a>
    </div>
  </div>
 </div>

--- a/pages/resources/training.md
+++ b/pages/resources/training.md
@@ -12,7 +12,7 @@ We expect this list to grow significantly in both content and usability.
 These links are provided as a service to the US Research Software Engineer community.
 While we have made every effort to ensure these have been reviewed and vetted for applicability and appropriateness, US-RSE does not formally endorse any content below.
 
-_Additions to this list or general comments/questions should be directed to the [US-RSE Training and Education Working Group]({{ site.baseurl }}/about/working-groups/)._
+_Additions to this list or general comments/questions should be directed to the [US-RSE Training and Education Working Group]({{ site.baseurl }}/wg/education_training/)._
 
 
 

--- a/pages/wg/working-groups.md
+++ b/pages/wg/working-groups.md
@@ -77,6 +77,8 @@ Visit the [Outreach Working Group page]({{ site.baseurl }}/wg/outreach/) for
 more details and a catalog of work products.
 
 
+<hr>
+
 <h3><a href="{{ site.baseurl }}/wg/rse-empowerment-national-labs/">RSE Empowerment in National Labs</a></h3>
 
 The RSE Empowerment in National Labs working group, conceptualized in 2022, is for those who are interested in working towards the empowerment of RSEs in national labs and other similar organizations.


### PR DESCRIPTION
## Description
I found a few links that were missed when the main working groups pages was moved into its own dropdown. This fixes those.

## Motivation and Context
We don't want dead links!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
