### PR TITLE
Resolve Job Cleaner Failures

### DIFF
--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -31,11 +31,19 @@ jobs:
     - name: Run URLs-checker
       uses: urlstechie/urlchecker-action@0.0.34
       with:
+        # A comma-separated list of file types to cover in the URL checks
         file_types: .md,.py,.yml
+        # Choose whether to include file with no URLs in the prints.
         print_all: false
+        # More verbose summary at the end of a run
+        verbose: true
+        # How many times to retry a failed request (defaults to 1)
         retry_count: 3
+        # Google Forms is having enormous timeouts
         timeout: 10
-        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov
+        # Exclude these patterns from the checker
+        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov,jobs.bnl.gov,https://www.rd-alliance.org/,https://uwhires.admin.washington.edu/
+        # Exclude these files from the checker
         exclude_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
     # - name: Push Fixes

--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -4,11 +4,6 @@ on:
   schedule:
     # Run nightly 1am
     - cron: 0 1 * * *
-  workflow_dispatch:
-    inputs:
-      git-ref:
-        description: Git Hash (Optional)
-        required: false
 
 jobs:
   clean-jobs:
@@ -46,25 +41,25 @@ jobs:
         # Exclude these files from the checker
         exclude_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
-    # - name: Push Fixes
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   run: |
-    #     printf "GitHub Actor: ${GITHUB_ACTOR}\n"
+    - name: Push Fixes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        printf "GitHub Actor: ${GITHUB_ACTOR}\n"
 
-    #     git config --global user.name "github-actions"
-    #     git config --global user.email "github-actions@users.noreply.github.com"
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions@users.noreply.github.com"
 
-    #     git add _data/jobs.yml _data/related-jobs.yml
+        git add _data/jobs.yml _data/related-jobs.yml
 
-    #     set +e
-    #     git status | grep modified
-    #     if [ $? -eq 0 ]; then
-    #         set -e
-    #         printf "Changes\n"
-    #         git commit -m "Automated push to update jobs files $(date '+%Y-%m-%d')" || exit 0
-    #         git push origin main
-    #     else
-    #         set -e
-    #         printf "No changes\n"
-    #     fi
+        set +e
+        git status | grep modified
+        if [ $? -eq 0 ]; then
+            set -e
+            printf "Changes\n"
+            git commit -m "Automated push to update jobs files $(date '+%Y-%m-%d')" || exit 0
+            git push origin main
+        else
+            set -e
+            printf "No changes\n"
+        fi

--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -13,18 +13,18 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+    - name: Install required packages
+      run: |
+        pip install requests pyaml urlchecker
     - name: Remove Expired Jobs
       run: |
-        sudo apt-get update && sudo apt-get install -y python3 python3-pip python3-setuptools wget
-        sudo pip3 install requests pyaml urlchecker
-        # Ensure using a particular version
-        wget https://raw.githubusercontent.com/USRSE/usrse.github.io/8975717b2c00e72d4b368dfb3ad2b611875b0038/scripts/clean_jobs.py
-        chmod +x clean_jobs.py
-        mv clean_jobs.py scripts/clean_jobs.py
-        python3 scripts/clean_jobs.py
-
+        python scripts/clean_jobs.py
     - name: Run URLs-checker
-      uses: urlstechie/urlchecker-action@0.0.25
+      uses: urlstechie/urlchecker-action@0.0.34
       with:
         file_types: .md,.py,.yml
         print_all: false
@@ -33,25 +33,25 @@ jobs:
         exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov
         exclude_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
-    - name: Push Fixes
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        printf "GitHub Actor: ${GITHUB_ACTOR}\n"
+    # - name: Push Fixes
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   run: |
+    #     printf "GitHub Actor: ${GITHUB_ACTOR}\n"
 
-        git config --global user.name "github-actions"
-        git config --global user.email "github-actions@users.noreply.github.com"
+    #     git config --global user.name "github-actions"
+    #     git config --global user.email "github-actions@users.noreply.github.com"
 
-        git add _data/jobs.yml _data/related-jobs.yml
+    #     git add _data/jobs.yml _data/related-jobs.yml
 
-        set +e
-        git status | grep modified
-        if [ $? -eq 0 ]; then
-            set -e
-            printf "Changes\n"
-            git commit -m "Automated push to update jobs files $(date '+%Y-%m-%d')" || exit 0
-            git push origin main
-        else
-            set -e
-            printf "No changes\n"
-        fi
+    #     set +e
+    #     git status | grep modified
+    #     if [ $? -eq 0 ]; then
+    #         set -e
+    #         printf "Changes\n"
+    #         git commit -m "Automated push to update jobs files $(date '+%Y-%m-%d')" || exit 0
+    #         git push origin main
+    #     else
+    #         set -e
+    #         printf "No changes\n"
+    #     fi

--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -4,6 +4,11 @@ on:
   schedule:
     # Run nightly 1am
     - cron: 0 1 * * *
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        description: Git Hash (Optional)
+        required: false
 
 jobs:
   clean-jobs:

--- a/README.md
+++ b/README.md
@@ -488,6 +488,10 @@ that a link is not expired and the check fails, we would want to know about this
 (and the test will fail). For all jobs, we don't remove them immediately upon expiration -
 we give the submitter 60 days to possibly update the data file with a later expiration date.
 
+This job needs to be updated in conjunction with the URL checker. If they are not on
+compatible URL checker versions, you may receive inconsistent behavior and erroneous
+failures between this and the PR linting job.
+
 #### Post New Jobs to Slack
 
 The workflow [jobs-poster.yaml](.github/workflows/jobs-poster.yaml) is run on any push

--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -133,11 +133,6 @@
   name: Postdoctoral Appointee - Software Engineering Research
   posted: 2022-11-19
   url: https://cg.sandia.gov/psp/applicant/EMPLOYEE/HRMS/c/HRS_HRAM_FL.HRS_CG_SEARCH_FL.GBL?Page=HRS_APP_JBPST_FL&Action=U&FOCUS=Applicant&SiteId=1&JobOpeningId=686817&PostingSeq=1&SiteId=1
-- expires: 2022-11-30
-  location: Lamont-Doherty Earth Observatory, Columbia University, New York, NY
-  name: Systems Analyst/Programmer
-  posted: 2022-11-10
-  url: https://opportunities.columbia.edu/en-us/job/530386/systems-analystprogrammer
 - expires: 2022-11-14
   location: Arizona State University, Tempe, Arizona
   name: Research Software Engineer


### PR DESCRIPTION
## Description
The `clean-expired-jobs` workflow has been broken for a really long time. This PR fixes that.

## Motivation and Context
So we don't have to keep manually updating the job board after something expires / stops working.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [ ] I have previewed changes locally
- [x] I have updated the README.md if necessary

cc @usrse-maintainers
