### PR TITLE
Update mastodon link in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
         </a>{% endif %}
 
 
-{% if site.mastodon %}<a href="https://fosstodon.org/{{ site.mastodon }}"
+{% if site.mastodon %}<a href="https://fosstodon.org/@{{ site.mastodon }}"
    target="_blank"
    rel="noopener "
   class="button button-icon">


### PR DESCRIPTION
Fixing the link to mastodon in the footer to: https://fosstodon.org/@us_rse. Right now it's missing the "@"