### PR TITLE
Fix Remove Jobs Workflow

### DIFF
--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -37,9 +37,9 @@ jobs:
         # Google Forms is having enormous timeouts
         timeout: 10
         # Exclude these patterns from the checker
-        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov,jobs.bnl.gov,https://www.rd-alliance.org/,https://uwhires.admin.washington.edu/,https://twitter.com/,https://careers.umich.edu/
+        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov,jobs.bnl.gov,https://www.rd-alliance.org/,https://uwhires.admin.washington.edu/,https://careers.umich.edu/,https://twitter.com/us_rse,https://twitter.com/us_rse/status/1447622175133945860,https://twitter.com/iancosden/status/1122937311644323841
         # Exclude these files from the checker
-        exclude_files: README.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
+        exclude_files: README.md,docs/events.md,docs/tests_ci.md,docs/local_previews.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/
 
     - name: Push Fixes
       env:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Want merge permissions?  Join the #website channel in Slack, help out a bit with
 
 ### Checks and Tests
 
+[![Remove Expired Jobs](https://github.com/USRSE/usrse.github.io/actions/workflows/clean-expired-jobs.yaml/badge.svg)](https://github.com/USRSE/usrse.github.io/actions/workflows/clean-expired-jobs.yaml)
+
 When you create a PR, automated tests run; see [docs/tests_ci.md](docs/tests_ci.md) for details.  
 
 What the PR submitter is responsible for:


### PR DESCRIPTION
## Description
The job cleaning workflow has been failing for a few weeks. It was failing due to files that should have been ignored. This updates that.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
