### PR TITLE
Add Sept 2023 DiveRSE event

### DIFF
--- a/_events/2023/2023-09-diverse-kaye-sharan.md
+++ b/_events/2023/2023-09-diverse-kaye-sharan.md
@@ -1,0 +1,28 @@
+---
+title: "A conversation about Equity, Diversity, Inclusion and Accessibility (EDIA) in the RSE community: reflections on successes and challenges"
+subtitle: DiveRSE Seminar
+expires: 2023-09-13
+event_date: "September 12, 2023"
+layout: event
+duration: 60
+repeated: false
+category: dei
+time:
+    - - start: 2023-09-12T09:00:00Z
+        end: 2023-09-12T10:00:00Z
+---
+
+
+In this next event in the DiveRSE seminar series on Equity, Diversity and Inclusion within the
+research software community, **Ella Kaye** (Research Software Engineer, University of Warwick)
+and **Malvika Sharan** (Senior Researcher – Open Research at the Alan Turing Institute and
+co-lead of The Turing Way) will converse about their experiences with the RSE community and
+the challenges and successes they’ve encountered when working to improve Equity, Diversity,
+Inclusion and Accessibility (EDIA).
+
+[**Event Website**](https://diverse-rse.github.io/events/2023-09-12)
+
+Please [register for online attendance via Zoom](https://imperial-ac-uk.zoom.us/meeting/register/tJcvcO6tpz4uGNIJRRrFVePCiZd3qEPoGIH6). 
+
+The talk will also be recorded and shared via the
+[Society of Research Software Engineering’s YouTube channel](https://www.youtube.com/@SocRSE).


### PR DESCRIPTION
## Description

This PR adds the next DiveRSE event that takes place in September 2023. 

**NOTE**: Yes, the time is correct. Tuesday 12th September 2023, 09:00-10:00 UTC


## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
