### PR TITLE
Change "grants" -> "funds"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -105,7 +105,7 @@
       link: resources/rses/
     - name: Organizations
       link: resources/organizations/
-    - name: Grants and Awards
+    - name: Funds and Awards
       link: funds-and-awards/
 
 - name: External


### PR DESCRIPTION
Changes the wording from grants to funds in the drop down "Resources" menu. 