### PR TITLE
fix: expire repeating event instead of deleting it

### DIFF
--- a/_events/repeated/dei-working-group-call.md
+++ b/_events/repeated/dei-working-group-call.md
@@ -1,0 +1,27 @@
+---
+title: Diversity, Equity, and Inclusion Working Group Call
+subtitle:
+location: Virtual
+expires: 2024-08-01
+event_date: "every other Wednesday at 3PM Eastern"
+layout: event
+category: dei
+time:
+  - - start: 2023-11-08 15:00 EST
+
+repeated: true
+rrule:
+  - DTSTART;TZID=America/New_York:20231108T150000
+  - RRULE:FREQ=WEEKLY;INTERVAL=2;WKST=SU;BYDAY=WE
+  - RDATE;TZID=America/New_York:20231108T150000
+---
+
+The Diversity, Equity, and Inclusion Working Group meets for one hour, every
+other Wednesday at 3 pm (ET), Noon (PT).
+
+See the [DEI Working Group webpage](https://us-rse.org/wg/dei/) for more
+information about the group and how to get involved.
+
+You can also find us in the
+[`#wg-diversity-equity-inclusion`](https://usrse.slack.com/archives/C03V3CY5MSQ)
+channel on the US-RSE Slack workspace.

--- a/_posts/2024-06-01-pride-month.md
+++ b/_posts/2024-06-01-pride-month.md
@@ -43,7 +43,7 @@ how they will celebrate and reflect on pride this month. This will likely come
 in many different forms for each individual. Checkout the resources below to
 inspire your introspection throughout the month. Finally, please consider
 joining us at our [bi-weekly DEI-WG
-call](https://us-rse.org/events/repeated/dei-working-group-call/) (the next on
+call](link _events/repeated/dei-working-group-call.md) (the next on
 is on Wednesday, June 19th at 12PT/3ET).
 
 We'd also like to bring to your attention the


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->
Restore a old repeating event to preserve history and fix links. Instead, expire the event.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
