### PR TITLE
Closes #1068 - Use current time zone when creating calendar entries

### DIFF
--- a/_includes/buttons/add-to-calendar-button.html
+++ b/_includes/buttons/add-to-calendar-button.html
@@ -24,8 +24,9 @@ var myCalendar = addToCalendar({
 
     {% if time.end %}end: new Date('{{ time.end | date_to_xmlschema }}'),{% endif %}
 
-    // Event timezone. Will convert the given time to that zone
-    timezone: "America/New_York", 
+    // Event timezone. Will convert the given time to that zone. Should use the browser's
+    // timezone to ensure event is created properly for the user.
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 
     // Event duration (IN MINUTES)
     {% if post.duration %}duration: {{ post.duration }},{% endif %}


### PR DESCRIPTION
The "Add to Calendar" button (per issue #1068) was creating entries anchored in "America/New_York" which meant it was shifting the time to the other time zone for non-Eastern time zone folks.  This uses the current time zone for the user.

Credit to @exoticDFT for the actual code fix to use

<!--- Thank you for opening a pull request! Here are some helpful tips:
     
      1. To solicit reviewers: 
           the @usrse-maintainers are automatically notified when you open this pull request
           If you need additional reviewers you can:
               (if you have permission to do so) assign the label "reviewers-needed" 
               if you are on the usrse slack, post a link to your PR there and ask for reviewers

      2. To get help:
           you can ask the question directly in this pull request for @usrse-maintainers
           you can ask a question in the #website channel of usrse.slack.com
           for important issues, you can @usrse-admin to alert all admins of the repository (use sparingly)
 -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
The "Add to Calendar" button (per issue #1068) was creating entries anchored in "America/New_York" which meant it was shifting the time to the other time zone for non-Eastern time zone folks.  This uses the current time zone for the user.

## Motivation and Context
The "Add to Calendar" button (per issue #1068) was creating entries anchored in "America/New_York" which meant it was shifting the time to the other time zone for non-Eastern time zone folks.  This uses the current time zone for the user.

https://github.com/USRSE/usrse.github.io/issues/1068

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have posted the link for the PR in the usrse slack (#website) to ask for reviewers
- [x] I have previewed changes locally
- [ ] I have updated the README.md if necessary

cc @usrse-maintainers
