### PR TITLE
fix: Rafael Mudafort's bio link

### DIFF
--- a/_posts/2022-06-04-info-interview-form-rse-group.md
+++ b/_posts/2022-06-04-info-interview-form-rse-group.md
@@ -28,7 +28,7 @@ Members of the working group that drafted these questions
 were
 [Abbey Roelofs (UM)](https://lsa.umich.edu/technology-services/people/research-computing-and-infrastructure/aheinlei.html),
 [Cherry Liu (GaTech)](https://www.cc.gatech.edu/people/fang-cherry-liu),
-[Rafael Mudafort (NREL)](https://www.nrel.gov/research/staff/rafael-mudafort.html),
+[Rafael Mudafort (NREL)](https://research-hub.nrel.gov/en/persons/rafael-mudafort),
 [David Nicholson (EI)](https://nicholdav.info/),
 [Zhiyong Zhang (Stanford)](https://profiles.stanford.edu/zhiyong-zhang),
 [Claire Wyatt (SSI)](https://society-rse.org/about/governance/claire-wyatt/),


### PR DESCRIPTION
## Description
Update Rafael Mudafort's bio link to its new location

This change was discussed with Rafael on Slack.  It should address the relevant recent failures in CI.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
