### PR TITLE
resume scipy2022 urlchecking

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -40,7 +40,7 @@ jobs:
         timeout: 10
 
         # Exclude these patterns from the checker
-        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov,jobs.bnl.gov,https://www.rd-alliance.org/,https://uwhires.admin.washington.edu/,https://careers.umich.edu/,https://twitter.com/us_rse,https://twitter.com/us_rse/status/1447622175133945860,https://twitter.com/iancosden/status/1122937311644323841,www.scipy2022.scipy.org
+        exclude_patterns: supercomputing.org,https://pace.gatech.edu,https://www.linkedin.com,jobs.colorado.edu,zoom.us,danielskatz.org,usrse.github.io.wiki.git,ornl.gov,jobs.bnl.gov,https://www.rd-alliance.org/,https://uwhires.admin.washington.edu/,https://careers.umich.edu/,https://twitter.com/us_rse,https://twitter.com/us_rse/status/1447622175133945860,https://twitter.com/iancosden/status/1122937311644323841
 
         # Exclude these files from the checker
         exclude_files: README.md,docs/events.md,docs/tests_ci.md,docs/local_previews.md,SocialNetworks.yml,map.yml,_config.yml,tests/test_,.github/workflows,_posts/newsletters/


### PR DESCRIPTION
## Description
The scipy2022 conference site has been restored.  Revert the change in https://github.com/USRSE/usrse.github.io/pull/1405/commits/53956d3b2831d784ba9924e4ef373318d280286a / #1405.


## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
