### PR TITLE
Update Steering Committee Members for 2023

### DIFF
--- a/pages/about/steering-committee.md
+++ b/pages/about/steering-committee.md
@@ -11,18 +11,21 @@ set_last_modified: true
 
 ### Current Steering Committee
 
-* Nicole Brewer, Arizona State University, 2022-2023, International Council Representative
-* Jeffrey C. Carver, University of Alabama, 2019-2023, Secretary
-* Ian Cosden, Princeton University, 2019-2023, Chair
-* Julia Damerow, Arizona State University, 2021-2022, Treasurer
-* Sandra Gesing, University of Illinois Discovery Partner Institute, 2019-2023, Vice Chair
-* Chris Hill, MIT, 2019-2022
-* Daniel S. Katz, University of Illinois at Urbana-Champaign, 2019-2022, International Council Representative
-* Christina Maimone, Northwestern University, 2019-2023, Elections Chair
-* Lance Parsons, Princeton University, 2019-2022
+* Nicole Brewer, Arizona State University, 2022-2023
+* Jeffrey C. Carver, University of Alabama, 2019-2023
+* Ian Cosden, Princeton University, 2019-2023
+* Julia Damerow, Arizona State University, 2021-2024
+* Sandra Gesing, University of Illinois Discovery Partner Institute, 2019-2023
+* Rinku Gupta, Argonne National Laboratory, 2023-2024
+* Christina Maimone, Northwestern University, 2019-2023
+* Kenton McHenry, University of Illinois at Urbana-Champaign, 2023-2024 
+* Miranda Mundt, Sandia National Laboratories, 2023-2024
 
 ### Former Steering Committee Members
 
+* Chris Hill, MIT, 2019-2022
+* Daniel S. Katz, University of Illinois at Urbana-Champaign, 2019-2022
+* Lance Parsons, Princeton University, 2019-2022
 * Charles Ferenbaugh, Los Alamos National Laboratory, 2019-2021
 * Jordan Perr-Sauer, National Renewable Energy Laboratory, 2019-2020
 


### PR DESCRIPTION
This updates the steering committee members for 2023. I've removed all roles for now and will add them later once they are decided. 
The former members are listed by year last served, then alphabetically. 

cc @usrse-maintainers
