### PR TITLE
Add US-RSE jobs

### DIFF
--- a/_data/callouts/home.yml
+++ b/_data/callouts/home.yml
@@ -1,9 +1,9 @@
 style: is-light
 items:
-  - title: Funder Series
-    subtitle: Talk with funding agencies and foundations about RSE opportunities
-    link: /wg/outreach/#funder-series
-    link_name: Register for a Session 
+  - title: We're Hiring!
+    subtitle: US-RSE is hiring an Executive Director and a Community Manager
+    link: /jobs/
+    link_name: See the Job Descriptions 
   - title: RSE Group Leaders' Network
     subtitle: Join this new network to connect with peers about leadership and management challenges
     link: /ag/rse-gln

--- a/_data/us-rse-jobs.yml
+++ b/_data/us-rse-jobs.yml
@@ -1,0 +1,10 @@
+- expires: 2023-10-31
+  location: Remote
+  name: Community Manager
+  posted: 2023-07-18
+  url: /jobs/2023-community-manager/
+- expires: 2023-09-30
+  location: Remote
+  name: Executive Director
+  posted: 2023-07-18
+  url: /jobs/2023-executive-director/

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -4,8 +4,12 @@ title: RSE Opportunities
 permalink: /jobs/
 ---
 
+{% assign us-rse_jobs = site.data.us-rse-jobs | sort: "posted" | reverse %}
+{% include joblist.html section_heading="## Current US-RSE Assocation Openings" sorted_jobs=us-rse_jobs %}
+
+
 {% assign rse_jobs = site.data.jobs | sort: "posted" | reverse %}
-{% include joblist.html section_heading="## Current RSE openings" sorted_jobs=rse_jobs %}
+{% include joblist.html section_heading="## Current RSE Openings" sorted_jobs=rse_jobs %}
 
 {% assign related_jobs = site.data.related-jobs | sort: "posted" | reverse %}
 {% include joblist.html section_heading="### Related Openings" sorted_jobs=related_jobs %}

--- a/pages/opportunities/jobs.md
+++ b/pages/opportunities/jobs.md
@@ -5,7 +5,7 @@ permalink: /jobs/
 ---
 
 {% assign us-rse_jobs = site.data.us-rse-jobs | sort: "posted" | reverse %}
-{% include joblist.html section_heading="## Current US-RSE Assocation Openings" sorted_jobs=us-rse_jobs %}
+{% include joblist.html section_heading="## Current US-RSE Association Openings" sorted_jobs=us-rse_jobs %}
 
 
 {% assign rse_jobs = site.data.jobs | sort: "posted" | reverse %}

