### PR TITLE
add june community call

### DIFF
--- a/_events/2025/2025-06-community-call.md
+++ b/_events/2025/2025-06-community-call.md
@@ -1,0 +1,19 @@
+---
+title: June 2025 Community Call
+expires: 2025-06-13
+event_date: "June 13, 2025"
+layout: event
+duration: 60
+repeated: false
+category: community-call
+time:
+    - - start: 2025-04-13T18:00:00Z
+        end: 2025-04-13T19:00:00Z
+---
+
+Our **June Community Call** will be all about **AI in Research Software Engineering** on Friday, June 13, at 2pm ET/1pm CT/12pm MT/11am PT.
+
+It's been almost two years since we talked about AI, ChatGPT, and LLMs in RSEng, and a lot has changed in that time! Let's get together and share how we're using these tools today to write code, check code, or otherwise help out in our roles as RSEs. What do they mean for our job? How are they best deployed? Do they create trustworthy code? Or maybe you use them for research rather than for creating code for research? What do they mean for the next generation of research software engineers? These and so many more questions will be discussed at our next community call. Join us and share your experiences and opinions!
+
+#### Registration details
+Information on how to register for the Zoom meeting will be sent via email and posted in the #general channel on Slack. The registration link can also be found in the Channel Overview and Bookmarks of the #communitycalls channel on Slack.


### PR DESCRIPTION
## Description
adds June community call to community call section of events page. Uses previous April Community Call as template with replaced date and abstract from the planning doc.
