### PR TITLE
trivial fix to make the tributors badge go to the correct section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 https://us-rse.org
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-73-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-73-orange.svg?style=flat-square)](#contributors)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 ## What is this?


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->

This is just a trivial fix to make the link on the tributors badge go to the correct section.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