--- a/pages/opportunities/us-rse-jobs/2023-community-manager.md
+++ b/pages/opportunities/us-rse-jobs/2023-community-manager.md
@@ -79,5 +79,5 @@ US-RSE is a fiscally sponsored project of [Community Initiatives](https://commun
 Community Initiatives is an equal opportunity employer and gives consideration for employment to qualified applicants without regard to age, race, color, religion, creed, sex, sexual orientation, gender identity or expression, national origin, marital status, disability or protected veteran status, or any other status or characteristic protected by federal, state, or local law.
 
 
-## [Apply Here](https://docs.google.com/forms/d/1RjRCdKoNtnA-wGc0MoQdYPWDNaPs4gWlD0UH4AOzsog/edit)
+## [Apply Here](https://docs.google.com/forms/d/e/1FAIpQLSfChi3FSUCrrOwie_iEWFzhyCREC6Nx7y0b8Iew98_FteR8oQ/viewform?usp=sf_link)
 

--- a/pages/opportunities/us-rse-jobs/2023-community-manager.md
+++ b/pages/opportunities/us-rse-jobs/2023-community-manager.md
@@ -49,7 +49,7 @@ As US-RSE’s Community Manager, your role will be varied, covering four main ar
 * Demonstrated ability to communicate clearly and effectively in English in writing and in spoken presentations.  
 * Experience managing multiple projects or competing tasks.  
 
-#### Valued experience:
+#### Valued Experience
 * Knowledge of the research software development process, software development terminology, and research workflow.
 * Writing code.
 * Conducting research or contributing to research projects.

--- a/pages/opportunities/us-rse-jobs/2023-community-manager.md
+++ b/pages/opportunities/us-rse-jobs/2023-community-manager.md
@@ -57,7 +57,7 @@ As US-RSE’s Community Manager, your role will be varied, covering four main ar
 * Developing diverse and inclusive communities.
 * Editing the writing of others
 
-#### Valued knowledge and certifications:
+#### Valued Knowledge and Certifications
 * Knowledge of and previous engagement with the US-RSE or broader research software communities.
 * Community manager training or certifications, such as that offered by the Center for Scientific Collaboration and Community Engagement.
 

--- a/pages/opportunities/us-rse-jobs/2023-community-manager.md
+++ b/pages/opportunities/us-rse-jobs/2023-community-manager.md
@@ -13,7 +13,7 @@ Community is the first part of the US Research Software Engineer Association's (
 
 As the Community Manager, you will report to the new Executive Director and work with the US-RSE Steering Committee, working group (WG) chairs, and other volunteer organizational leaders to ensure clear and effective communications, organize and execute events, execute day-to-day operational tasks, reach out to new members, and realize the strategic vision of the organization. 
 
-#### Responsibilities: 
+#### Responsibilities
 As US-RSE’s Community Manager, your role will be varied, covering four main areas of responsibility. You’ll lean into different parts of the [CSCCE skills wheel](https://www.cscce.org/research/skills-wheel/) depending on the situation, need, time of year, and your strengths and interests. The activities below are examples of ways you may support US-RSE in the different areas of responsibility though not all activities will be conducted on a daily basis. 
 * Community Management
   * Regularly engage in community discussion forums (Slack) and promote a positive and active environment that encourages further participation 

--- a/pages/opportunities/us-rse-jobs/2023-community-manager.md
+++ b/pages/opportunities/us-rse-jobs/2023-community-manager.md
@@ -42,7 +42,7 @@ As US-RSE’s Community Manager, your role will be varied, covering four main ar
   * Help community members develop their ideas and put them into action 
 
 
-#### Required qualifications: 
+#### Required Qualifications
 * Experience working with virtual teams with diverse membership, coordinating group activities, and communicating with groups of dozens or hundreds of members.
 * Ability to use GitHub, Markdown, and HTML; and a variety of online technical services, such as Google Workspace, Slack, and YouTube; or the ability and interest to quickly learn these skills.
 * Knowledge of diversity, equity, and inclusion principles and experience working with and supporting diverse groups.

--- a/pages/opportunities/us-rse-jobs/2023-community-manager.md
+++ b/pages/opportunities/us-rse-jobs/2023-community-manager.md
@@ -1,0 +1,83 @@
+---
+layout: page
+title: US-RSE Community Manager
+permalink: /jobs/2023-community-manager/
+
+---
+
+Posted: July 18, 2023
+
+### US-RSE is hiring a Community Manager!
+
+Community is the first part of the US Research Software Engineer Association's ([US-RSE](https://us-rse.org/)) [mission](https://us-rse.org/about/mission/). The US-RSE Community Manager supports our members in building this rapidly growing community of research software engineers and in achieving the other components of US-RSE's mission: advocating for RSEs and RSEs' work; developing resources to support RSEs; and strengthening diversity, equity, and inclusion in our broader community.
+
+As the Community Manager, you will report to the new Executive Director and work with the US-RSE Steering Committee, working group (WG) chairs, and other volunteer organizational leaders to ensure clear and effective communications, organize and execute events, execute day-to-day operational tasks, reach out to new members, and realize the strategic vision of the organization. 
+
+#### Responsibilities: 
+As US-RSE’s Community Manager, your role will be varied, covering four main areas of responsibility. You’ll lean into different parts of the [CSCCE skills wheel](https://www.cscce.org/research/skills-wheel/) depending on the situation, need, time of year, and your strengths and interests. The activities below are examples of ways you may support US-RSE in the different areas of responsibility though not all activities will be conducted on a daily basis. 
+* Community Management
+  * Regularly engage in community discussion forums (Slack) and promote a positive and active environment that encourages further participation 
+  * Proactively identify opportunities, venues, or events for new community engagement
+  * Develop methods to recognize community members for the work they do supporting US-RSE
+  * Identify and triage issues that arise in the community
+  * Lead moderation of community interactions as part of the Code of Conduct process
+* Communications
+  * Lead the compilation and distribution of a regular newsletter, including coordinating contributions and gathering events and news of interest to the community
+  * Manage website updates and social media channels, sharing information about US-RSE, building connections among US-RSE members on social media, and raising awareness about issues affecting RSEs.
+  * Manage membership communication including regular announcements and reminders to the community about ongoing events
+  * Write website content highlighting the activities of the organization 
+  * Coordinate recording and distribution of videos for virtual events
+* Logistics and Planning
+  * Provide event support, e.g., for conference planning, event sponsors, speaker coordination, etc. 
+  * Plan monthly community calls with community input
+  * Participate in WGs and regional/affinity groups to keep public information on the groups up to date and publicize WG activities in the community
+  * Manage membership sign-ups, member information changes, welcome emails, and other membership-related logistics
+  * Administer the organization's service accounts (e.g. Slack, Google, GitHub, YouTube)
+* Outreach
+  * Attend conferences, events, and virtual calls relevant to the community to promote US-RSE and build connections between US-RSE and other related organizations
+  * Advocate for US-RSE and RSEs by occasionally presenting at events about US-RSE and the reasons for joining
+  * Recruit volunteers (identify and cultivate individuals)
+  * Grow the membership of RSEs; in particular, identify gaps in the community by identifying new potential partnerships with other organization and outreach to un- or under-represented areas
+  * Welcome new members into the community and help them find ways to contribute
+  * Help community members develop their ideas and put them into action 
+
+
+#### Required qualifications: 
+* Experience working with virtual teams with diverse membership, coordinating group activities, and communicating with groups of dozens or hundreds of members.
+* Ability to use GitHub, Markdown, and HTML; and a variety of online technical services, such as Google Workspace, Slack, and YouTube; or the ability and interest to quickly learn these skills.
+* Knowledge of diversity, equity, and inclusion principles and experience working with and supporting diverse groups.
+* Demonstrated ability to communicate clearly and effectively in English in writing and in spoken presentations.  
+* Experience managing multiple projects or competing tasks.  
+
+#### Valued experience:
+* Knowledge of the research software development process, software development terminology, and research workflow.
+* Writing code.
+* Conducting research or contributing to research projects.
+* Website development.
+* Developing diverse and inclusive communities.
+* Editing the writing of others
+
+#### Valued knowledge and certifications:
+* Knowledge of and previous engagement with the US-RSE or broader research software communities.
+* Community manager training or certifications, such as that offered by the Center for Scientific Collaboration and Community Engagement.
+
+
+US-RSE values a diverse and inclusive community consistent with our DEI mission. We actively foster a supportive team environment that permits diverse backgrounds to thrive including those looking to make a career change and those with a non-traditional career track, educational path, or life experiences. If this environment sounds like a strong match or even an exciting challenge, we encourage you to apply and use your cover letter to explain why you would be a good fit for the role.
+
+
+#### Compensation
+This is a full-time, remote, two-year term position, with the option for renewal based on performance and available funding. The salary range is $75,000 - $95,000 depending on experience and applicable skills. 
+
+
+In compliance with federal law, all persons hired will be required to verify identity and eligibility to work in the United States and to complete the required employment eligibility verification form upon hire.
+
+
+US-RSE is a fiscally sponsored project of [Community Initiatives](https://communityinitiatives.org/).
+
+
+### Equal Employment Opportunity
+Community Initiatives is an equal opportunity employer and gives consideration for employment to qualified applicants without regard to age, race, color, religion, creed, sex, sexual orientation, gender identity or expression, national origin, marital status, disability or protected veteran status, or any other status or characteristic protected by federal, state, or local law.
+
+
+## [Apply Here](https://docs.google.com/forms/d/1RjRCdKoNtnA-wGc0MoQdYPWDNaPs4gWlD0UH4AOzsog/edit)
+

--- a/pages/opportunities/us-rse-jobs/2023-executive-director.md
+++ b/pages/opportunities/us-rse-jobs/2023-executive-director.md
@@ -15,7 +15,8 @@ The Executive Director reports to the US-RSE Steering Committee Chair and works 
 
 This is a part-time position, up to 50% effort. We plan for this position to grow into a full-time, or nearly full-time position with additional responsibilities. The long-term vision of the Executive Director is to run day-to-day operations of the US-RSE organization with only general oversight from the elected steering committee.
 
-#### Initial responsibilities include:
+#### Responsibilities
+We expect this position to evolve over time. Initial responsibilities will include:
 * Financial Sustainability
    * Lead work towards financial sustainability, in collaboration with the Steering Committee and the Treasurer
    * Lead efforts to obtain funding from external sources including grants (public and private), sponsorships, membership fees, conference revenue, and other sources that may be identified in the future.

--- a/pages/opportunities/us-rse-jobs/2023-executive-director.md
+++ b/pages/opportunities/us-rse-jobs/2023-executive-director.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: US-RSE Executive Director (Part-Time)
+permalink: /jobs/2023-executive-director/
+
+---
+
+Posted: July 18, 2023
+
+### US-RSE is hiring an Executive Director!
+
+Up to this point in its history, the US-RSE Association has been organized and run solely by volunteers, primarily members of the steering committee. As it has now reached a point where the membership is growing and the community needs are growing, we are hiring an Executive Director to continue moving the Association forward. By having an Executive Director, it will allow the Association to more effectively pursue the goals of building a vibrant RSE community in the US.
+
+The Executive Director reports to the US-RSE Steering Committee Chair and works with the Steering Committee, working group chairs, and other volunteer organizational leaders to oversee the execution of the mission of the US-RSE Association, advocate for the Association and the needs of its members, and ensure the long-term financial sustainability of the Association.
+
+This is a part-time position, up to 50% effort. We plan for this position to grow into a full-time, or nearly full-time position with additional responsibilities. The long-term vision of the Executive Director is to run day-to-day operations of the US-RSE organization with only general oversight from the elected steering committee.
+
+#### Initial responsibilities include:
+* Financial Sustainability
+   * Lead work towards financial sustainability, in collaboration with the Steering Committee and the Treasurer
+   * Lead efforts to obtain funding from external sources including grants (public and private), sponsorships, membership fees, conference revenue, and other sources that may be identified in the future.
+* External Visibility
+   * Lead and/or commission policy statements and position papers on topics of importance to the Association
+* Supervision of Staff
+   * Provide day-to-day management and oversight of US-RSE staff. Currently this consists of a yet-to-be-filled, full-time, Community Manager.
+
+
+#### Required Qualifications
+* Knowledge of the research software development process, software development terminology, and research workflow
+* Experience in working with funding agencies to obtain funding
+* Strong knowledge of the US-RSE Association and its current operations
+* Evidence of leadership within organizations (preferably within the US-RSE Association)
+* Demonstrated ability to communicate clearly and effectively in English in writing and in spoken presentations
+* Experience leading/managing teams or groups of people
+
+#### Valued Experience
+* Conducting research and/or contributing to research projects
+* Advocating for research and/or people to external constituents
+
+
+
+US-RSE values a diverse and inclusive community consistent with our DEI mission. We actively foster a supportive team environment that permits diverse backgrounds to thrive including those looking to make a career change and those with a non-traditional career track, educational path, or life experiences. If this environment sounds like a strong match or even an exciting challenge, we encourage you to apply and use your cover letter to explain why you would be a good fit for the role.
+
+#### Compensation
+This is a part-time (up to 50%) remote position. The salary range (at 0.5 FTE) is $80,000 - $100,000 depending on experience and applicable skills. 
+
+
+In compliance with federal law, all persons hired will be required to verify identity and eligibility to work in the United States and to complete the required employment eligibility verification form upon hire.
+
+
+US-RSE is a fiscally sponsored project of [Community Initiatives](https://communityinitiatives.org/).
+
+
+### Equal Employment Opportunity
+Community Initiatives is an equal opportunity employer and gives consideration for employment to qualified applicants without regard to age, race, color, religion, creed, sex, sexual orientation, gender identity or expression, national origin, marital status, disability or protected veteran status, or any other status or characteristic protected by federal, state, or local law.
+
+
+## [Apply Here](https://docs.google.com/forms/d/1HgB04tYZDDfnKb5ZiCzYqXU-A4ONUbw4rx_1rKV62Oo/edit)
+
+
+

--- a/pages/opportunities/us-rse-jobs/2023-executive-director.md
+++ b/pages/opportunities/us-rse-jobs/2023-executive-director.md
@@ -56,7 +56,7 @@ US-RSE is a fiscally sponsored project of [Community Initiatives](https://commun
 Community Initiatives is an equal opportunity employer and gives consideration for employment to qualified applicants without regard to age, race, color, religion, creed, sex, sexual orientation, gender identity or expression, national origin, marital status, disability or protected veteran status, or any other status or characteristic protected by federal, state, or local law.
 
 
-## [Apply Here](https://docs.google.com/forms/d/1HgB04tYZDDfnKb5ZiCzYqXU-A4ONUbw4rx_1rKV62Oo/edit)
+## [Apply Here](https://docs.google.com/forms/d/e/1FAIpQLSd2pcLuq6m294RyeKbiSK7MqacIOH0CTQeghJMTmNunArkFNg/viewform?usp=sf_link)
 
 
 


### PR DESCRIPTION
This adds: 
* A job ad for the new part time US-RSE Executive Director
* A job ad for the new US-RSE Community Manager
* A new yml file to hold US-RSE jobs
* A new section, at the top, on the job board for US-RSE jobs. It will only display when there are active jobs. 

I put the job ad pages in a new directory in opportunities and permalinked them under /jobs/2023-<job-name>/. Open to suggestions for alternatives. 

Also, something happened on my local preview halfway through. So I either broke the site (if so, help!) or broke my local preview (couldn't figure it out quickly), so will need to check the CI previews carefully. 