### PR TITLE
Fix mastodon link typo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ twitter: us_rse
 github_org: USRSE
 github_repo: usrse.github.io
 linkedin: company/us-rse/
-mastodon: us_rse
+mastodon: @us_rse
 youtube: us_rse
 
 # Twitter card for meta tags


### PR DESCRIPTION
I'm not sure if this is the right place to fix it, but the correct url should be: https://fosstodon.org/@us_rse. Right now it's missing the "@"