### PR TITLE
Update webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem "github-pages", '228', group: :jekyll_plugins
 gem 'jekyll-paginate', '1.1.0'
 gem 'faraday', '2.7.4'
 gem 'faraday-retry', '2.0.0'
-gem "webrick", ">= 2.2.8"
+gem 'webrick', '2.2.8'

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ gem "github-pages", '228', group: :jekyll_plugins
 gem 'jekyll-paginate', '1.1.0'
 gem 'faraday', '2.7.4'
 gem 'faraday-retry', '2.0.0'
-gem 'webrick', '1.8.1'
+gem "webrick", ">= 2.2.8"


### PR DESCRIPTION
We got a dependabot alert https://github.com/USRSE/usrse.github.io/security/dependabot/5 about a vulnerability with webrick versions <2.2.8.

This updates the version in the Gemfile with the the suggested fix  `gem "webrick", ">= 2.2.8"`
