### PR TITLE
Support local container-based development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+_site/
+Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,26 @@
-FROM jekyll/jekyll
+FROM jekyll/jekyll:3.8
+## Currently jekyll/jekyll:4 fails with the error below so tag 3.8 is used instead.
+#      Dockerfile:10
+#      --------------------
+#         8 |     ## Install required gems
+#         9 |     COPY ./Gemfile ./Gemfile
+#        10 | >>> RUN bundle install
+#        11 |     
+#        12 |     ## Copy source files
+#      --------------------
+#      ERROR: failed to solve: process "/bin/sh -c bundle install" 
+#             did not complete successfully: exit code: 5
 
-COPY Gemfile .
+ENV JEKYLL_UID=1000
+ENV JEKYLL_GID=1000
 
-RUN bundle install --quiet --clean
+USER ${JEKYLL_UID}
 
-CMD ["jekyll", "serve"]
+## Install required gems
+COPY ./Gemfile ./Gemfile
+RUN bundle install
+
+## Copy source files
+COPY --chown=${JEKYLL_UID}:${JEKYLL_GID} ./ ./
+
+CMD ["bundle", "exec", "jekyll", "serve", "--host=0.0.0.0", "--watch", "--drafts"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,19 @@
-# frozen_string_literal: true
-
 source "https://rubygems.org"
 
-gem 'kramdown'
-gem 'kramdown-parser-gfm'
-gem 'webrick'
+gem "github-pages", '228', group: :jekyll_plugins
+
+# enable tzinfo-data for local build
+# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+gem 'faraday', '2.7.4'
+gem 'faraday-retry', '2.0.0'
+gem 'webrick', '1.8.1'
+gem 'kramdown', '2.3.2'
+gem 'kramdown-parser-gfm', '1.1.0'
+# frozen_string_literal: true
 
 group :jekyll_plugins do
-    gem "jekyll-feed", "~> 0.6"
-    gem "jekyll-sitemap"
-    gem "jekyll-paginate"
+    gem "jekyll-feed", '0.15.1'
+    gem "jekyll-sitemap", '1.4.0'
+    gem "jekyll-paginate", '1.1.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,7 @@ gem "github-pages", '228', group: :jekyll_plugins
 
 # enable tzinfo-data for local build
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+gem 'jekyll-paginate', '1.1.0'
 gem 'faraday', '2.7.4'
 gem 'faraday-retry', '2.0.0'
 gem 'webrick', '1.8.1'
-gem 'kramdown', '2.3.2'
-gem 'kramdown-parser-gfm', '1.1.0'
-# frozen_string_literal: true
-
-group :jekyll_plugins do
-    gem "jekyll-feed", '0.15.1'
-    gem "jekyll-sitemap", '1.4.0'
-    gem "jekyll-paginate", '1.1.0'
-end
-

--- a/README.md
+++ b/README.md
@@ -440,6 +440,43 @@ $ bundle exec jekyll serve
 and open your browser to <http://localhost:4000>.
 If you are having trouble try `rm -rf _site`, followed by `bundle update`, then `bundle exec jekyll serve`.
 
+
+#### Container-based development
+ou can build and run a Docker container to preview the site locally and support a local development workflow. If you do not already have Docker installed, please visit https://docs.docker.com/get-docker/ and follow the links to get started with Docker on your operating system.
+
+Build the container image:
+
+```bash
+docker build -t us-rse-website:latest .
+```
+
+Run the container to access the website at the URL http://127.0.0.1:4000/
+
+```bash
+$ docker run --rm -it -p 4000:4000 us-rse-website:latest
+Configuration file: /srv/jekyll/_config.yml
+            Source: /srv/jekyll
+       Destination: /srv/jekyll/_site
+ Incremental build: disabled. Enable with --incremental
+      Generating... 
+       Jekyll Feed: Generating feed for posts
+                    done in 6.215 seconds.
+ Auto-regeneration: enabled for '/srv/jekyll'
+LiveReload address: http://0.0.0.0:35729
+    Server address: http://0.0.0.0:4000/
+  Server running... press ctrl-c to stop.
+```
+
+To develop the website, launch the container using the following command, where the source files are mounted into the container:
+
+```bash
+docker run --rm -it -p 4000:4000 \
+    -v $(pwd):/srv/jekyll \
+    us-rse-website:latest
+```
+
+Edit a source file and save the changes. You will see Jekyll automatically regenerate the site, after which you can reload the page in your browser to see the rendered changes.
+
 #### Rakefile
 
 A legacy [Rakefile](Rakefile) is kept with the repository to allow for a manual `rake test`

--- a/README.md
+++ b/README.md
@@ -442,7 +442,8 @@ If you are having trouble try `rm -rf _site`, followed by `bundle update`, then 
 
 
 #### Container-based development
-ou can build and run a Docker container to preview the site locally and support a local development workflow. If you do not already have Docker installed, please visit https://docs.docker.com/get-docker/ and follow the links to get started with Docker on your operating system.
+
+You can build and run a Docker container to preview the site locally and support a local development workflow. If you do not already have Docker installed, please visit https://docs.docker.com/get-docker/ and follow the links to get started with Docker on your operating system.
 
 Build the container image:
 


### PR DESCRIPTION
## Description

This update fixes the Dockerfile and associated Gemfile to allow a successful container image build. Additionally, instructions are added to the `Readme.md` file describing how to build, run, and develop code in the local container. This is the analog to changes made in PR https://github.com/USRSE/usrse23/pull/8.

## Motivation and Context

This update addresses issue #767. While CircleCI is already the primary system for evaluating site updates, supporting a Docker-based development workflow can enable more collaborators to run the code in a reproducible way locally, which might be desirable in some circumstances.

## Checklist:
- [ ] I have posted the link for the PR in the usrse slack (#usrse-2023-conference-planning-committee) to ask for content reviewers
- [x] I have previewed changes locally
- [x] I have updated the README.md if necessary

cc @usrse-maintainers
