### PR TITLE
Fix issue with links missing site domain.

### DIFF
--- a/.circleci/circle_urls.sh
+++ b/.circleci/circle_urls.sh
@@ -1,2 +1,3 @@
 BASEURL=https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/${CIRCLE_NODE_INDEX}/usrse.github.io
 sed -i "8 s,.*,baseurl: $BASEURL,g" "_config.yml"
+sed -i "8 s,.*,url: https://usrse.org,g" "_config.yml"

--- a/.circleci/circle_urls.sh
+++ b/.circleci/circle_urls.sh
@@ -1,3 +1,0 @@
-BASEURL=https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/${CIRCLE_NODE_INDEX}/usrse.github.io
-sed -i "8 s,.*,baseurl: $BASEURL,g" "_config.yml"
-sed -i "8 s,.*,url: https://usrse.org,g" "_config.yml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,7 @@ build_jekyll: &build_jekyll
     command: |
         if [ -z "$CIRCLECI_TRIGGER" ]; then
             echo "Building RSE Blog for Preview"
-            cp ~/repo/.circleci/circle_urls.sh ~/repo/circle_urls.sh
             cd ~/repo
-            chmod u+x circle_urls.sh
-            bash circle_urls.sh              
             bundle exec jekyll build
         else
             echo "Nightly build detected, preview not needed."

--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,8 @@ lang: en
 title: US-RSE
 description: United States Research Software Engineer Association
 
-url: ""
-baseurl: ""  # for testing, also check .circleci/circle_urls.sh
+url: https://us-rse.org
+baseurl: ""
 title-img: /assets/img/main_logo_transparent.png  # baseurl will be prepended
 twitter-img: /assets/img/main_logo_transparent.png  # url + baseurl will be prepended
 banner: /assets/img/main_logo_transparent.png


### PR DESCRIPTION
## Description

`site.url` is empty causing all links to exclude the site domain. This causes issues with "social" share buttons.

Jekyll appears to have been misconfigured. `site.url` should be the domain/protocol/etc. while `site.baseurl` should be the root directory that the site is served from. In this case, the site is served from `/` so `site.baseurl` should be empty.

Removing the script that alters the config and updating `site.url` fixes the share buttons and leaves any usages of `site.baseurl` unchanged.


Closes #1201

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled. 
