### PR TITLE
Add "501(c)(3) nonprofit" to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="site-footer-inside">
         <p class="site-info"> 
           © US-RSE  •  2021-{{ 'now' | date: "%Y" }}
-          •   US-RSE is a fiscally sponsored project of  <a href="http://communityin.org/" target="_blank">Community Initiatives</a>.
+          •   US-RSE is a fiscally sponsored project of  <a href="http://communityin.org/" target="_blank">Community Initiatives</a>, a 501(c)(3) nonprofit organization.
          </p>
       <div class="social-links">
 


### PR DESCRIPTION
This adds to the footer, after Community initiatives: ", a 501(c)(3) nonprofit organization"

This way it's (more) clear we are part of a nonprofit. 