### PR TITLE
Update clean-expired-jobs.yaml

### DIFF
--- a/.github/workflows/clean-expired-jobs.yaml
+++ b/.github/workflows/clean-expired-jobs.yaml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install required packages


### PR DESCRIPTION
## Description
The expired jobs cleaner has been failing because of a Node 16 deprecation in some of the actions it uses.  This change updates the workflow to use the newer versions of those actions based on Node 20.

GitHub published additional information about the changes here:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
