### PR TITLE
update tributors to 0.0.21-node-20

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Tributors Update
       
         # Important! Update to release https://github.com/con/tributors
-        uses: con/tributors@0.0.21
+        uses: con/tributors@0.0.21-node-20
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:        


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->
This change updates the update-contributors workflow to use a newer upstream version of tributrors based on node:20 instead of the deprecated node:12

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have posted the link for the PR in the US-RSE Slack (#website) to ask for reviewers


<!---Ask questions if needed in the #website channel of US-RSE Slack --->