### PR TITLE
add a badgeTemplate for all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,6 +7,7 @@
         "README.md"
     ],
     "imageSize": 100,
+    "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
     "commit": true,
     "commitConvention": "none",
     "contributors": [


### PR DESCRIPTION

## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->
This change adds a `badgeTemplate` to correctly generate the link to the Contributors section

This is the more complete fix for #1190

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
