### PR TITLE
Fix times for SC23 workshop

### DIFF
--- a/_events/2023/2023-11-sc23.md
+++ b/_events/2023/2023-11-sc23.md
@@ -7,13 +7,13 @@ event_date: "November 12, 2023"
 layout: event
 category: workshop
 time:
-    - - start: 2023-11-12T15:30:00Z
-        end: 2023-11-12T19:00:00Z
+    - - start: 2023-11-12T16:00:00Z
+        end: 2023-11-12T19:30:00Z
 ---
 
 We are excited to announce the Research Software Engineers in HPC Workshop (RSE-HPC-2023)
 to be held as part of [SC23](https://sc23.supercomputing.org/) (hybrid event, in Denver, CO and virtually).
-This will be a half-day workshop 8:30pm-noon MST (UTC-7), Sunday, November 12, 2023.
+This will be a half-day workshop 9:00am-12:30pm MST (UTC-7), Sunday, November 12, 2023.
 The theme for this year’s workshop is "Growing the RSE Community."
 
 This workshop will bring together RSEs and allies involved in HPC, from all over the world,


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->

I noticed the times on the RSE-HPC-2023 calendar event are based on last year's schedule instead of this year's.  This PR fixes them.

## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
