### PR TITLE
Add UC Davis Group

### DIFF
--- a/_data/rse-groups.yml
+++ b/_data/rse-groups.yml
@@ -103,3 +103,6 @@
 - institution: Boston University
   name: Software & Application Innovation Lab (SAIL)
   url: https://sail.bu.edu
+- institution: University of California Davis
+  name: Life Science Research Software Engineering Group
+  url: 


### PR DESCRIPTION
This adds the UC Davis Life Science Research Software Engineering Group (form submission 22). The submitter didn't provide a URL. I emailed last week to ask what URL to use (google wasn't helpful) and have not yet received a response.
I'll make this a draft until we get a response, or decide to publish without a URL 