### PR TITLE
bump pull request action to v1.1.0

### DIFF
--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -78,7 +78,7 @@ jobs:
           echo "PULL_REQUEST_BODY=Tributors update automated pull request." >> $GITHUB_ENV
 
       - name: Open Pull Request
-        uses: vsoch/pull-request-action@1.0.24
+        uses: vsoch/pull-request-action@1.1.0
         if: ${{ env.OPEN_PULL_REQUEST == '1' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
This PR fixes the failures with our `update-contributors` action by updating the dependent `pull-request-action` to version 1.1.0.

See https://github.com/vsoch/pull-request-action/pull/100 for more information.

## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
