### PR TITLE
Update Steering Committee for 2025 cohort

### DIFF
--- a/pages/about/steering-committee.md
+++ b/pages/about/steering-committee.md
@@ -11,23 +11,24 @@ set_last_modified: true
 
 ### Current Steering Committee
 
-* Keith Beattie, Lawrence Berkeley National Laboratory, 2024-2025, Election Co-Chair & International RSE Council Representative
-* Jeffrey C. Carver, University of Alabama, 2019-2025, Vice Chair
-* Ian Cosden, Princeton University, 2019-2025, Chair
-* Julia Damerow, Arizona State University, 2021-2024, Treasurer
-* Rinku Gupta, Argonne National Laboratory, 2023-2024, International RSE Council Representative
-* Alex Koufos, Stanford University, 2024-2025, Election Co-Chair
-* Kenton McHenry, University of Illinois at Urbana-Champaign, 2023-2024, Community Builder Group Representative
-* Miranda Mundt, Sandia National Laboratories, 2023-2024, Secretary
-* Abbey Roelofs, University of Michigan, 2024-2025, Deputy Treasurer
+* Keith Beattie, Lawrence Berkeley National Laboratory, 2024-2025
+* Jeffrey C. Carver, University of Alabama, 2019-2025
+* Cordero Core, University of Washington, 2025-2026
+* Ian Cosden, Princeton University, 2019-2025
+* Julia Damerow, Arizona State University, 2021-2026
+* Alex Koufos, Stanford University, 2024-2025
+* Kenton McHenry, University of Illinois at Urbana-Champaign, 2023-2026
+* Miranda Mundt, Sandia National Laboratories, 2023-2026
+* Abbey Roelofs, University of Michigan, 2024-2025
 
 ### Former Steering Committee Members
 
+* Rinku Gupta, Argonne National Laboratory, 2023-2024
 * Nicole Brewer, Arizona State University, 2022-2023
-* Chris Hill, MIT, 2019-2022
 * Sandra Gesing, University of Illinois Discovery Partner Institute, 2019-2023
-* Daniel S. Katz, University of Illinois at Urbana-Champaign, 2019-2022
 * Christina Maimone, Northwestern University, 2019-2023
+* Chris Hill, MIT, 2019-2022
+* Daniel S. Katz, University of Illinois at Urbana-Champaign, 2019-2022
 * Lance Parsons, Princeton University, 2019-2022
 * Charles Ferenbaugh, Los Alamos National Laboratory, 2019-2021
 * Jordan Perr-Sauer, National Renewable Energy Laboratory, 2019-2020


### PR DESCRIPTION
This updates the Steering Committee membership for 2025. Once roles (e.g. chair) have been decided, we'll update. 

Also, I changed the former members to be chronological by final year (alphabetical within year). That is, the most recent members are listed first.  