### PR TITLE
add Mastodon tooting for new jobs

### DIFF
--- a/.github/workflows/jobs-poster.yaml
+++ b/.github/workflows/jobs-poster.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - id: updater
         name: Job Updater
-        uses: rseng/jobs-updater@add/multiple-metadata-fields
+        uses: rseng/jobs-updater
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         with:
@@ -39,6 +39,11 @@ jobs:
           twitter_api_key: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           twitter_consumer_secret: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
           twitter_consumer_key: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
+
+          # Also deploy to Mastodon (all secrets required in repository secrets)
+          mastodon_deploy: true
+          mastodon_access_token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          mastodon_api_base_url: ${{ secrets.MASTODON_API_BASE_URL }}
 
       - run: echo ${{ steps.updater.outputs.fields }}
         name: Show Fields Used


### PR DESCRIPTION
## Description
This change adds a step to the jobs posting workflow to toot to Mastodon when a new job is added to the list.

It does not (yet) disable the step to tweet new jobs.


## Checklist:
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.
