### PR TITLE
Updates the US-RSE logo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,8 +9,8 @@ baseurl: ""  # for testing, also check .circleci/circle_urls.sh
 title-img: /assets/img/main_logo_transparent.png  # baseurl will be prepended
 twitter-img: /assets/img/main_logo_transparent.png  # url + baseurl will be prepended
 banner: /assets/img/main_logo_transparent.png
-# icon: /assets/img/main_logo_transparent.png
-icon: /assets/img/USRSE_Pride_6ColorChevronsSquare.png
+icon: /assets/img/main_logo_transparent.png
+# icon: /assets/img/USRSE_Pride_6ColorChevronsSquare.png
 domain: https://us-rse.org
 
 email: contact@us-rse.org

--- a/_data/callouts/home.yml
+++ b/_data/callouts/home.yml
@@ -14,10 +14,9 @@ items:
     link_name: >
       "Research Software Engineers: Creating a Career Path—and a Career"
     link_name: Learn More
-  - title: US-RSE'24 Paper and Notebooks Deadline
+  - title: 2024 US-RSE Community Awards Winners Announced
     subtitle: >
-      The deadline for submitting a paper or notebook to US-RSE'24, happening
-      in Albuquerque, NM, October 15-17, is on June 3rd. Consider submitting
-      to our second annual conference!
-    link: https://us-rse.org/usrse24/participate/
+      The 2024 Community Awards winners are: Daniel S. Katz for US-RSE Impact
+      Award and Christina Maimone for US-RSE Excellence in Service Award.
+    link: https://us-rse.org/community-awards/
     link_name: Learn More

--- a/pages/index.md
+++ b/pages/index.md
@@ -5,8 +5,6 @@ show_hero: true
 callouts: home
 permalink: /
 full_width: true
-hero_link: 2024-06-01-pride-month
-hero_link_text: Celebrate Pride Month with US-RSE!
 ---
 
 <div class="card" style="padding:50px; margin-top:-50px">


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->
Reverts the US-RSE Pride logo to our default. Also updates the callouts, which closes #1511

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
