### PR TITLE
Add UVM RC to RSE group list

### DIFF
--- a/_data/rse-groups.yml
+++ b/_data/rse-groups.yml
@@ -82,3 +82,6 @@
 - institution: Georgia Institute of Technology
   name: Scientific Software Engineering Center
   url: https://ssecenter.cc.gatech.edu/
+- institution: University of Vermont
+  name: Research Computing
+  url: https://www.uvm.edu/it/research-computing


### PR DESCRIPTION
Adds Univ of Vermont Research Computing to the organizational list of RSE groups