### PR TITLE
Fix heading typo in Dec23 newsletter

### DIFF
--- a/_posts/newsletters/2023-12-20-newsletter.md
+++ b/_posts/newsletters/2023-12-20-newsletter.md
@@ -155,7 +155,7 @@ The User Experience Working Group (UXWG) is a newly formed working group. Co-cha
 ## Community Calls
  
  
- ### January Community Call 
+### January Community Call 
 
 **Call for Presenters: Present Your Favorite Tools or Project!**
 


### PR DESCRIPTION
Not sure how we missed this in the preview! 

<img width="572" alt="image" src="https://github.com/USRSE/usrse.github.io/assets/5824618/2e423026-a8c7-4450-b4d6-72d2c2c8a889">
