### PR TITLE
Add Princeton Assoc Dir of RSEng Job

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -1,3 +1,8 @@
+- expires: 2024-05-15
+  location: Princeton University, Princeton, NJ
+  name: Associate Director, Research Software Engineering
+  posted: 2024-02-19
+  url: https://main-princeton.icims.com/jobs/18555/associate-director%2c-research-software-engineering/job
 - expires: 2024-06-21
   location: Stanford University, Stanford, CA or remote
   name: Software Engineer


### PR DESCRIPTION
New Associate Director, Research Software Engineering job at Princeton. Totally biased opinion, but this sounds _really cool_. 