### PR TITLE
Fix issue with social buttons.

### DIFF
--- a/.circleci/circle_urls.sh
+++ b/.circleci/circle_urls.sh
@@ -1,2 +1,3 @@
 BASEURL=https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/${CIRCLE_NODE_INDEX}/usrse.github.io
 sed -i "8 s,.*,baseurl: $BASEURL,g" "_config.yml"
+sed -i "7 s,.*,url: \"\",g" "_config.yml"

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ lang: en
 title: US-RSE
 description: United States Research Software Engineer Association
 
-url: ""
+url: "https://us-rse.org"
 baseurl: ""  # for testing, also check .circleci/circle_urls.sh
 title-img: /assets/img/main_logo_transparent.png  # baseurl will be prepended
 twitter-img: /assets/img/main_logo_transparent.png  # url + baseurl will be prepended


### PR DESCRIPTION
## Description

`site.url` is empty causing all links to exclude the site domain. This causes issues with "social" share buttons.

This change sets `site.url` to the site's domain, and updates the circleci script to maintain the artifact preview behavior.

Closes #1201



## Checklist:
- [X] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  