### PR TITLE
fix jobs poster workflow

### DIFF
--- a/.github/workflows/jobs-poster.yaml
+++ b/.github/workflows/jobs-poster.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - id: updater
         name: Job Updater
-        uses: rseng/jobs-updater
+        uses: rseng/jobs-updater@0.0.13
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         with:


### PR DESCRIPTION
## Description
This fixes a bug I introduced in #1232 that broke the jobs poster workflow.


## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.
