### PR TITLE
Change pearc23 event expiration date

### DIFF
--- a/_events/2023/2023-07-se4rs23.md
+++ b/_events/2023/2023-07-se4rs23.md
@@ -1,6 +1,6 @@
 ---
 title: "Software Engineering for Research Software (SE4RS'23)"
-expires: 2023-10-24
+expires: 2023-07-25
 event_date: "July 24, 2023"
 layout: event
 repeated: false


### PR DESCRIPTION
This updates the expiration date for the PEARC23 workshop (that was held yesterday) so that it moves to the events archive. 

It was previously set to October - I'm assuming this was a typo? 