### PR TITLE
Update google_analytics parameter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,14 +45,14 @@ plugins:
   - jekyll-paginate
   - jekyll-feed
 
-exclude: 
+exclude:
   - Gemfile
   - Gemfile.lock
   - vendor
 
 livereload: true
 
-google_analytics: "UA-133428825-1"
+google_analytics: "G-TB8FXJCCW1"
 
 defaults:
   -
@@ -68,7 +68,7 @@ defaults:
     values:
       layout: post
       show_sidebar: true
-  - 
+  -
     scope:
       path: "_events"
       type: "events"
@@ -84,7 +84,7 @@ collections:
   events:
     output: true
     permalink: /:collection/:path/
-  products: 
+  products:
     output: true
     layout: product
     image: https://via.placeholder.com/800x600


### PR DESCRIPTION
## Description
Google Universal Analytics is being deprecated in July 2023. This pull request updates the current Google Analytics parameter (`google_analytics`) specified in `_config.yml` to be the new GA4 parameter.

## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
