### PR TITLE
Update 2024 SC Members

### DIFF
--- a/pages/about/steering-committee.md
+++ b/pages/about/steering-committee.md
@@ -11,20 +11,23 @@ set_last_modified: true
 
 ### Current Steering Committee
 
-* Nicole Brewer, Arizona State University, 2022-2023, International RSE Council Representative
-* Jeffrey C. Carver, University of Alabama, 2019-2023, Vice Chair & International RSE Council Representative
-* Ian Cosden, Princeton University, 2019-2023, Chair
-* Julia Damerow, Arizona State University, 2021-2024, Treasurer
-* Rinku Gupta, Argonne National Laboratory, 2023-2024, Election Co-Chair
-* Christina Maimone, Northwestern University, 2019-2023
-* Kenton McHenry, University of Illinois at Urbana-Champaign, 2023-2024, Election Co-Chair
-* Miranda Mundt, Sandia National Laboratories, 2023-2024, Secretary & Community Builder Group Representative
+* Keith Beattie, Lawrence Berkeley National Laboratory, 2024-2025
+* Jeffrey C. Carver, University of Alabama, 2019-2025
+* Ian Cosden, Princeton University, 2019-2025
+* Julia Damerow, Arizona State University, 2021-2024
+* Rinku Gupta, Argonne National Laboratory, 2023-2024
+* Alex Koufos, Stanford University, 2024-2025
+* Kenton McHenry, University of Illinois at Urbana-Champaign, 2023-2024
+* Miranda Mundt, Sandia National Laboratories, 2023-2024
+* Abbey Roelofs, University of Michigan, 2024-2025
 
 ### Former Steering Committee Members
 
+* Nicole Brewer, Arizona State University, 2022-2023
 * Chris Hill, MIT, 2019-2022
 * Sandra Gesing, University of Illinois Discovery Partner Institute, 2019-2023
 * Daniel S. Katz, University of Illinois at Urbana-Champaign, 2019-2022
+* Christina Maimone, Northwestern University, 2019-2023
 * Lance Parsons, Princeton University, 2019-2022
 * Charles Ferenbaugh, Los Alamos National Laboratory, 2019-2021
 * Jordan Perr-Sauer, National Renewable Energy Laboratory, 2019-2020


### PR DESCRIPTION
This updates the Steering Committee members by 
* adding new members
* updating former member list

The 2023 committee roles (e.g. Chair, Treasurer) have been removed and left of until the new committee has decided for 2024. This page will be updated once that happens. 