### PR TITLE
Add eScience 2023 workshop

### DIFF
--- a/_events/2023/2023-10-escience.md
+++ b/_events/2023/2023-10-escience.md
@@ -1,0 +1,39 @@
+---
+title: Research Software Engineers in eScience (Workshop at eScience 2023)
+subtitle: Sustainable RSE Ecosystems within eScience
+location: Limassol, Cyprus
+url: https://us-rse.org/rse-escience-2023
+expires: 2023-10-12
+event_date: "October 11, 2023"
+layout: event
+category: workshop
+time:
+    - - start: 2023-10-11T06:00:00Z
+        end: 2023-10-11T09:00:00Z
+---
+
+This workshop is to be held as part of [eScience 2023](https://www.escience-conference.org/2023/),
+which will be held **IN-PERSON**.
+
+Research Software Engineers (RSEs) combine professional software engineering
+expertise with an intimate understanding of research. They are uniquely placed
+in the eScience ecosystem to ensure development of sustainable research
+environments and reproducible research outputs. However, the position of RSEs
+within eScience is still not fully established, with many RSEs not gaining proper
+recognition for their contributions and struggling to find a way to progress their
+careers. The theme of this workshop is sustainable RSE ecosystems, encompassing
+both the role of RSEs in sustainable eScience and making the RSE ecosystem
+itself more sustainable. We intend for this workshop to raise awareness of the
+concept of research software engineers and research software engineering (RSEng),
+as well as to provide an opportunity for RSEs and those interested in RSEng to
+talk about issues and solutions. Anyone involved or interested in RSEng is
+welcome to attend. 
+
+The first half of our workshop will consist of a series of invited talks and
+interactive question/answer. The second half of the program will be discussion-based
+breakouts. We will produce a blog post after the workshop that discusses the
+talks and the breakouts. 
+
+The workshop is October 11th from 9:00 AM - 12:00 PM EEST.
+More information can be found on the
+[workshop website](https://us-rse.org/rse-escience-2023).

--- a/_events/2023/2023-10-escience.md
+++ b/_events/2023/2023-10-escience.md
@@ -9,10 +9,10 @@ layout: event
 category: workshop
 time:
     - - start: 2023-10-11T06:00:00Z
-        end: 2023-10-11T09:00:00Z
+        end: 2023-10-11T09:30:00Z
 ---
 
-This workshop is to be held as part of [eScience 2023](https://www.escience-conference.org/2023/),
+This workshop is part of [eScience 2023](https://www.escience-conference.org/2023/),
 which will be held **IN-PERSON**.
 
 Research Software Engineers (RSEs) combine professional software engineering
@@ -34,6 +34,6 @@ interactive question/answer. The second half of the program will be discussion-b
 breakouts. We will produce a blog post after the workshop that discusses the
 talks and the breakouts. 
 
-The workshop is October 11th from 9:00 AM - 12:00 PM EEST.
+The workshop is October 11th from 09:00 - 12:30 EEST.
 More information can be found on the
 [workshop website](https://us-rse.org/rse-escience-2023).


### PR DESCRIPTION
## Description
Add an event to the US-RSE calendar for the eScience 2023 workshop.

## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
