### PR TITLE
Update Typo Linter

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Check Spelling
-      uses: crate-ci/typos@12c64918956d94e55a2ca8c5cbca111e759f5654 # version 1.13.8
+      uses: crate-ci/typos@master # we should really incorporate all new changes
       with:
         files: ./_posts ./pages ./README.md
         config: ./.github/workflows/typo_config.toml

--- a/.github/workflows/typo_config.toml
+++ b/.github/workflows/typo_config.toml
@@ -1,5 +1,12 @@
-[default.extend-words]
-# Don't correct the surname "Hsi"
-Hsi = "Hsi"
-# Don't correct the acronym NWO
-NWO = "NWO"
+[files]
+extend-exclude = [
+    ".git/",
+    ".github/workflows/typo_config.toml",
+    "assets/js/*.min.*",
+]
+ignore-hidden = true
+[default]
+extend-ignore-re = [
+    "Brain tailoRed stImulation protocoL",
+    "Vas Vasiliadis",
+]

--- a/.github/workflows/typo_config.toml
+++ b/.github/workflows/typo_config.toml
@@ -9,4 +9,8 @@ ignore-hidden = true
 extend-ignore-re = [
     "Brain tailoRed stImulation protocoL",
     "Vas Vasiliadis",
+    "Nam Pho",
+    "SLAC",
+    "Paul Hsi",
+    "NWO"
 ]

--- a/_posts/2019-05-06-usrse-goals.md
+++ b/_posts/2019-05-06-usrse-goals.md
@@ -9,7 +9,7 @@ tags: [governance]
 
 The US-RSE Association is centered around three main goals.  Moving
 forward we aim to target our activities and actions to serving these
-three main goals. Over time we plan to revist and refine these goals as
+three main goals. Over time we plan to revisit and refine these goals as
 the needs and desires of the community change.
 
 


### PR DESCRIPTION
## Description
Our typo version / linter is wildly out of date. I use the same tool for Pyomo, and new versions find new misspellings. This updates the version and modernizes the `typo_config.toml` as well.


## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
