### PR TITLE
Fix broken UK RSE survey links

### DIFF
--- a/_posts/2021-11-22-rse-survey.md
+++ b/_posts/2021-11-22-rse-survey.md
@@ -18,3 +18,5 @@ The results of this survey will be greatly beneficial to US-RSE as we move forwa
 The more responses we have, the better our knowledge.
 
 For more details on the survey visit [https://software.ac.uk/news/complete-international-rse-survey-and-help-us-understand-rse-community](https://software.ac.uk/news/complete-international-rse-survey-and-help-us-understand-rse-community). 
+
+**NOTE: this survey has ended and the results can be found [here](https://softwaresaved.github.io/international-survey-2022/).**

--- a/_posts/2021-11-22-rse-survey.md
+++ b/_posts/2021-11-22-rse-survey.md
@@ -18,10 +18,3 @@ The results of this survey will be greatly beneficial to US-RSE as we move forwa
 The more responses we have, the better our knowledge.
 
 For more details on the survey visit [https://software.ac.uk/news/complete-international-rse-survey-and-help-us-understand-rse-community](https://software.ac.uk/news/complete-international-rse-survey-and-help-us-understand-rse-community). 
-
-**You can complete the 2021 RSE survey in
-[English](https://softwaresaved.limequery.com/386272?lang=en),
-[French](https://softwaresaved.limequery.com/386272?lang=fr),
-[German](https://softwaresaved.limequery.com/386272?lang=de-informal),
-or [Spanish](https://softwaresaved.limequery.com/386272?lang=es).**
-

--- a/_posts/history/2022-02-06-a-brief-history-of-usrse.md
+++ b/_posts/history/2022-02-06-a-brief-history-of-usrse.md
@@ -93,7 +93,7 @@ Dan also reached out to other organizations that might have interest, such as Ca
 
 > Subject: [campuschampions] Research Software Engineer survey
 > 
-> Are you an Research Software Engineer in the United States? Do you work professionally in software in a research environment, at least partly writing code for other people? Your job title might be research programmer, facilitator, postdoctoral researcher, or research assistant. If so, please fill out this short survey, being run by the UK Software Sustainability Institute with the idea of understanding and helping to organize the US RSE community: [http://bit.ly/US-RSE-2017-survey](http://bit.ly/US-RSE-2017-survey) (Please feel free to forward this to others, particularly possible RSEs in your center or at your university.)
+> Are you an Research Software Engineer in the United States? Do you work professionally in software in a research environment, at least partly writing code for other people? Your job title might be research programmer, facilitator, postdoctoral researcher, or research assistant. If so, please fill out this short survey, being run by the UK Software Sustainability Institute with the idea of understanding and helping to organize the US RSE community: http://bit.ly/US-RSE-2017-survey (Please feel free to forward this to others, particularly possible RSEs in your center or at your university.)
 >
 > -- 
 > Daniel S. Katz

--- a/_posts/history/2022-02-06-a-brief-history-of-usrse.md
+++ b/_posts/history/2022-02-06-a-brief-history-of-usrse.md
@@ -93,7 +93,7 @@ Dan also reached out to other organizations that might have interest, such as Ca
 
 > Subject: [campuschampions] Research Software Engineer survey
 > 
-> Are you an Research Software Engineer in the United States? Do you work professionally in software in a research environment, at least partly writing code for other people? Your job title might be research programmer, facilitator, postdoctoral researcher, or research assistant. If so, please fill out this short survey, being run by the UK Software Sustainability Institute with the idea of understanding and helping to organize the US RSE community: http://bit.ly/US-RSE-2017-survey (Please feel free to forward this to others, particularly possible RSEs in your center or at your university.)
+> Are you an Research Software Engineer in the United States? Do you work professionally in software in a research environment, at least partly writing code for other people? Your job title might be research programmer, facilitator, postdoctoral researcher, or research assistant. If so, please fill out this short survey, being run by the UK Software Sustainability Institute with the idea of understanding and helping to organize the US RSE community: http<nolink>://bit.ly/US-RSE-2017-survey (Please feel free to forward this to others, particularly possible RSEs in your center or at your university.)
 >
 > -- 
 > Daniel S. Katz


### PR DESCRIPTION
## Description
Fix some broken UK RSE survey links that are causing urlcheck failures.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
