### PR TITLE
Add a workflow to post related jobs to slack

### DIFF
--- a/.github/workflows/jobs-poster-related.yaml
+++ b/.github/workflows/jobs-poster-related.yaml
@@ -1,0 +1,50 @@
+name: Post New Jobs
+
+on:
+  push:
+    paths:
+      - '_data/related-jobs.yml'
+    branches:
+      - main
+
+jobs:
+  jobs-poster:
+    runs-on: ubuntu-latest
+    name: Run Jobs Poster
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - id: updater
+        name: Job Updater
+        uses: rseng/jobs-updater@0.0.13
+        with:
+          filename: "_data/related-jobs.yml"
+
+          # Fields to include (all but url will have title before)
+          keys: "name,location,url"
+
+          # Field to determine job uniqueness
+          unique: "url"
+
+          hashtag: "#RSEng-related"
+
+          deploy: true
+          test: false
+
+          # Deploy to Slack channel
+          slack_deploy: true
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+
+          # Don't deploy to social media
+          twitter_deploy: false
+          mastodon_deploy: false
+
+      - run: echo ${{ steps.updater.outputs.fields }}
+        name: Show Fields Used
+        shell: bash
+
+      - run: echo ${{ steps.updater.outputs.matrix }}
+        name: Show New Jobs
+        shell: bash


### PR DESCRIPTION
## Description

This adds a workflow to post related USEng jobs to the USRSE slack `jobs` channel but *not* to social media (I think that's the general consensus when we've talked about it before).

Notably, the only difference between jobs and related jobs will be the hashtag used:
* Jobs: `#RSEng`
  ![image](https://github.com/USRSE/usrse.github.io/assets/7882693/11a26b5f-8b65-4ed9-a97b-37dfcf55c663)

* Related Jobs: `#RSEng-related`

I think this is fine, but I could see wanting more visual distinction between the types of jobs. That, however, would require updates to the [jobs-updater action](https://github.com/rseng/jobs-updater).

## Checklist:
<!---Check these off after you create the PR --->
- [X] ~~I have previewed changes locally or with CircleCI (runs when PR is created)~~ **N/A**
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
