### PR TITLE
remove missing PSC internships

### DIFF
--- a/_data/internships.yml
+++ b/_data/internships.yml
@@ -3,21 +3,6 @@
   name: Associate in Research Software Engineering - Temporary
   posted: 2024-02-14
   url: https://main-princeton.icims.com/jobs/18493/associate-in-research-software-engineering---temporary/job
-- expires: 2024-03-15
-  location: Pittsburgh Supercomputing Center, Pittsburgh, PA
-  name: Anton Data Portal Internship
-  posted: 2024-02-01
-  url: https://www.psc.edu/anton-data-portal-internship/
-- expires: 2024-03-15
-  location: Pittsburgh Supercomputing Center, Pittsburgh, PA
-  name: Molecular Dynamics Internship
-  posted: 2024-02-01
-  url: https://www.psc.edu/molecular-dynamics-internship/
-- expires: 2024-03-15
-  location: Pittsburgh Supercomputing Center, Pittsburgh, PA
-  name: Software Packaging Internship
-  posted: 2024-02-01
-  url: https://www.psc.edu/software-packaging-internship/
 - expires: 2024-03-08
   location: Pittsburgh Supercomputing Center, Pittsburgh, PA
   name: Brain Image Library Student Research Programmer

--- a/_data/related-jobs.yml
+++ b/_data/related-jobs.yml
@@ -3,11 +3,6 @@
   name: Assistant Professor, Teaching Track, in Software Development and Design
   posted: 2024-02-12
   url: https://apply.interfolio.com/140131
-- expires: 2024-04-07
-  location: Tufts University, Remote
-  name: HPC Systems Engineer
-  posted: 2024-02-07
-  url: https://jobs.tufts.edu/jobs/20073?lang=en-us
 - expires: 2024-03-02
   location: BioTeam, Inc., Remote
   name: Senior HPC Consultant, Life Sciences


### PR DESCRIPTION
## Description
Remove 3 missing PSC internships, which are now 404 on the PSC site.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
