### PR TITLE
Update code review working group information

### DIFF
--- a/pages/wg/code-review.md
+++ b/pages/wg/code-review.md
@@ -9,15 +9,15 @@ set_last_modified: true
 
 # Overview
 
-This working group grew out of a BoF at the US-RSE conference. The chairs,
-listed below, were two of the panelists in the BoF Discussion. It was evident
+This working group grew out of a BoF at the US-RSE conference. The original chairs,
+Jeff Carver and Troy Comi, were two of the panelists in the BoF Discussion. It was evident
 from the discussion that there was a strong desire to continue this discussion
 beyond the BoF. 
 
 The goal of this working group is to build a community of RSEs who are
 interested in code review. The working group will provide a forum to gather
 resources related to code review, discuss the use of code review in research
-software project, and seek help in conducting code reviews. 
+software project, and host code-review-related activities for the US-RSE community. 
 
 To get involved, visit the
 [`#wg-code-review`](https://usrse.slack.com/messages/wg-code-review) channel


### PR DESCRIPTION
## Description
The description of the code review working group was no longer accurate; this change updates it to correctly reflect what the group does and who was originally involved.


## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
