### PR TITLE
Add UFIT Research Computing to RSE Group page

### DIFF
--- a/_data/rse-groups.yml
+++ b/_data/rse-groups.yml
@@ -94,4 +94,7 @@
 - institution: Dartmouth College
   name: Research Software Engineering
   url: https://rc.dartmouth.edu/index.php/research-software-engineering/
+- institution: University of Florida
+  name: UFIT Research Computing
+  url: https://www.rc.ufl.edu
   


### PR DESCRIPTION
This adds the UFIT RSE group to the list. Submitted via the google form as response #19. 