### PR TITLE
Community Call updates, August 2023

### DIFF
--- a/_events/2023/2023-08-community-call.md
+++ b/_events/2023/2023-08-community-call.md
@@ -1,0 +1,20 @@
+---
+title: August 2023 Community Call
+expires: 2023-08-12
+event_date: "August 11, 2023"
+layout: event
+duration: 60
+repeated: false
+category: community-call
+time:
+    - - start: 2023-08-11T18:00:00Z
+        end: 2023-08-11T19:00:00Z
+---
+
+The next community call will be about **Career Mentoring Plans** on **Friday, August 11, 2pm ET/1pm CT/12pm MT/11am PT**.
+
+What does a good RSE (and more generally cyber infrastructure) profession’s development and mentoring plan look like? What works in practice and what aspiration goals are still harder than they should be? What could be done to improve short-term and long-term career development planning? These are just some of the questions that come to mind when thinking about how we can improve RSE careers. In our August US-RSE Community Call, we will gather different perspectives and experiences about what mentoring for RSEs looks (or could look) like in different types of organizations. Have you been mentored to climb the career ladder? Was there a plan in place? How did it work out for you? Or do you wish you would have had a career mentor? Come join us and share your thoughts!
+
+
+#### Registration details
+Information on how to register for the Zoom meeting will be sent via email and posted in the #general channel on Slack.

--- a/_events/2023/2023-08-community-call.md
+++ b/_events/2023/2023-08-community-call.md
@@ -17,4 +17,4 @@ What does a good RSE (and more generally cyber infrastructure) profession’s de
 
 
 #### Registration details
-Information on how to register for the Zoom meeting will be sent via email and posted in the #general channel on Slack.
+Information on how to register for the Zoom meeting will be sent via email and posted in the `#general` and `#communitycalls` channels on Slack.

--- a/_events/repeated/community-call-fridays.md
+++ b/_events/repeated/community-call-fridays.md
@@ -7,7 +7,7 @@ event_date: "alternating 2nd Thursday (12:00-1:00pm ET) and 2nd Friday (2:00-3:0
 layout: event
 category: community-call
 time:
-  - - start: 2022-06-10 14:00 EST
+  - - start: 2022-06-10 14:00 ET
 
 # Repeated events information
 repeated: true
@@ -30,4 +30,4 @@ Community calls alternate between the second Thursday (12:00-1:00pm ET) of each 
 Any and all suggestions for topics are
 welcome at [https://github.com/USRSE/monthly-community-calls/issues](https://github.com/USRSE/monthly-community-calls/issues).
 Anyone in USRSE is super welcome to lead a call on a topic of their choosing. Feel free to reach out to the organizers (currently Julia Damerow and
-Chris Hill) on USRSE slack ( "@Julia Damerow" and/or "@Chris Hill") or elsewhere if you would like to host (or help with) a call.
+Abbey Roelofs) on USRSE slack ( "@Julia Damerow" and/or "@Abbey Roelofs") or elsewhere if you would like to host (or help with) a call.

--- a/_events/repeated/community-call-fridays.md
+++ b/_events/repeated/community-call-fridays.md
@@ -7,7 +7,7 @@ event_date: "alternating 2nd Thursday (12:00-1:00pm ET) and 2nd Friday (2:00-3:0
 layout: event
 category: community-call
 time:
-  - - start: 2022-06-10 14:00 ET
+  - - start: 2022-06-10 14:00 EST
 
 # Repeated events information
 repeated: true

--- a/_events/repeated/community-call-planning.md
+++ b/_events/repeated/community-call-planning.md
@@ -7,7 +7,7 @@ event_date: "fourth Thursday each month 12:00-13:00 Eastern"
 layout: event
 category: community-call
 time:
-  - - start: 2022-01-27 12:00 EST
+  - - start: 2022-01-27 12:00 ET
 
 # Repeated events information
 repeated: true
@@ -27,4 +27,4 @@ plan for the next community call. All are welcome to join the call, zoom details
 Any and all suggestions for community topics are 
 welcome at [https://github.com/USRSE/monthly-community-calls/issues](https://github.com/USRSE/monthly-community-calls/issues).
 Anyone in USRSE is super welcome to lead a call on a topic of their choosing. Feel free to reach out to the organizers (currently Julia Damerow and
-Chris Hill) on USRSE slack ( "@Julia Damerow" and/or "@Chris Hill") or elsewhere if you would like to host (or help with) a call.
+Abbey Roelofs) on USRSE slack ("@Julia Damerow" and/or "@Abbey Roelofs") or elsewhere if you would like to host (or help with) a call.

--- a/_events/repeated/community-call-planning.md
+++ b/_events/repeated/community-call-planning.md
@@ -7,7 +7,7 @@ event_date: "fourth Thursday each month 12:00-13:00 Eastern"
 layout: event
 category: community-call
 time:
-  - - start: 2022-01-27 12:00 ET
+  - - start: 2022-01-27 12:00 EST
 
 # Repeated events information
 repeated: true

--- a/_events/repeated/community-call.md
+++ b/_events/repeated/community-call.md
@@ -7,7 +7,7 @@ event_date: "alternating 2nd Thursday (12:00-1:00pm ET) and 2nd Friday (2:00-3:0
 layout: event
 category: community-call
 time:
-  - - start: 2022-07-14 12:00 EST
+  - - start: 2022-07-14 12:00 ET
 
 # Repeated events information
 repeated: true
@@ -30,4 +30,4 @@ Community calls alternate between the second Thursday (12:00-1:00pm ET) of each 
 Any and all suggestions for topics are
 welcome at [https://github.com/USRSE/monthly-community-calls/issues](https://github.com/USRSE/monthly-community-calls/issues).
 Anyone in USRSE is super welcome to lead a call on a topic of their choosing. Feel free to reach out to the organizers (currently Julia Damerow and
-Chris Hill) on USRSE slack ( "@Julia Damerow" and/or "@Chris Hill") or elsewhere if you would like to host (or help with) a call.
+Abbey Roelofs) on USRSE slack ( "@Julia Damerow" and/or "@Abbey Roelofs") or elsewhere if you would like to host (or help with) a call.

--- a/_events/repeated/community-call.md
+++ b/_events/repeated/community-call.md
@@ -7,7 +7,7 @@ event_date: "alternating 2nd Thursday (12:00-1:00pm ET) and 2nd Friday (2:00-3:0
 layout: event
 category: community-call
 time:
-  - - start: 2022-07-14 12:00 ET
+  - - start: 2022-07-14 12:00 EST
 
 # Repeated events information
 repeated: true


### PR DESCRIPTION
## Description
* Add August 2023 Community Call
* Update contact info for community calls on repeated events
* Update timezones for community calls on repeated events (ET instead of EST--they were off by an hour during daylight savings time months)


## Checklist:
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
