### PR TITLE
Fix slack jobs bot

### DIFF
--- a/.github/workflows/jobs-poster.yaml
+++ b/.github/workflows/jobs-poster.yaml
@@ -8,9 +8,9 @@ on:
       - main
 
 jobs:
-  slack-poster:
+  jobs-poster:
     runs-on: ubuntu-latest
-    name: Run Jobs Slack Poster
+    name: Run Jobs Poster
     steps:
       - uses: actions/checkout@v3
         with:
@@ -19,8 +19,6 @@ jobs:
       - id: updater
         name: Job Updater
         uses: rseng/jobs-updater@0.0.13
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         with:
           filename: "_data/jobs.yml"
 
@@ -32,6 +30,9 @@ jobs:
 
           deploy: true
           test: false
+
+          slack_deploy: true
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
 
           # Also deploy to Twitter (all secrets required in repository secrets)
           twitter_deploy: true

--- a/.github/workflows/jobs-poster.yaml
+++ b/.github/workflows/jobs-poster.yaml
@@ -31,6 +31,7 @@ jobs:
           deploy: true
           test: false
 
+          # Deploy to Slack channel
           slack_deploy: true
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
## Description
Fix the slack jobs bot posting process.

v0.0.13 of the jobs-updater action includes mastodon support we want,
but slightly changed the method for slack posting, reflecting that it's
just one of multiple channels where updates can be posted.  This change
fixes our workflow accordingly.

## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.


