### PR TITLE
Add event Varun Chandola (NSF) Funders Talk presentation

### DIFF
--- a/_events/2023/2023-06-funder-talk-series.md
+++ b/_events/2023/2023-06-funder-talk-series.md
@@ -1,0 +1,38 @@
+---
+title: Varun Chandola - National Science Foundation
+subtitle: US-RSE Funders Talk Series
+expires: 2023-06-20
+event_date: "June 20, 2023"
+layout: event
+duration: 60
+repeated: false
+category: funder
+time:
+    - - start: 2023-06-20T16:00:00Z
+        end: 2023-06-20T17:00:00Z
+---
+
+## US-RSE Funders Talk Series Info
+
+US-RSE is happy to be continuing its series of conversations with funders for 1) RSEs to learn about funding opportunities and review and other processes, 2) RSEs to ask questions of the funder, and 3) funders to ask questions and learn about RSEs.  
+
+Visit the [Funder Talk Series]({{ site.baseurl }}/wg/outreach/#funder-series) for more information and links to past presentations.
+
+## Event
+
+This talk in the US-RSE Funder Talk Series will feature Varun Chandola, Program Director, Office of Advanced Cyberinfrastructure, National Science Foundation. This event will take place **Tuesday, June 20th at 12 PM ET, 11 AM CT, 10 AM MT, 9 AM PT**
+
+Please join us in this interactive conversation. (If you can't participate in the interactive event, where you will be able to ask questions and help funders understand US-RSE, it will also be recorded.)
+
+[**Register on Zoom**](https://boisestate.zoom.us/meeting/register/tJAuduGpqDstHdxZwHmSEHVgLV6k_qx6CaNF)
+
+
+### Biography
+
+Varun Chandola is currently program director in the Office of Advanced Cyberinfrastructure at NSF in charge of software and data related cyberinfrastructure programs. He is on leave from his permanent position as an Associate Professor in the Computer Science and Engineering Department and the Center for Computational and Data-Enabled Science and Engineering (CDSE) at the University at Buffalo. His research covers the application of data mining and machine learning to problems involving big and complex data, focusing on anomaly detection from big and complex data. Before joining UB, he was a scientist in the Computational Sciences and Engineering Division at the Oak Ridge National Laboratory. He has a PhD in Computer Science and Engineering from University of Minnesota.
+
+
+
+### Registration
+
+You can [register on Zoom](https://boisestate.zoom.us/meeting/register/tJAuduGpqDstHdxZwHmSEHVgLV6k_qx6CaNF) for this presentation.  A recording of the presentation will be made available to those who have registered.

--- a/_events/2023/2023-06-funder-talk-series.md
+++ b/_events/2023/2023-06-funder-talk-series.md
@@ -28,7 +28,7 @@ Please join us in this interactive conversation. (If you can't participate in th
 
 
 ### Biography
-
+![Varun Chandola](https://ubdsgroup.github.io/images/team/varun-chandola.jpg){: style="float: left; margin-right: 10px; clear: left; width: 143px; height: 153px;"}
 Varun Chandola is currently program director in the Office of Advanced Cyberinfrastructure at NSF in charge of software and data related cyberinfrastructure programs. He is on leave from his permanent position as an Associate Professor in the Computer Science and Engineering Department and the Center for Computational and Data-Enabled Science and Engineering (CDSE) at the University at Buffalo. His research covers the application of data mining and machine learning to problems involving big and complex data, focusing on anomaly detection from big and complex data. Before joining UB, he was a scientist in the Computational Sciences and Engineering Division at the Oak Ridge National Laboratory. He has a PhD in Computer Science and Engineering from University of Minnesota.
 
 

--- a/pages/wg/outreach.md
+++ b/pages/wg/outreach.md
@@ -79,6 +79,8 @@ about opportunities, strategies, and starting points for finding funding.
 
 - __2023-05-09 Carly Strasser__ - Chan Zuckerberg Initiative: [Event info and registration]({{ site.baseurl }}/events/2023/2023-05-funder-talk-series/)
 
+- __2023-06-20 Varun Chandola__ - National Science Foundation: [Event info and registration]({{ site.baseurl }}/events/2023/2023-06-funder-talk-series/)
+
 Please keep an eye out for future announcements regarding this series.
 
 #### Past Presentations


### PR DESCRIPTION
## Description
Adding event entry and corresponding link on the Outreach WG page for Varun Chandola's presentation on 2023-06-20 as part of the US-RSE Funders Talk Series.


## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have posted the link for the PR in the US-RSE Slack (#website) to ask for reviewers


<!---Ask questions if needed in the #website channel of US-RSE Slack --->