### PR TITLE
feat(admin): groups subsystem + public refactor

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -18,6 +18,8 @@ import { OrganizationMergeWizardPage } from "./pages/organizations/OrganizationM
 import { VocabDetailPage } from "./pages/vocab/VocabDetailPage";
 import { VocabListPage } from "./pages/vocab/VocabListPage";
 import { VocabQueuePage } from "./pages/vocab/VocabQueuePage";
+import { GroupDetailPage } from "./pages/groups/GroupDetailPage";
+import { GroupsListPage } from "./pages/groups/GroupsListPage";
 
 export function App() {
   const { user: workosUser, isLoading: authLoading } = useAuth();
@@ -64,7 +66,8 @@ export function App() {
         <Route path="vocab/:kind/:id" element={<VocabDetailPage />} />
         <Route path="vocab/:kind" element={<VocabListPage />} />
         <Route path="vocab" element={<VocabQueuePage />} />
-        <Route path="groups" element={<ComingSoon number="04" label="Groups" blurb="Working, affinity, and regional groups. Chair assignments and group page content lifecycle." />} />
+        <Route path="groups/:id" element={<GroupDetailPage />} />
+        <Route path="groups" element={<GroupsListPage />} />
         <Route path="events" element={<ComingSoon number="05" label="Events" blurb="Event creation and approval, committee assignment, session scheduling, attendance, and sponsor wiring." />} />
         <Route path="recognition" element={<ComingSoon number="06" label="Recognition" blurb="Awards lifecycle, mentorship pairings, and community contribution logging — the source of dossier badges." />} />
         <Route path="settings" element={<ComingSoon number="07" label="Settings" blurb="Super-admin operations, integration toggles, and global flags." />} />

--- a/apps/admin/src/components/StatusDot.tsx
+++ b/apps/admin/src/components/StatusDot.tsx
@@ -1,0 +1,56 @@
+type StatusDotKind = "pending" | "approved" | "rejected";
+
+interface StatusDotProps {
+  status: StatusDotKind;
+  /** Size hint. Default "md" (7px) suits dense list rows. "sm" (5px)
+   *  pairs with marginalia-sized type. */
+  size?: "sm" | "md";
+  className?: string;
+}
+
+/**
+ * Tiny circular status indicator — the three-state vocab signal
+ * (pending / approved / rejected) as a glyph rather than a word.
+ * Used on list/index surfaces where horizontal column space is at a
+ * premium and the eye scans dozens of rows; detail pages keep the
+ * spelled-out word because individual rows there earn their space.
+ *
+ * Aesthetic register: editorial atlas. No animation (the topbar's
+ * pulse-soft is reserved for "live now" state, and re-using it here
+ * would dilute that signal). Solid fill, no border, sized to read as
+ * a typographic dingbat rather than a UI pill.
+ *
+ * Accessibility: color alone is hostile to colorblind users and
+ * useless to screen readers. The element carries role="img" with an
+ * aria-label and a native title tooltip so the meaning is always
+ * available — by hover, by keyboard focus (assistive), and by screen
+ * reader announcement.
+ */
+const COLOR: Record<StatusDotKind, string> = {
+  pending: "var(--color-warning-700)",
+  approved: "var(--color-success-700)",
+  rejected: "var(--color-danger-700)",
+};
+
+const LABEL: Record<StatusDotKind, string> = {
+  pending: "Pending review",
+  approved: "Approved",
+  rejected: "Rejected",
+};
+
+export function StatusDot({ status, size = "md", className }: StatusDotProps) {
+  const px = size === "sm" ? 5 : 7;
+  return (
+    <span
+      role="img"
+      aria-label={LABEL[status]}
+      title={LABEL[status]}
+      className={`inline-block rounded-full align-middle ${className ?? ""}`}
+      style={{
+        width: `${px}px`,
+        height: `${px}px`,
+        background: COLOR[status],
+      }}
+    />
+  );
+}

--- a/apps/admin/src/hooks/useActorContext.ts
+++ b/apps/admin/src/hooks/useActorContext.ts
@@ -43,6 +43,21 @@ const INITIAL: State = { status: "idle", actor: null, error: null };
  * Loads /api/admin/me. Mirrors the public-app useCurrentMember pattern.
  * Polls every 60s while signed in so role changes propagate without a
  * full page reload (per the spec's token-doesn't-refresh tradeoff).
+ *
+ * Background polls MUST be silent. The initial mount can flip status
+ * to "loading" because no actor is on screen yet, but a subsequent
+ * poll that does the same thing causes App.tsx to render its
+ * <FullScreenStatus message="Loading actor context…" /> scrim and
+ * unmount the current admin route — which destroys any in-flight form
+ * state (drafts, scroll position, dropdown selections). On a 60s
+ * cadence that's catastrophic for the admin's actual workflow.
+ *
+ * The fix: poll-mode fetches only mutate state when the response
+ * carries new information. Successful refreshes replace the actor
+ * object silently; a 403 still surfaces (the user lost access — that
+ * IS a meaningful change worth showing); transient errors are logged
+ * and discarded so the admin doesn't see "Couldn't load admin context"
+ * on a momentary network blip.
  */
 export function useActorContext(): State & { refetch: () => void } {
   const { user: workosUser, isLoading: authLoading } = useAuth();
@@ -50,9 +65,12 @@ export function useActorContext(): State & { refetch: () => void } {
   const [state, setState] = useState<State>(INITIAL);
   const tokenRef = useRef(0);
 
-  const fetchActor = useCallback(async () => {
+  const fetchActor = useCallback(async (options?: { silent?: boolean }) => {
+    const silent = options?.silent === true;
     const token = ++tokenRef.current;
-    setState({ status: "loading", actor: null, error: null });
+    if (!silent) {
+      setState({ status: "loading", actor: null, error: null });
+    }
     try {
       const res = await apiFetch("/admin/me");
       if (tokenRef.current !== token) return;
@@ -62,6 +80,8 @@ export function useActorContext(): State & { refetch: () => void } {
         return;
       }
       if (res.status === 403) {
+        // Forbidden is a meaningful change even on a silent poll —
+        // the admin lost access and needs to know.
         setState({ status: "forbidden", actor: null, error: null });
         return;
       }
@@ -78,6 +98,10 @@ export function useActorContext(): State & { refetch: () => void } {
           setState({ status: "user_pending", actor: null, error: null });
           return;
         }
+        if (silent) {
+          console.warn("/admin/me returned 404 during silent refresh");
+          return;
+        }
         setState({
           status: "error",
           actor: null,
@@ -87,6 +111,10 @@ export function useActorContext(): State & { refetch: () => void } {
         });
         return;
       }
+      if (silent) {
+        console.warn(`/admin/me returned ${res.status} during silent refresh`);
+        return;
+      }
       setState({
         status: "error",
         actor: null,
@@ -94,6 +122,13 @@ export function useActorContext(): State & { refetch: () => void } {
       });
     } catch (e) {
       if (tokenRef.current !== token) return;
+      if (silent) {
+        console.warn(
+          "/admin/me errored during silent refresh:",
+          e instanceof Error ? e.message : String(e)
+        );
+        return;
+      }
       setState({
         status: "error",
         actor: null,
@@ -110,12 +145,15 @@ export function useActorContext(): State & { refetch: () => void } {
       return;
     }
     void fetchActor();
-    const interval = window.setInterval(() => void fetchActor(), 60_000);
+    const interval = window.setInterval(
+      () => void fetchActor({ silent: true }),
+      60_000
+    );
     return () => {
       tokenRef.current++;
       window.clearInterval(interval);
     };
   }, [authLoading, workosUser, fetchActor]);
 
-  return { ...state, refetch: fetchActor };
+  return { ...state, refetch: () => void fetchActor() };
 }

--- a/apps/admin/src/pages/groups/GroupDetailPage.tsx
+++ b/apps/admin/src/pages/groups/GroupDetailPage.tsx
@@ -1,0 +1,706 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useApi } from "@us-rse/auth-shell";
+import { useShellActor } from "../../layout/AdminShell";
+import { EditorialInput } from "../../components/EditorialInput";
+import { EditorialTextarea } from "../../components/EditorialTextarea";
+
+type GroupType = "working_group" | "affinity_group" | "regional_group";
+type Tab = "identity" | "content" | "roster" | "lifecycle";
+
+interface GroupDetail {
+  ok: true;
+  group: {
+    id: string;
+    name: string;
+    slug: string;
+    type: GroupType;
+    description: string | null;
+    charter: string | null;
+    slackChannel: string | null;
+    links: Array<{ label: string; url: string }>;
+    isActive: boolean;
+    isPublished: boolean;
+    deletedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  members: Array<{
+    userId: string;
+    email: string;
+    displayName: string | null;
+    role: "member" | "chair" | "co_chair";
+    joinedAt: string;
+  }>;
+  recentAudit: Array<{
+    id: string;
+    action: string;
+    targetType: string;
+    targetId: string;
+    createdAt: string;
+  }>;
+}
+
+const TYPE_LABELS: Record<GroupType, string> = {
+  working_group: "Working group",
+  affinity_group: "Affinity group",
+  regional_group: "Regional group",
+};
+
+export function GroupDetailPage() {
+  const apiFetch = useApi();
+  const actor = useShellActor();
+  const { id } = useParams<{ id: string }>();
+
+  const [data, setData] = useState<GroupDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("identity");
+  const [acting, setActing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Identity draft state
+  const [draftDescription, setDraftDescription] = useState("");
+  const [draftSlackChannel, setDraftSlackChannel] = useState("");
+  // Content draft state
+  const [draftCharter, setDraftCharter] = useState("");
+  const [draftLinks, setDraftLinks] = useState<Array<{ label: string; url: string }>>([]);
+  // Roster picker state
+  const [chairSearch, setChairSearch] = useState("");
+  const [chairResults, setChairResults] = useState<
+    Array<{ id: string; displayName: string | null; email: string }>
+  >([]);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setError(null);
+    try {
+      const res = await apiFetch(`/admin/groups/${id}`);
+      if (!res.ok) {
+        setError(`/admin/groups/${id} responded ${res.status}`);
+        return;
+      }
+      const body = (await res.json()) as GroupDetail;
+      setData(body);
+      setDraftDescription(body.group.description ?? "");
+      setDraftSlackChannel(body.group.slackChannel ?? "");
+      setDraftCharter(body.group.charter ?? "");
+      setDraftLinks(body.group.links ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [apiFetch, id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Debounced member search for the chair picker.
+  useEffect(() => {
+    const term = chairSearch.trim();
+    if (term.length < 2) {
+      setChairResults([]);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      try {
+        const sp = new URLSearchParams({ q: term, limit: "10", status: "active" });
+        const res = await apiFetch(`/admin/users?${sp}`);
+        if (!res.ok) return;
+        const body = (await res.json()) as {
+          rows: Array<{ id: string; displayName: string | null; email: string }>;
+        };
+        setChairResults(body.rows);
+      } catch {
+        /* silent — picker is a convenience */
+      }
+    }, 200);
+    return () => clearTimeout(handle);
+  }, [apiFetch, chairSearch]);
+
+  async function saveIdentity() {
+    if (!data) return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const body: Record<string, unknown> = {};
+      if (draftDescription !== (data.group.description ?? "")) {
+        body.description = draftDescription.trim() || null;
+      }
+      if (draftSlackChannel !== (data.group.slackChannel ?? "")) {
+        body.slackChannel = draftSlackChannel.trim() || null;
+      }
+      if (Object.keys(body).length === 0) {
+        setActing(false);
+        return;
+      }
+      const res = await apiFetch(`/admin/groups/${data.group.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string } | null;
+        setActionError(err?.message ?? `PATCH responded ${res.status}`);
+        return;
+      }
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function saveContent() {
+    if (!data) return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const cleanLinks = draftLinks.filter((l) => l.label.trim() && l.url.trim());
+      const body: Record<string, unknown> = {};
+      if (draftCharter !== (data.group.charter ?? "")) {
+        body.charter = draftCharter.trim() || null;
+      }
+      if (JSON.stringify(cleanLinks) !== JSON.stringify(data.group.links)) {
+        body.links = cleanLinks;
+      }
+      if (Object.keys(body).length === 0) {
+        setActing(false);
+        return;
+      }
+      const res = await apiFetch(`/admin/groups/${data.group.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string } | null;
+        setActionError(err?.message ?? `PATCH responded ${res.status}`);
+        return;
+      }
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function assignChair(userId: string, role: "chair" | "co_chair") {
+    if (!data) return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const res = await apiFetch(`/admin/groups/${data.group.id}/chairs`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, role }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string } | null;
+        setActionError(err?.message ?? `POST responded ${res.status}`);
+        return;
+      }
+      setChairSearch("");
+      setChairResults([]);
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function removeChair(userId: string) {
+    if (!data) return;
+    if (!window.confirm("Demote this chair to a regular member?")) return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const res = await apiFetch(`/admin/groups/${data.group.id}/chairs/${userId}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string } | null;
+        setActionError(err?.message ?? `DELETE responded ${res.status}`);
+        return;
+      }
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function togglePublish(makePublished: boolean) {
+    if (!data) return;
+    if (
+      !makePublished &&
+      !window.confirm("Unpublish this group? It will disappear from the public site immediately.")
+    )
+      return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const path = makePublished ? "publish" : "unpublish";
+      const res = await apiFetch(`/admin/groups/${data.group.id}/${path}`, { method: "POST" });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string } | null;
+        setActionError(err?.message ?? `POST responded ${res.status}`);
+        return;
+      }
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function toggleArchive(archive: boolean) {
+    if (!data) return;
+    if (
+      archive &&
+      !window.confirm(
+        "Archive this group? It will be hidden from the public site and the default admin list."
+      )
+    )
+      return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const path = archive ? "archive" : "reopen";
+      const res = await apiFetch(`/admin/groups/${data.group.id}/${path}`, { method: "POST" });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string } | null;
+        setActionError(err?.message ?? `POST responded ${res.status}`);
+        return;
+      }
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  // Render fallthrough until data loads
+  if (error)
+    return (
+      <p className="admin-classification" style={{ color: "var(--color-danger-700)" }}>
+        {error}
+      </p>
+    );
+  if (!data) return <p className="admin-marginalia">Loading…</p>;
+
+  const g = data.group;
+  const isStaff = actor.systemTier >= 1;
+
+  return (
+    <div className="admin-animate-reveal">
+      <p className="admin-classification mb-6">
+        US-RSE · Admin · Groups · {TYPE_LABELS[g.type]}
+      </p>
+      <h2 className="admin-display mb-2" style={{ fontSize: "clamp(2rem, 3vw + 0.5rem, 3rem)" }}>
+        {g.name}
+      </h2>
+      <div className="flex items-center gap-4 mb-10">
+        <span className="admin-classification">{TYPE_LABELS[g.type]}</span>
+        <span
+          className="admin-classification"
+          style={{
+            color: g.isPublished ? "var(--color-success-700)" : "var(--admin-marginalia)",
+          }}
+        >
+          {g.isPublished ? "Published" : "Draft"}
+        </span>
+        {!g.isActive && (
+          <span className="admin-classification" style={{ color: "var(--color-danger-700)" }}>
+            Archived
+          </span>
+        )}
+      </div>
+
+      <nav
+        className="flex items-baseline gap-8 mb-8"
+        style={{ borderBottom: "1px solid var(--admin-rule)" }}
+      >
+        {(["identity", "content", "roster", "lifecycle"] as Tab[]).map((t, i) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className="pb-3 admin-classification transition-colors"
+            style={{
+              color: tab === t ? "var(--admin-ribbon)" : "var(--admin-ink-medium)",
+              borderBottom: tab === t ? "2px solid var(--admin-ribbon)" : "2px solid transparent",
+              marginBottom: "-1px",
+            }}
+          >
+            <span className="tabular-nums mr-2">{String(i + 1).padStart(2, "0")}</span>
+            <span>
+              {t === "identity"
+                ? "Identity"
+                : t === "content"
+                  ? "Content"
+                  : t === "roster"
+                    ? "Roster + chairs"
+                    : "Lifecycle + audit"}
+            </span>
+          </button>
+        ))}
+      </nav>
+
+      {actionError && (
+        <p className="mb-4 admin-classification" style={{ color: "var(--color-danger-700)" }}>
+          {actionError}
+        </p>
+      )}
+
+      {tab === "identity" && (
+        <section className="max-w-2xl space-y-6">
+          <EditorialInput
+            label="Name"
+            value={g.name}
+            readOnly
+            hint="Name is locked after create. Contact a super_admin to rename."
+          />
+          <EditorialInput
+            label="Slug"
+            value={g.slug}
+            readOnly
+            hint="Slug is locked. The permalink uses the group ID, not the slug."
+          />
+          <EditorialTextarea
+            label="Short description"
+            value={draftDescription}
+            onChange={(e) => setDraftDescription(e.target.value)}
+            rows={2}
+            hint="One sentence shown on the public list card."
+          />
+          <EditorialInput
+            label="Slack channel"
+            value={draftSlackChannel}
+            onChange={(e) => setDraftSlackChannel(e.target.value)}
+            hint="Bare channel name, no leading #."
+          />
+          <button
+            type="button"
+            onClick={() => void saveIdentity()}
+            disabled={acting}
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm transition-colors hover:bg-purple-600 disabled:opacity-50"
+          >
+            {acting ? "Saving…" : "Save changes"}
+          </button>
+        </section>
+      )}
+
+      {tab === "content" && (
+        <section className="max-w-3xl space-y-8">
+          <EditorialTextarea
+            label="Charter (markdown)"
+            value={draftCharter}
+            onChange={(e) => setDraftCharter(e.target.value)}
+            rows={16}
+            hint="Long-form purpose / governance text rendered on the public per-group page."
+          />
+          <div>
+            <p className="admin-classification mb-3">Links</p>
+            <div className="space-y-3">
+              {draftLinks.map((l, i) => (
+                <div key={i} className="flex items-baseline gap-3">
+                  <input
+                    type="text"
+                    placeholder="Label"
+                    value={l.label}
+                    onChange={(e) => {
+                      const next = [...draftLinks];
+                      next[i] = { ...next[i], label: e.target.value };
+                      setDraftLinks(next);
+                    }}
+                    className="font-mono text-[13px] py-1.5 outline-none bg-transparent flex-1 max-w-[12rem]"
+                    style={{
+                      borderBottom: "1px solid var(--admin-rule)",
+                      color: "var(--admin-ink)",
+                    }}
+                  />
+                  <input
+                    type="text"
+                    placeholder="https://..."
+                    value={l.url}
+                    onChange={(e) => {
+                      const next = [...draftLinks];
+                      next[i] = { ...next[i], url: e.target.value };
+                      setDraftLinks(next);
+                    }}
+                    className="font-mono text-[13px] py-1.5 outline-none bg-transparent flex-1"
+                    style={{
+                      borderBottom: "1px solid var(--admin-rule)",
+                      color: "var(--admin-ink)",
+                    }}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setDraftLinks(draftLinks.filter((_, j) => j !== i))}
+                    className="admin-classification"
+                    style={{ color: "var(--color-danger-700)" }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => setDraftLinks([...draftLinks, { label: "", url: "" }])}
+                className="admin-classification"
+                style={{ color: "var(--admin-ribbon)" }}
+              >
+                + Add link
+              </button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void saveContent()}
+            disabled={acting}
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm transition-colors hover:bg-purple-600 disabled:opacity-50"
+          >
+            {acting ? "Saving…" : "Save content"}
+          </button>
+        </section>
+      )}
+
+      {tab === "roster" && (
+        <section className="max-w-3xl space-y-8">
+          {isStaff && (
+            <div>
+              <p className="admin-classification mb-3">Assign chair / co-chair</p>
+              <input
+                type="text"
+                placeholder="Search by name or email…"
+                value={chairSearch}
+                onChange={(e) => setChairSearch(e.target.value)}
+                className="w-full max-w-lg font-mono text-[13px] py-1.5 outline-none bg-transparent"
+                style={{
+                  borderBottom: "1px solid var(--admin-rule)",
+                  color: "var(--admin-ink)",
+                }}
+              />
+              {chairResults.length > 0 && (
+                <ul
+                  className="mt-4 max-w-2xl"
+                  style={{ borderTop: "1px solid var(--admin-rule-subtle)" }}
+                >
+                  {chairResults.map((r) => (
+                    <li
+                      key={r.id}
+                      className="py-3 flex items-baseline justify-between gap-6"
+                      style={{ borderBottom: "1px solid var(--admin-rule-subtle)" }}
+                    >
+                      <span className="flex-1">
+                        <span style={{ color: "var(--admin-ink)" }}>
+                          {r.displayName ?? <em>no name</em>}
+                        </span>
+                        <span
+                          className="font-mono text-[12px] ml-3"
+                          style={{ color: "var(--admin-ink-medium)" }}
+                        >
+                          {r.email}
+                        </span>
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => void assignChair(r.id, "chair")}
+                        disabled={acting}
+                        className="admin-classification disabled:opacity-50"
+                        style={{ color: "var(--admin-ribbon)" }}
+                      >
+                        Add as chair
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void assignChair(r.id, "co_chair")}
+                        disabled={acting}
+                        className="admin-classification disabled:opacity-50"
+                        style={{ color: "var(--admin-ribbon)" }}
+                      >
+                        Add as co-chair
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          <div>
+            <p className="admin-classification mb-3">Members ({data.members.length})</p>
+            {data.members.length === 0 ? (
+              <p className="italic" style={{ color: "var(--admin-marginalia)" }}>
+                No members yet.
+              </p>
+            ) : (
+              <ul style={{ borderTop: "1px solid var(--admin-rule)" }}>
+                {data.members.map((m) => (
+                  <li
+                    key={m.userId}
+                    className="py-3 flex items-baseline justify-between gap-6"
+                    style={{ borderBottom: "1px solid var(--admin-rule-subtle)" }}
+                  >
+                    <span className="flex-1">
+                      <span style={{ color: "var(--admin-ink)" }}>
+                        {m.displayName ?? <em>no name</em>}
+                      </span>
+                      <span
+                        className="font-mono text-[12px] ml-3"
+                        style={{ color: "var(--admin-ink-medium)" }}
+                      >
+                        {m.email}
+                      </span>
+                      <span
+                        className="admin-marginalia ml-3"
+                        style={{
+                          color:
+                            m.role === "chair"
+                              ? "var(--admin-ribbon)"
+                              : m.role === "co_chair"
+                                ? "var(--admin-mark)"
+                                : "var(--admin-marginalia)",
+                        }}
+                      >
+                        {m.role.replace("_", "-")}
+                      </span>
+                    </span>
+                    {(m.role === "chair" || m.role === "co_chair") && isStaff && (
+                      <button
+                        type="button"
+                        onClick={() => void removeChair(m.userId)}
+                        disabled={acting}
+                        className="admin-classification disabled:opacity-50"
+                        style={{ color: "var(--color-danger-700)" }}
+                      >
+                        Demote to member ✕
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      )}
+
+      {tab === "lifecycle" && (
+        <section className="max-w-3xl space-y-10">
+          <div>
+            <p className="admin-classification mb-3">Visibility</p>
+            <div className="flex items-baseline gap-4">
+              <p className="text-[14px]" style={{ color: "var(--admin-ink-medium)" }}>
+                Currently:{" "}
+                <span
+                  style={{
+                    color: g.isPublished
+                      ? "var(--color-success-700)"
+                      : "var(--admin-marginalia)",
+                  }}
+                >
+                  {g.isPublished ? "Published" : "Draft"}
+                </span>
+              </p>
+              <button
+                type="button"
+                onClick={() => void togglePublish(!g.isPublished)}
+                disabled={acting}
+                className="admin-classification disabled:opacity-50"
+                style={{ color: "var(--admin-ribbon)" }}
+              >
+                {g.isPublished ? "Unpublish →" : "Publish →"}
+              </button>
+              {g.isPublished && (
+                <a
+                  href={`/community/groups/${g.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="admin-classification ml-auto"
+                  style={{ color: "var(--admin-ribbon)" }}
+                >
+                  View public page →
+                </a>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p className="admin-classification mb-3">Lifecycle</p>
+            <div className="flex items-baseline gap-4">
+              <p className="text-[14px]" style={{ color: "var(--admin-ink-medium)" }}>
+                Currently:{" "}
+                <span
+                  style={{
+                    color: g.isActive ? "var(--admin-ink)" : "var(--color-danger-700)",
+                  }}
+                >
+                  {g.isActive ? "Active" : "Archived"}
+                </span>
+              </p>
+              {g.isActive ? (
+                <button
+                  type="button"
+                  onClick={() => void toggleArchive(true)}
+                  disabled={acting}
+                  className="admin-classification disabled:opacity-50"
+                  style={{ color: "var(--color-danger-700)" }}
+                >
+                  Archive this group
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => void toggleArchive(false)}
+                  disabled={acting}
+                  className="admin-classification disabled:opacity-50"
+                  style={{ color: "var(--admin-ribbon)" }}
+                >
+                  Reopen
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p className="admin-classification mb-3">
+              Recent audit ({data.recentAudit.length})
+            </p>
+            {data.recentAudit.length === 0 ? (
+              <p className="italic" style={{ color: "var(--admin-marginalia)" }}>
+                No audit entries.
+              </p>
+            ) : (
+              <ol style={{ borderTop: "1px solid var(--admin-ink)" }}>
+                {data.recentAudit.map((a, i) => (
+                  <li
+                    key={a.id}
+                    className="py-3 grid grid-cols-[3rem_minmax(8rem,auto)_minmax(0,1fr)] gap-6 items-baseline text-[13px]"
+                    style={{ borderBottom: "1px solid var(--admin-rule-subtle)" }}
+                  >
+                    <span className="admin-marginalia tabular-nums">
+                      {String(i + 1).padStart(3, "0")}
+                    </span>
+                    <span
+                      className="font-mono whitespace-nowrap"
+                      style={{ color: "var(--admin-ink-medium)" }}
+                    >
+                      {new Date(a.createdAt).toLocaleString()}
+                    </span>
+                    <span className="font-mono" style={{ color: "var(--admin-ink)" }}>
+                      {a.action}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+        </section>
+      )}
+
+      <p className="mt-12">
+        <Link
+          to="/groups"
+          className="admin-classification"
+          style={{ color: "var(--admin-ribbon)" }}
+        >
+          ← Back to all groups
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/pages/groups/GroupsListPage.tsx
+++ b/apps/admin/src/pages/groups/GroupsListPage.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useApi } from "@us-rse/auth-shell";
+import { useShellActor } from "../../layout/AdminShell";
+import { NewGroupModal } from "./NewGroupModal";
+
+type GroupType = "working_group" | "affinity_group" | "regional_group";
+type StatusFilter = "active" | "archived" | "all";
+type VisibilityFilter = "all" | "published" | "draft";
+
+interface GroupRow {
+  id: string;
+  name: string;
+  slug: string;
+  type: GroupType;
+  description: string | null;
+  isActive: boolean;
+  isPublished: boolean;
+  slackChannel: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+  memberCount: number;
+  chairCount: number;
+}
+
+interface ListResponse {
+  ok: true;
+  rows: GroupRow[];
+  counts: { total: number; active: number; draft: number; archived: number };
+}
+
+const TYPE_LABELS: Record<GroupType | "all", string> = {
+  all: "All kinds",
+  working_group: "Working",
+  affinity_group: "Affinity",
+  regional_group: "Regional",
+};
+
+export function GroupsListPage() {
+  const apiFetch = useApi();
+  const actor = useShellActor();
+  const [params, setParams] = useSearchParams();
+  const [data, setData] = useState<ListResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showNewModal, setShowNewModal] = useState(false);
+
+  const typeFilter = (params.get("type") ?? "all") as GroupType | "all";
+  const status = (params.get("status") ?? "active") as StatusFilter;
+  const visibility = (params.get("visibility") ?? "all") as VisibilityFilter;
+
+  const load = useCallback(async () => {
+    setError(null);
+    const sp = new URLSearchParams({ status, visibility });
+    if (typeFilter !== "all") sp.set("type", typeFilter);
+    try {
+      const res = await apiFetch(`/admin/groups?${sp}`);
+      if (!res.ok) {
+        setError(`/admin/groups responded ${res.status}`);
+        return;
+      }
+      setData((await res.json()) as ListResponse);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [apiFetch, typeFilter, status, visibility]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  function setParam(name: string, value: string) {
+    const next = new URLSearchParams(params);
+    const isDefault =
+      (name === "type" && value === "all") ||
+      (name === "status" && value === "active") ||
+      (name === "visibility" && value === "all");
+    if (value && !isDefault) next.set(name, value);
+    else next.delete(name);
+    setParams(next, { replace: true });
+  }
+
+  if (error)
+    return (
+      <p className="admin-classification" style={{ color: "var(--color-danger-700)" }}>
+        {error}
+      </p>
+    );
+
+  return (
+    <div className="admin-animate-reveal">
+      <p className="admin-classification mb-6">US-RSE · Admin · Groups</p>
+      <div className="flex items-baseline justify-between gap-6 mb-2">
+        <h2 className="admin-display" style={{ fontSize: "clamp(2rem, 3vw + 0.5rem, 3rem)" }}>
+          Groups.
+        </h2>
+        {actor.systemTier >= 2 && (
+          <button
+            type="button"
+            onClick={() => setShowNewModal(true)}
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm transition-colors hover:bg-purple-600"
+          >
+            + New group
+          </button>
+        )}
+      </div>
+      {data && (
+        <p className="admin-classification mb-8">
+          {data.counts.active} active · {data.counts.draft} draft ·{" "}
+          {data.counts.archived} archived
+        </p>
+      )}
+
+      <div className="flex items-baseline gap-6 mb-6">
+        <select
+          value={typeFilter}
+          onChange={(e) => setParam("type", e.target.value)}
+          className="admin-classification bg-transparent border-0 outline-none"
+          style={{ color: "var(--admin-ink-medium)" }}
+        >
+          <option value="all">All kinds</option>
+          <option value="working_group">Working</option>
+          <option value="affinity_group">Affinity</option>
+          <option value="regional_group">Regional</option>
+        </select>
+        <select
+          value={status}
+          onChange={(e) => setParam("status", e.target.value)}
+          className="admin-classification bg-transparent border-0 outline-none"
+          style={{ color: "var(--admin-ink-medium)" }}
+        >
+          <option value="active">Active</option>
+          <option value="archived">Archived</option>
+          <option value="all">All</option>
+        </select>
+        <select
+          value={visibility}
+          onChange={(e) => setParam("visibility", e.target.value)}
+          className="admin-classification bg-transparent border-0 outline-none ml-auto"
+          style={{ color: "var(--admin-ink-medium)" }}
+        >
+          <option value="all">Any visibility</option>
+          <option value="published">Published</option>
+          <option value="draft">Draft</option>
+        </select>
+      </div>
+
+      <div>
+        <div
+          className="grid grid-cols-[3rem_minmax(0,1fr)_6rem_minmax(0,1fr)_5rem_5rem_6rem_auto] gap-6 items-baseline py-2 text-[11px]"
+          style={{ borderTop: "1px solid var(--admin-ink)", borderBottom: "1px solid var(--admin-rule)" }}
+        >
+          <span className="admin-classification">#</span>
+          <span className="admin-classification">Name</span>
+          <span className="admin-classification">Type</span>
+          <span className="admin-classification">Slack</span>
+          <span className="admin-classification text-right">Chairs</span>
+          <span className="admin-classification text-right">Members</span>
+          <span className="admin-classification">Visibility</span>
+          <span className="admin-classification text-right">Open →</span>
+        </div>
+        {data?.rows.map((r, i) => (
+          <Link
+            key={r.id}
+            to={`/groups/${r.id}`}
+            className="grid grid-cols-[3rem_minmax(0,1fr)_6rem_minmax(0,1fr)_5rem_5rem_6rem_auto] gap-6 items-baseline py-3 text-[14px] transition-colors hover:bg-[var(--admin-paper-edge)]"
+            style={{ borderBottom: "1px solid var(--admin-rule-subtle)" }}
+          >
+            <span className="admin-marginalia tabular-nums">{String(i + 1).padStart(3, "0")}</span>
+            <span className="truncate" style={{ color: "var(--admin-ink)" }}>
+              {r.name}
+              {!r.isActive && (
+                <span className="admin-marginalia ml-2" style={{ color: "var(--color-danger-700)" }}>
+                  · archived
+                </span>
+              )}
+            </span>
+            <span className="admin-marginalia">{TYPE_LABELS[r.type]}</span>
+            <span className="truncate font-mono text-[12px]" style={{ color: "var(--admin-ink-medium)" }}>
+              {r.slackChannel ? `#${r.slackChannel}` : "—"}
+            </span>
+            <span className="text-right tabular-nums" style={{ color: "var(--admin-ink)" }}>{r.chairCount}</span>
+            <span className="text-right tabular-nums" style={{ color: "var(--admin-ink-medium)" }}>{r.memberCount}</span>
+            <span
+              className="admin-classification"
+              style={{
+                color: r.isPublished ? "var(--color-success-700)" : "var(--admin-marginalia)",
+              }}
+            >
+              {r.isPublished ? "Published" : "Draft"}
+            </span>
+            <span className="admin-classification text-right" style={{ color: "var(--admin-ribbon)" }}>
+              Open →
+            </span>
+          </Link>
+        ))}
+        {data && data.rows.length === 0 && (
+          <p className="py-6 text-center italic" style={{ color: "var(--admin-marginalia)" }}>
+            No groups match.
+          </p>
+        )}
+      </div>
+
+      {showNewModal && (
+        <NewGroupModal
+          onClose={() => setShowNewModal(false)}
+          onCreated={() => {
+            setShowNewModal(false);
+            void load();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/pages/groups/NewGroupModal.tsx
+++ b/apps/admin/src/pages/groups/NewGroupModal.tsx
@@ -1,0 +1,133 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useApi } from "@us-rse/auth-shell";
+import { EditorialInput } from "../../components/EditorialInput";
+import { EditorialTextarea } from "../../components/EditorialTextarea";
+
+interface Props {
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function NewGroupModal({ onClose, onCreated }: Props) {
+  const apiFetch = useApi();
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [type, setType] = useState<"working_group" | "affinity_group" | "regional_group">("working_group");
+  const [description, setDescription] = useState("");
+  const [slackChannel, setSlackChannel] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit() {
+    if (!name.trim()) {
+      setError("Name is required.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await apiFetch("/admin/groups", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          type,
+          description: description.trim() || undefined,
+          slackChannel: slackChannel.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string } | null;
+        setError(err?.message ?? `POST responded ${res.status}`);
+        return;
+      }
+      const body = (await res.json()) as { ok: true; group: { id: string } };
+      onCreated();
+      navigate(`/groups/${body.group.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: "rgba(0,0,0,0.4)" }}
+      onClick={onClose}
+    >
+      <div
+        className="bg-white p-8 max-w-lg w-full rounded-md shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="admin-classification mb-4">New group</p>
+        <h3 className="admin-display mb-6" style={{ fontSize: "1.5rem" }}>
+          Create a group.
+        </h3>
+
+        {error && (
+          <p className="mb-4 admin-classification" style={{ color: "var(--color-danger-700)" }}>
+            {error}
+          </p>
+        )}
+
+        <div className="space-y-6">
+          <EditorialInput
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+          />
+          <div>
+            <p className="admin-classification mb-2">Type</p>
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value as typeof type)}
+              className="bg-transparent border-0 outline-none py-1.5 w-full"
+              style={{ borderBottom: "1px solid var(--admin-rule)", color: "var(--admin-ink)", fontSize: "15px" }}
+            >
+              <option value="working_group">Working group</option>
+              <option value="affinity_group">Affinity group</option>
+              <option value="regional_group">Regional group</option>
+            </select>
+          </div>
+          <EditorialTextarea
+            label="Short description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            hint="One sentence shown on the public group list card."
+          />
+          <EditorialInput
+            label="Slack channel (optional)"
+            value={slackChannel}
+            onChange={(e) => setSlackChannel(e.target.value)}
+            hint="e.g., wg-outreach — no leading #."
+          />
+        </div>
+
+        <div className="mt-8 flex justify-end gap-4">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="admin-classification disabled:opacity-50"
+            style={{ color: "var(--admin-ink-medium)" }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void submit()}
+            disabled={submitting}
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm transition-colors hover:bg-purple-600 disabled:opacity-50"
+          >
+            {submitting ? "Creating…" : "Create draft →"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/pages/organizations/OrganizationDetailPage.tsx
+++ b/apps/admin/src/pages/organizations/OrganizationDetailPage.tsx
@@ -102,33 +102,60 @@ export function OrganizationDetailPage() {
     }>
   >([]);
 
-  const fetchOrg = useCallback(async () => {
-    if (!id) return;
-    setError(null);
-    try {
-      const res = await apiFetch(`/admin/organizations/${id}`);
-      if (!res.ok) {
-        setError(`/admin/organizations/${id} responded ${res.status}`);
-        return;
+  /**
+   * Refetch the org. Mode controls whether the form draft gets re-seeded
+   * from the server response.
+   *
+   *   - "reset-draft":    initial load + after saveIdentity. Used when
+   *                       the server's value is authoritative for the
+   *                       form, either because nothing was on screen yet
+   *                       or because we just pushed the draft to the
+   *                       server (so a re-seed reflects any server-side
+   *                       normalization like slug derivation).
+   *   - "preserve-draft": after every other action — status flip, soft-
+   *                       delete / restore, logo upload, unmerge. These
+   *                       change OTHER server fields, so the user's
+   *                       in-flight edits to name/slug/shortName/url
+   *                       MUST NOT be clobbered.
+   *
+   * The original implementation re-seeded unconditionally, which meant
+   * any non-save action silently discarded the user's pending edits.
+   */
+  const fetchOrg = useCallback(
+    async (mode: "reset-draft" | "preserve-draft" = "preserve-draft") => {
+      if (!id) return;
+      setError(null);
+      try {
+        const res = await apiFetch(`/admin/organizations/${id}`);
+        if (!res.ok) {
+          setError(`/admin/organizations/${id} responded ${res.status}`);
+          return;
+        }
+        const body = (await res.json()) as DetailResponse;
+        setData(body);
+        if (mode === "reset-draft") {
+          setDraft({
+            name: body.organization.name,
+            slug: body.organization.slug,
+            shortName: body.organization.shortName ?? "",
+            url: body.organization.url ?? "",
+          });
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
       }
-      const body = (await res.json()) as DetailResponse;
-      setData(body);
-      setDraft({
-        name: body.organization.name,
-        slug: body.organization.slug,
-        shortName: body.organization.shortName ?? "",
-        url: body.organization.url ?? "",
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, [apiFetch, id]);
+    },
+    [apiFetch, id]
+  );
 
   useEffect(() => {
-    void fetchOrg();
+    void fetchOrg("reset-draft");
   }, [fetchOrg]);
 
-  async function patch(body: Record<string, unknown>) {
+  async function patch(
+    body: Record<string, unknown>,
+    mode: "reset-draft" | "preserve-draft" = "preserve-draft"
+  ) {
     if (!data) return;
     setSaving(true);
     setSaveError(null);
@@ -145,7 +172,7 @@ export function OrganizationDetailPage() {
         setSaveError(err?.message ?? `PATCH responded ${res.status}`);
         return;
       }
-      await fetchOrg();
+      await fetchOrg(mode);
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -154,15 +181,24 @@ export function OrganizationDetailPage() {
   }
 
   async function saveIdentity() {
-    await patch({
-      name: draft.name.trim() || undefined,
-      slug: draft.slug.trim() || undefined,
-      shortName: draft.shortName.trim() === "" ? null : draft.shortName.trim(),
-      url: draft.url.trim() === "" ? null : draft.url.trim(),
-    });
+    // Save IS the moment server-state catches up to draft — refetch can
+    // safely re-seed the form so server-side normalization (slug derivation
+    // etc.) appears in the inputs.
+    await patch(
+      {
+        name: draft.name.trim() || undefined,
+        slug: draft.slug.trim() || undefined,
+        shortName: draft.shortName.trim() === "" ? null : draft.shortName.trim(),
+        url: draft.url.trim() === "" ? null : draft.url.trim(),
+      },
+      "reset-draft"
+    );
   }
 
   async function setVocabStatus(next: "pending" | "approved") {
+    // Status flip changes the row's status field only — anything the
+    // user typed into the identity inputs stays untouched (defaults to
+    // "preserve-draft").
     await patch({ status: next });
   }
 

--- a/apps/admin/src/pages/organizations/OrganizationsListPage.tsx
+++ b/apps/admin/src/pages/organizations/OrganizationsListPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useApi } from "@us-rse/auth-shell";
 import { OrgStatusTag } from "../../components/OrgStatusTag";
+import { StatusDot } from "../../components/StatusDot";
 import { useShellActor } from "../../layout/AdminShell";
 
 interface OrgRow {
@@ -207,11 +208,18 @@ export function OrganizationsListPage() {
               {r.memberCount}
             </span>
             <span>
-              <OrgStatusTag
-                deletedAt={r.deletedAt}
-                mergedIntoId={r.mergedIntoId}
-                vocabStatus={r.status}
-              />
+              {/* Lifecycle states (deleted / merged) earn the loud
+                  word — they're exceptional and benefit from being
+                  unmistakable. Otherwise the row gets a vocab-status
+                  dot: green/yellow/red for approved/pending/rejected. */}
+              {r.deletedAt || r.mergedIntoId ? (
+                <OrgStatusTag
+                  deletedAt={r.deletedAt}
+                  mergedIntoId={r.mergedIntoId}
+                />
+              ) : (
+                <StatusDot status={r.status} />
+              )}
             </span>
             <span className="admin-marginalia text-right whitespace-nowrap tabular-nums">
               {new Date(r.createdAt).toLocaleDateString()}

--- a/apps/admin/src/pages/vocab/VocabDetailPage.tsx
+++ b/apps/admin/src/pages/vocab/VocabDetailPage.tsx
@@ -41,26 +41,39 @@ export function VocabDetailPage() {
   const [draftSlug, setDraftSlug] = useState("");
   const [mergeTarget, setMergeTarget] = useState<string>("");
 
-  const load = useCallback(async () => {
-    if (!kind || !id) return;
-    setError(null);
-    try {
-      const res = await apiFetch(`/admin/vocab/${kind}/${id}`);
-      if (!res.ok) {
-        setError(`/admin/vocab/${kind}/${id} responded ${res.status}`);
-        return;
+  /**
+   * Refetch the vocab row. Mode controls whether the form draft gets
+   * re-seeded from the server response — see the matching docstring on
+   * OrganizationDetailPage.fetchOrg for the rationale. Approve / reject /
+   * merge change OTHER server fields, so they must NOT overwrite the
+   * user's in-flight name/slug edits. saveIdentity IS the moment server
+   * state catches up to draft, so a re-seed there is safe and useful.
+   */
+  const load = useCallback(
+    async (mode: "reset-draft" | "preserve-draft" = "preserve-draft") => {
+      if (!kind || !id) return;
+      setError(null);
+      try {
+        const res = await apiFetch(`/admin/vocab/${kind}/${id}`);
+        if (!res.ok) {
+          setError(`/admin/vocab/${kind}/${id} responded ${res.status}`);
+          return;
+        }
+        const body = (await res.json()) as DetailResponse;
+        setData(body);
+        if (mode === "reset-draft") {
+          setDraftName(body.row.name);
+          setDraftSlug(body.row.slug);
+          setMergeTarget(body.similarApproved[0]?.id ?? "");
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
       }
-      const body = (await res.json()) as DetailResponse;
-      setData(body);
-      setDraftName(body.row.name);
-      setDraftSlug(body.row.slug);
-      setMergeTarget(body.similarApproved[0]?.id ?? "");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, [apiFetch, kind, id]);
+    },
+    [apiFetch, kind, id]
+  );
 
-  useEffect(() => { void load(); }, [load]);
+  useEffect(() => { void load("reset-draft"); }, [load]);
 
   async function saveIdentity() {
     if (!data) return;
@@ -84,7 +97,9 @@ export function VocabDetailPage() {
         setActionError(err?.message ?? `PATCH responded ${res.status}`);
         return;
       }
-      await load();
+      // Save pushed the draft to the server; re-seed the inputs from the
+      // server's normalized values (slug derivation etc.).
+      await load("reset-draft");
     } finally {
       setActing(false);
     }

--- a/apps/admin/src/pages/vocab/VocabListPage.tsx
+++ b/apps/admin/src/pages/vocab/VocabListPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useApi } from "@us-rse/auth-shell";
+import { StatusDot } from "../../components/StatusDot";
 
 type VocabKind = "disciplines" | "skills" | "languages";
 type StatusFilter = "pending" | "approved" | "rejected" | "all";
@@ -139,7 +140,9 @@ export function VocabListPage() {
             >
               {r.usageCount}
             </span>
-            <span className="admin-marginalia">{r.status}</span>
+            <span>
+              <StatusDot status={r.status} />
+            </span>
             <span className="truncate text-[12px]" style={{ color: "var(--admin-ink-medium)" }}>
               {r.suggestedBy?.displayName ?? r.suggestedBy?.email ?? "—"}
             </span>

--- a/apps/admin/src/pages/vocab/VocabQueuePage.tsx
+++ b/apps/admin/src/pages/vocab/VocabQueuePage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useApi } from "@us-rse/auth-shell";
+import { StatusDot } from "../../components/StatusDot";
 
 type VocabKind = "disciplines" | "skills" | "languages";
 type SortMode = "newest" | "most-used" | "strongest-match";
@@ -168,21 +169,9 @@ export function VocabQueuePage() {
             style={{ borderBottom: "1px solid var(--admin-rule-subtle)" }}
           >
             <span className="admin-marginalia tabular-nums">{String(i + 1).padStart(3, "0")}</span>
-            <span className="admin-marginalia truncate">
+            <span className="admin-marginalia truncate inline-flex items-center gap-2">
+              <StatusDot status={r.status} />
               {r.kind}
-              {r.status !== "pending" && (
-                <span
-                  className="ml-2"
-                  style={{
-                    color:
-                      r.status === "approved"
-                        ? "var(--color-success-700)"
-                        : "var(--color-danger-700)",
-                  }}
-                >
-                  · {r.status}
-                </span>
-              )}
             </span>
             <span className="truncate" style={{ color: "var(--admin-ink)" }}>{r.name}</span>
             <span

--- a/apps/admin/tests/admin-foundation.spec.ts
+++ b/apps/admin/tests/admin-foundation.spec.ts
@@ -48,3 +48,13 @@ test("unauthenticated visit to /vocab/skills triggers sign-in flow", async ({ pa
   await page.goto("/vocab/skills");
   await expect(page.getByText(/connecting to workos|sign in/i)).toBeVisible();
 });
+
+test("unauthenticated visit to /groups triggers sign-in flow", async ({ page }) => {
+  await page.goto("/groups");
+  await expect(page.getByText(/connecting to workos|sign in/i)).toBeVisible();
+});
+
+test("unauthenticated visit to /groups/<uuid> triggers sign-in flow", async ({ page }) => {
+  await page.goto("/groups/00000000-0000-4000-8000-000000000000");
+  await expect(page.getByText(/connecting to workos|sign in/i)).toBeVisible();
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Nav } from "@/components/Nav";
 import { Footer } from "@/components/Footer";
 import { CommandPalette } from "@/components/members/CommandPalette";
@@ -16,7 +16,8 @@ import { StaffPage } from "@/pages/about/StaffPage";
 import { FinancialStatusPage } from "@/pages/about/FinancialStatusPage";
 import { WorkingGroupsPage } from "@/pages/community/WorkingGroupsPage";
 import { AffinityGroupsPage } from "@/pages/community/AffinityGroupsPage";
-import { CommunityCallsPage } from "@/pages/community/CommunityCallsPage";
+import { RegionalGroupsPage } from "@/pages/community/RegionalGroupsPage";
+import { GroupPage } from "@/pages/community/GroupPage";
 import { CommunityAwardsPage } from "@/pages/community/CommunityAwardsPage";
 import { CommunityFundsPage } from "@/pages/community/CommunityFundsPage";
 import { UpcomingEventsPage } from "@/pages/events/UpcomingEventsPage";
@@ -73,7 +74,10 @@ export function App() {
             <Route path="/about/financial-status" element={<FinancialStatusPage />} />
             <Route path="/community/working-groups" element={<WorkingGroupsPage />} />
             <Route path="/community/affinity-groups" element={<AffinityGroupsPage />} />
-            <Route path="/community/calls" element={<CommunityCallsPage />} />
+            <Route path="/community/regional-groups" element={<RegionalGroupsPage />} />
+            <Route path="/community/groups/:id" element={<GroupPage />} />
+            {/* TODO: replace target with /community/groups/<community-calls-id> after ingest run */}
+            <Route path="/community/calls" element={<Navigate to="/community/working-groups" replace />} />
             <Route path="/community/awards" element={<CommunityAwardsPage />} />
             <Route path="/community/funds" element={<CommunityFundsPage />} />
             <Route path="/events" element={<UpcomingEventsPage />} />

--- a/apps/web/src/hooks/useGroups.ts
+++ b/apps/web/src/hooks/useGroups.ts
@@ -69,3 +69,74 @@ export function useGroups(type: GroupType): UseGroupsState {
 
   return state;
 }
+
+export interface PublicGroupDetail extends PublicGroupCard {
+  charter: string | null;
+  links: Array<{ label: string; url: string }>;
+  chairs: Array<{ displayName: string | null; photoUrl: string | null }>;
+}
+
+interface UseGroupState {
+  group: PublicGroupDetail | null;
+  loading: boolean;
+  error: string | null;
+  notFound: boolean;
+}
+
+/**
+ * Public hook for the /community/groups/:id detail page. Fetches a
+ * single group's full detail (charter, links, chairs) plus the card
+ * fields. Returns `notFound: true` for 404 so the page can render a
+ * dedicated empty state.
+ */
+export function useGroup(id: string | undefined): UseGroupState {
+  const [state, setState] = useState<UseGroupState>({
+    group: null,
+    loading: true,
+    error: null,
+    notFound: false,
+  });
+
+  useEffect(() => {
+    if (!id) {
+      setState({ group: null, loading: false, error: null, notFound: true });
+      return;
+    }
+    let cancelled = false;
+    setState({ group: null, loading: true, error: null, notFound: false });
+    void (async () => {
+      try {
+        const res = await fetch(`${API_BASE_URL}/groups/${id}`);
+        if (cancelled) return;
+        if (res.status === 404) {
+          setState({ group: null, loading: false, error: null, notFound: true });
+          return;
+        }
+        if (!res.ok) {
+          setState({
+            group: null,
+            loading: false,
+            error: `/groups/${id} responded ${res.status}`,
+            notFound: false,
+          });
+          return;
+        }
+        const body = (await res.json()) as { ok: true; group: PublicGroupDetail };
+        setState({ group: body.group, loading: false, error: null, notFound: false });
+      } catch (e) {
+        if (cancelled) return;
+        setState({
+          group: null,
+          loading: false,
+          error: e instanceof Error ? e.message : String(e),
+          notFound: false,
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  return state;
+}

--- a/apps/web/src/hooks/useGroups.ts
+++ b/apps/web/src/hooks/useGroups.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ??
+  "https://us-rse-api.leadership-28b.workers.dev";
+
+export type GroupType = "working_group" | "affinity_group" | "regional_group";
+
+export interface PublicGroupCard {
+  id: string;
+  name: string;
+  slug: string;
+  type: GroupType;
+  description: string | null;
+  slackChannel: string | null;
+}
+
+interface UseGroupsState {
+  rows: PublicGroupCard[] | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Public hook for the /community/working-groups, affinity-groups,
+ * regional-groups list pages. Fetches once per type.
+ *
+ * The worker mounts the public route at /groups (no /api/ prefix);
+ * this hook fetches directly via fetch() since useApi is for
+ * authenticated admin calls only.
+ */
+export function useGroups(type: GroupType): UseGroupsState {
+  const [state, setState] = useState<UseGroupsState>({
+    rows: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ rows: null, loading: true, error: null });
+    void (async () => {
+      try {
+        const res = await fetch(`${API_BASE_URL}/groups?type=${type}`);
+        if (cancelled) return;
+        if (!res.ok) {
+          setState({
+            rows: null,
+            loading: false,
+            error: `/groups responded ${res.status}`,
+          });
+          return;
+        }
+        const body = (await res.json()) as { ok: true; rows: PublicGroupCard[] };
+        setState({ rows: body.rows, loading: false, error: null });
+      } catch (e) {
+        if (cancelled) return;
+        setState({
+          rows: null,
+          loading: false,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [type]);
+
+  return state;
+}

--- a/apps/web/src/pages/community/AffinityGroupsPage.tsx
+++ b/apps/web/src/pages/community/AffinityGroupsPage.tsx
@@ -1,44 +1,7 @@
 import { Link } from "react-router-dom";
 import { CommunityLayout } from "@/components/community/CommunityLayout";
 import { useInView } from "@/hooks/useInView";
-
-interface AffinityGroup {
-  num: string;
-  name: string;
-  type: string;
-  description: string;
-}
-
-const affinityGroups: AffinityGroup[] = [
-  {
-    num: "01",
-    name: "RSE Group Leaders' Network (RSE-GLN)",
-    type: "Leadership",
-    description:
-      "A space for leaders of RSE teams to share management strategies, organizational challenges, and successes. Includes the Aspiring RSE-GLN for those building toward leadership roles.",
-  },
-  {
-    num: "02",
-    name: "Neuro-RSE",
-    type: "Domain",
-    description:
-      "Connecting research software engineers working in neuroscience — sharing tools, workflows, and domain-specific challenges.",
-  },
-  {
-    num: "03",
-    name: "R-RSE",
-    type: "Language",
-    description:
-      "Increasing R user representation within US-RSE and fostering collaboration among R-focused research software engineers.",
-  },
-  {
-    num: "04",
-    name: "Institutional RSE Networking",
-    type: "Organizational",
-    description:
-      "Connecting RSEs who are building or sustaining RSE communities within their own organizations — sharing playbooks and institutional strategies.",
-  },
-];
+import { useGroups } from "@/hooks/useGroups";
 
 interface RegionalGroup {
   num: string;
@@ -153,6 +116,37 @@ export function AffinityGroupsPage() {
   const { ref: regionalRef, isInView: regionalInView } = useInView(0.05);
   const { ref: startRef, isInView: startInView } = useInView(0.1);
   const { ref: bridgeRef, isInView: bridgeInView } = useInView(0.1);
+  const { rows: affinityGroups, loading, error } = useGroups("affinity_group");
+
+  if (loading) {
+    return (
+      <CommunityLayout
+        title="Affinity Groups"
+        subtitle="Spaces for members who share identities, interests, or geography to connect and support each other."
+      >
+        <p className="text-gray-500">Loading…</p>
+      </CommunityLayout>
+    );
+  }
+  if (error) {
+    return (
+      <CommunityLayout
+        title="Affinity Groups"
+        subtitle="Spaces for members who share identities, interests, or geography to connect and support each other."
+      >
+        <p className="text-red-700">
+          Group list temporarily unavailable.{" "}
+          <button
+            onClick={() => window.location.reload()}
+            className="underline"
+          >
+            Retry
+          </button>
+        </p>
+      </CommunityLayout>
+    );
+  }
+  if (!affinityGroups) return null;
 
   return (
     <CommunityLayout
@@ -231,10 +225,12 @@ export function AffinityGroupsPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-neutral-200">
           {affinityGroups.map((g, i) => {
             const a = i % 2 === 0 ? pillarAccent.teal : pillarAccent.purple;
+            const num = String(i + 1).padStart(2, "0");
             return (
-              <article
-                key={g.num}
-                className={`bg-white pt-9 pb-10 px-6 md:px-8 border-t-2 ${a.border} ${
+              <Link
+                key={g.id}
+                to={`/community/groups/${g.id}`}
+                className={`bg-white pt-9 pb-10 px-6 md:px-8 border-t-2 ${a.border} hover:bg-neutral-50/60 transition-colors ${
                   affinityInView ? "animate-slide-up" : "opacity-0"
                 }`}
                 style={{ animationDelay: `${i * 90}ms` }}
@@ -243,21 +239,21 @@ export function AffinityGroupsPage() {
                   <p
                     className={`font-mono text-[11px] uppercase tracking-[0.2em] ${a.tag}`}
                   >
-                    {g.type}
+                    Affinity group
                   </p>
                   <span
                     className={`font-display text-sm font-bold tabular-nums ${a.num}`}
                   >
-                    {g.num}
+                    {num}
                   </span>
                 </div>
                 <h3 className="font-display text-xl lg:text-2xl font-bold text-neutral-900 tracking-tight leading-[1.2] mb-4 text-balance">
                   {g.name}
                 </h3>
                 <p className="text-sm text-neutral-600 leading-relaxed">
-                  {g.description}
+                  {g.description ?? ""}
                 </p>
-              </article>
+              </Link>
             );
           })}
         </div>

--- a/apps/web/src/pages/community/GroupPage.tsx
+++ b/apps/web/src/pages/community/GroupPage.tsx
@@ -1,0 +1,118 @@
+import { useParams } from "react-router-dom";
+import { CommunityLayout } from "@/components/community/CommunityLayout";
+import { useGroup } from "@/hooks/useGroups";
+
+const TYPE_LABELS: Record<string, string> = {
+  working_group: "Working group",
+  affinity_group: "Affinity group",
+  regional_group: "Regional group",
+};
+
+export function GroupPage() {
+  const { id } = useParams<{ id: string }>();
+  const { group, loading, error, notFound } = useGroup(id);
+
+  if (loading) {
+    return (
+      <CommunityLayout title="Loading…">
+        <p className="text-gray-500">Loading…</p>
+      </CommunityLayout>
+    );
+  }
+  if (notFound) {
+    return (
+      <CommunityLayout title="Group not found">
+        <p className="text-gray-600">
+          This group may have been archived or unpublished.{" "}
+          <a
+            href="/community/working-groups"
+            className="text-purple-700 underline"
+          >
+            Browse working groups →
+          </a>
+        </p>
+      </CommunityLayout>
+    );
+  }
+  if (error || !group) {
+    return (
+      <CommunityLayout title="Group">
+        <p className="text-red-700">
+          {error ?? "Group temporarily unavailable."}
+        </p>
+      </CommunityLayout>
+    );
+  }
+
+  return (
+    <CommunityLayout
+      title={group.name}
+      subtitle={group.description ?? undefined}
+    >
+      <p className="text-sm uppercase tracking-wider text-gray-500 mb-8">
+        {TYPE_LABELS[group.type] ?? group.type}
+      </p>
+
+      {group.charter && (
+        <div className="prose max-w-2xl mb-12 whitespace-pre-wrap">
+          {group.charter}
+        </div>
+      )}
+
+      {group.slackChannel && (
+        <div className="mb-8">
+          <p className="text-xs uppercase tracking-wider text-gray-500 mb-2">
+            Slack
+          </p>
+          <p className="font-mono text-sm">#{group.slackChannel}</p>
+        </div>
+      )}
+
+      {group.chairs.length > 0 && (
+        <div className="mb-8">
+          <p className="text-xs uppercase tracking-wider text-gray-500 mb-3">
+            Chairs
+          </p>
+          <div className="flex flex-wrap items-center gap-4">
+            {group.chairs.map((c, i) => (
+              <div key={i} className="flex items-center gap-3">
+                {c.photoUrl ? (
+                  <img
+                    src={c.photoUrl}
+                    alt=""
+                    className="w-10 h-10 rounded-full object-cover"
+                  />
+                ) : (
+                  <span className="w-10 h-10 rounded-full bg-gray-200 inline-block" />
+                )}
+                <span className="text-sm">{c.displayName ?? "Chair"}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {group.links.length > 0 && (
+        <div className="mb-8">
+          <p className="text-xs uppercase tracking-wider text-gray-500 mb-3">
+            Links
+          </p>
+          <ul className="space-y-1">
+            {group.links.map((l, i) => (
+              <li key={i}>
+                <a
+                  href={l.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-purple-700 underline"
+                >
+                  {l.label} →
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </CommunityLayout>
+  );
+}

--- a/apps/web/src/pages/community/RegionalGroupsPage.tsx
+++ b/apps/web/src/pages/community/RegionalGroupsPage.tsx
@@ -1,0 +1,56 @@
+import { Link } from "react-router-dom";
+import { CommunityLayout } from "@/components/community/CommunityLayout";
+import { useGroups } from "@/hooks/useGroups";
+
+export function RegionalGroupsPage() {
+  const { rows, loading, error } = useGroups("regional_group");
+
+  return (
+    <CommunityLayout
+      title="Regional Groups"
+      subtitle="Local US-RSE communities organized by geography."
+    >
+      {loading && <p className="text-gray-500">Loading…</p>}
+      {error && <p className="text-red-700">{error}</p>}
+
+      {rows && rows.length === 0 && (
+        <div className="bg-gray-50 p-8 rounded-md">
+          <p className="text-gray-700 mb-3">
+            Regional groups are coming soon. Interested in starting one in your
+            area?
+          </p>
+          <p className="text-sm text-gray-500">
+            <a
+              href="mailto:info@us-rse.org"
+              className="text-purple-700 underline"
+            >
+              Get in touch →
+            </a>
+          </p>
+        </div>
+      )}
+
+      {rows && rows.length > 0 && (
+        <ul className="grid sm:grid-cols-2 gap-6">
+          {rows.map((g) => (
+            <li
+              key={g.id}
+              className="border border-gray-200 rounded-md p-6"
+            >
+              <h2 className="text-xl font-semibold mb-2">{g.name}</h2>
+              {g.description && (
+                <p className="text-sm text-gray-700 mb-4">{g.description}</p>
+              )}
+              <Link
+                to={`/community/groups/${g.id}`}
+                className="text-purple-700 text-sm underline"
+              >
+                View →
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </CommunityLayout>
+  );
+}

--- a/apps/web/src/pages/community/WorkingGroupsPage.tsx
+++ b/apps/web/src/pages/community/WorkingGroupsPage.tsx
@@ -1,67 +1,7 @@
 import { Link } from "react-router-dom";
 import { CommunityLayout } from "@/components/community/CommunityLayout";
 import { useInView } from "@/hooks/useInView";
-
-interface WorkingGroup {
-  name: string;
-  description: string;
-  /** Only populated when the group has its own dedicated page on the site. */
-  route?: string;
-}
-
-const workingGroups: WorkingGroup[] = [
-  {
-    name: "Code Review",
-    description:
-      "Building a community interested in code review and providing resources for code review practices in research software.",
-  },
-  {
-    name: "Community Calls",
-    description:
-      "Monthly virtual meetings featuring invited speakers and breakout discussion sessions open to all members.",
-    route: "/community/calls",
-  },
-  {
-    name: "Diversity, Equity & Inclusion",
-    description:
-      "Fostering an inclusive environment with equitable treatment for all and integrating DEI practices across the organization.",
-  },
-  {
-    name: "Education & Training",
-    description:
-      "Developing RSE education resources, curating skill lists, and running a seminar series on research software topics.",
-  },
-  {
-    name: "Group Management",
-    description:
-      "Providing support and facilitating conversation between working group chairs on logistics, governance, and best practices.",
-  },
-  {
-    name: "Mentorship Program",
-    description:
-      "Inter-institutional mentorship pairing for professional growth, connecting early-career and experienced RSEs.",
-  },
-  {
-    name: "RSE Empowerment in National Labs",
-    description:
-      "Addressing unique challenges RSEs face in national laboratories through advocacy, knowledge sharing, and community building.",
-  },
-  {
-    name: "Testing",
-    description:
-      "Exploring testing limitations, sharing knowledge across domains, and improving research software reliability.",
-  },
-  {
-    name: "User Experience",
-    description:
-      "Promoting adoption of UX methods in research software engineering to improve usability and accessibility.",
-  },
-  {
-    name: "Website",
-    description:
-      "Managing the content, design, and technical infrastructure of the US-RSE website.",
-  },
-];
+import { useGroups } from "@/hooks/useGroups";
 
 interface Fact {
   value: string;
@@ -151,7 +91,39 @@ export function WorkingGroupsPage() {
   const { ref: groupsRef, isInView: groupsInView } = useInView(0.05);
   const { ref: pathwaysRef, isInView: pathwaysInView } = useInView(0.1);
   const { ref: bridgeRef, isInView: bridgeInView } = useInView(0.1);
+  const { rows, loading, error } = useGroups("working_group");
 
+  if (loading) {
+    return (
+      <CommunityLayout
+        title="Working Groups"
+        subtitle="Community-led teams tackling the challenges Research Software Engineers face every day."
+      >
+        <p className="text-gray-500">Loading…</p>
+      </CommunityLayout>
+    );
+  }
+  if (error) {
+    return (
+      <CommunityLayout
+        title="Working Groups"
+        subtitle="Community-led teams tackling the challenges Research Software Engineers face every day."
+      >
+        <p className="text-red-700">
+          Group list temporarily unavailable.{" "}
+          <button
+            onClick={() => window.location.reload()}
+            className="underline"
+          >
+            Retry
+          </button>
+        </p>
+      </CommunityLayout>
+    );
+  }
+  if (!rows) return null;
+
+  const workingGroups = rows;
   const midpoint = Math.ceil(workingGroups.length / 2);
   const leftColumn = workingGroups.slice(0, midpoint);
   const rightColumn = workingGroups.slice(midpoint);
@@ -234,7 +206,7 @@ export function WorkingGroupsPage() {
                 const isLast = i === column.length - 1;
                 return (
                   <div
-                    key={wg.name}
+                    key={wg.id}
                     className={`py-6 ${!isLast ? "border-b border-neutral-100" : ""} ${
                       groupsInView ? "animate-slide-up" : "opacity-0"
                     }`}
@@ -249,26 +221,24 @@ export function WorkingGroupsPage() {
                       </h3>
                     </div>
                     <p className="text-sm text-neutral-600 leading-relaxed pl-8">
-                      {wg.description}
+                      {wg.description ?? ""}
                     </p>
-                    {wg.route && (
-                      <Link
-                        to={wg.route}
-                        className="group inline-flex items-center gap-1.5 mt-2 pl-8 font-mono text-[11px] uppercase tracking-wider text-teal-700 hover:text-teal-900 transition-colors"
+                    <Link
+                      to={`/community/groups/${wg.id}`}
+                      className="group inline-flex items-center gap-1.5 mt-2 pl-8 font-mono text-[11px] uppercase tracking-wider text-teal-700 hover:text-teal-900 transition-colors"
+                    >
+                      View page
+                      <svg
+                        className="w-3 h-3 transition-transform group-hover:translate-x-0.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        aria-hidden="true"
                       >
-                        View page
-                        <svg
-                          className="w-3 h-3 transition-transform group-hover:translate-x-0.5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                          aria-hidden="true"
-                        >
-                          <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                        </svg>
-                      </Link>
-                    )}
+                        <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                      </svg>
+                    </Link>
                   </div>
                 );
               })}

--- a/packages/api/migrations/0019_groups_publishable.sql
+++ b/packages/api/migrations/0019_groups_publishable.sql
@@ -1,0 +1,15 @@
+-- Adds the four columns the admin/groups subsystem reads + writes:
+-- slack_channel (chip on the public group page), charter (long-form
+-- markdown rendered on the per-group page), links (jsonb array of
+-- {label, url}), and is_published (gates public visibility,
+-- independent of is_active). The partial index covers the hot path
+-- on the public list endpoint.
+
+ALTER TABLE "groups" ADD COLUMN "slack_channel" text;--> statement-breakpoint
+ALTER TABLE "groups" ADD COLUMN "charter" text;--> statement-breakpoint
+ALTER TABLE "groups" ADD COLUMN "links" jsonb NOT NULL DEFAULT '[]'::jsonb;--> statement-breakpoint
+ALTER TABLE "groups" ADD COLUMN "is_published" boolean NOT NULL DEFAULT false;--> statement-breakpoint
+
+CREATE INDEX "groups_published_idx"
+  ON "groups" ("id")
+  WHERE is_active = true AND is_published = true AND deleted_at IS NULL;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778940000000,
       "tag": "0018_organization_merges",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778788921927,
+      "tag": "0019_groups_publishable",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/scripts/import-groups.ts
+++ b/packages/api/scripts/import-groups.ts
@@ -1,0 +1,374 @@
+#!/usr/bin/env node --experimental-strip-types
+/**
+ * Seed-data import for working + affinity groups.
+ *
+ * Reads the two Google Forms exports in `.data/` and:
+ *   - inserts one `groups` row per CSV row (skipping any whose slug already exists)
+ *   - looks up chairs/co-chairs by email and inserts `group_memberships` rows
+ *   - looks up listed initial members (working groups only) by normalized
+ *     display name; only single-match lookups become memberships
+ *
+ * Two modes:
+ *   node --experimental-strip-types packages/api/scripts/import-groups.ts            # dry-run
+ *   node --experimental-strip-types packages/api/scripts/import-groups.ts --commit   # write
+ *
+ * Reads DATABASE_URL from packages/api/.dev.vars.
+ */
+import { neon, type NeonQueryFunction } from "@neondatabase/serverless";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ─── Inputs ─────────────────────────────────────────────────────────
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const WORKING_CSV = path.join(
+  REPO_ROOT,
+  ".data/US-RSE Working Group Creation Form (Responses) - Form Responses 1.csv",
+);
+const AFFINITY_CSV = path.join(
+  REPO_ROOT,
+  ".data/US-RSE Affinity Group Creation Form (Responses) - Form Responses 1.csv",
+);
+
+// ─── CLI args ───────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const COMMIT = args.includes("--commit");
+
+// ─── Tiny CSV parser (handles quoted fields with embedded commas + newlines) ─
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cell += ch;
+      }
+    } else {
+      if (ch === '"') inQuotes = true;
+      else if (ch === ",") {
+        row.push(cell);
+        cell = "";
+      } else if (ch === "\n") {
+        row.push(cell);
+        rows.push(row);
+        row = [];
+        cell = "";
+      } else if (ch === "\r") {
+        /* skip */
+      } else cell += ch;
+    }
+  }
+  if (cell || row.length) {
+    row.push(cell);
+    rows.push(row);
+  }
+  return rows;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function normalizeDisplayName(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function firstSentence(s: string, maxLen = 200): string {
+  const trimmed = s.trim();
+  const period = trimmed.indexOf(". ");
+  if (period > 0 && period < maxLen) return trimmed.slice(0, period + 1);
+  if (trimmed.length <= maxLen) return trimmed;
+  return trimmed.slice(0, maxLen - 1) + "…";
+}
+
+function cleanSlack(raw: string): string | null {
+  const trimmed = raw.trim().replace(/^#+/, "").toLowerCase();
+  return trimmed || null;
+}
+
+function isPlaceholderEmail(email: string): boolean {
+  return /tbd@/i.test(email);
+}
+
+// ─── Per-CSV import ─────────────────────────────────────────────────
+async function importGroups(
+  sql: NeonQueryFunction<false, false>,
+  type: "working_group" | "affinity_group",
+  csvPath: string,
+) {
+  const text = fs.readFileSync(csvPath, "utf8");
+  const [header, ...rows] = parseCsv(text);
+  console.log(
+    `─── ${type} ──── ${rows.length} CSV rows from ${path.basename(csvPath)} ───`,
+  );
+
+  const col = (name: string): number => {
+    const idx = header.indexOf(name);
+    if (idx < 0) {
+      throw new Error(
+        `Missing CSV column "${name}" in ${path.basename(csvPath)}. Available columns: ${header.join(" | ")}`,
+      );
+    }
+    return idx;
+  };
+
+  const NAME = col(
+    type === "working_group" ? "Working Group Name" : "Affinity Group Name",
+  );
+  const PURPOSE = col(
+    type === "working_group" ? "Working Group Purpose" : "One-sentence Description",
+  );
+  const SLACK = col("Slack channel name");
+  const CHAIR_NAME_1 = col(
+    type === "working_group" ? "Chair name" : "Coordinator 1 Name",
+  );
+  // Note: the affinity CSV has a typo — "Coordinate 1 Email" (not "Coordinator 1 Email").
+  const CHAIR_EMAIL_1 = col(
+    type === "working_group" ? "Chair email" : "Coordinate 1 Email",
+  );
+  const CHAIR_NAME_2 = col(
+    type === "working_group" ? "Co-chair name" : "Coordinator 2 Name",
+  );
+  const CHAIR_EMAIL_2 = col(
+    type === "working_group" ? "Co-chair email" : "Coordinator 2 Email",
+  );
+  const INITIAL_MEMBERS = type === "working_group" ? col("Initial Members") : -1;
+
+  // Pre-fetch existing groups by slug (cheap).
+  const existingGroups = await sql`SELECT slug FROM groups`;
+  const existingSlugs = new Set<string>(
+    existingGroups.map((r) => r.slug as string),
+  );
+
+  let inserted = 0;
+  let skipped = 0;
+  const chairAssignments: Array<{
+    groupName: string;
+    email: string;
+    role: "chair" | "co_chair";
+    matched: boolean;
+    userId: string | null;
+  }> = [];
+  const memberAssignments: Array<{
+    groupName: string;
+    rawName: string;
+    matched: boolean;
+    userId: string | null;
+  }> = [];
+
+  for (const row of rows) {
+    const name = (row[NAME] ?? "").trim();
+    if (!name) continue;
+    const slug = slugify(name);
+    if (!slug) {
+      console.log(`  · skipped (no slug-safe chars): ${name}`);
+      continue;
+    }
+    if (existingSlugs.has(slug)) {
+      console.log(`  · skipped (slug already exists): ${slug}`);
+      skipped++;
+      continue;
+    }
+
+    const purpose = (row[PURPOSE] ?? "").trim();
+    const description =
+      type === "working_group" ? firstSentence(purpose, 200) : purpose;
+    const charter = type === "working_group" ? purpose : null;
+    const slackChannel = cleanSlack(row[SLACK] ?? "");
+
+    let groupId: string | null = null;
+    if (COMMIT) {
+      const insertResult = await sql`
+        INSERT INTO groups (name, slug, type, description, charter, slack_channel, links, is_active, is_published)
+        VALUES (${name}, ${slug}, ${type}, ${description || null}, ${charter}, ${slackChannel}, '[]'::jsonb, true, true)
+        RETURNING id
+      `;
+      groupId = insertResult[0].id as string;
+    }
+
+    console.log(`  ✓ ${name}  (slug: ${slug}, type: ${type})`);
+    inserted++;
+    existingSlugs.add(slug);
+
+    // Chair assignments.
+    const chairColumns: Array<[number, number, "chair" | "co_chair"]> = [
+      [CHAIR_EMAIL_1, CHAIR_NAME_1, "chair"],
+      [CHAIR_EMAIL_2, CHAIR_NAME_2, "co_chair"],
+    ];
+    for (const [emailIdx, _nameIdx, role] of chairColumns) {
+      const email = (row[emailIdx] ?? "").trim().toLowerCase();
+      if (!email) continue;
+      if (isPlaceholderEmail(email)) {
+        chairAssignments.push({
+          groupName: name,
+          email,
+          role,
+          matched: false,
+          userId: null,
+        });
+        continue;
+      }
+      const userMatch = await sql`SELECT id FROM users WHERE LOWER(email) = ${email} LIMIT 1`;
+      if (userMatch.length > 0) {
+        const userId = userMatch[0].id as string;
+        if (COMMIT && groupId) {
+          await sql`
+            INSERT INTO group_memberships (user_id, group_id, role)
+            VALUES (${userId}, ${groupId}, ${role})
+            ON CONFLICT (user_id, group_id) DO UPDATE SET role = ${role}
+          `;
+        }
+        chairAssignments.push({
+          groupName: name,
+          email,
+          role,
+          matched: true,
+          userId,
+        });
+      } else {
+        chairAssignments.push({
+          groupName: name,
+          email,
+          role,
+          matched: false,
+          userId: null,
+        });
+      }
+    }
+
+    // Initial members (working_group only).
+    if (INITIAL_MEMBERS >= 0) {
+      const raw = (row[INITIAL_MEMBERS] ?? "").trim();
+      if (raw) {
+        const namesList = raw
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean);
+        for (const memberName of namesList) {
+          const norm = normalizeDisplayName(memberName);
+          if (norm.length < 4) {
+            memberAssignments.push({
+              groupName: name,
+              rawName: memberName,
+              matched: false,
+              userId: null,
+            });
+            continue;
+          }
+          const match = await sql`
+            SELECT u.id FROM users u
+            INNER JOIN profiles p ON p.user_id = u.id
+            WHERE LOWER(REGEXP_REPLACE(p.display_name, '[^a-zA-Z0-9]', '', 'g')) = ${norm}
+            LIMIT 2
+          `;
+          if (match.length === 1) {
+            const userId = match[0].id as string;
+            if (COMMIT && groupId) {
+              await sql`
+                INSERT INTO group_memberships (user_id, group_id, role)
+                VALUES (${userId}, ${groupId}, 'member')
+                ON CONFLICT (user_id, group_id) DO NOTHING
+              `;
+            }
+            memberAssignments.push({
+              groupName: name,
+              rawName: memberName,
+              matched: true,
+              userId,
+            });
+          } else {
+            memberAssignments.push({
+              groupName: name,
+              rawName: memberName,
+              matched: false,
+              userId: null,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Reports.
+  console.log(`\n─── Summary for ${type} ───`);
+  console.log(`  Inserted: ${inserted}, Skipped (slug exists): ${skipped}`);
+
+  const chairsMatched = chairAssignments.filter((a) => a.matched).length;
+  const chairsUnmatched = chairAssignments.filter(
+    (a) => !a.matched && !isPlaceholderEmail(a.email),
+  ).length;
+  const chairsPlaceholder = chairAssignments.filter((a) =>
+    isPlaceholderEmail(a.email),
+  ).length;
+  console.log(
+    `  Chair assignments: ${chairsMatched} matched, ${chairsUnmatched} unmatched, ${chairsPlaceholder} placeholder`,
+  );
+  for (const a of chairAssignments.filter(
+    (a) => !a.matched && !isPlaceholderEmail(a.email),
+  )) {
+    console.log(
+      `    × ${a.email} → ${a.role} of ${a.groupName}  (no user with that email)`,
+    );
+  }
+
+  if (memberAssignments.length) {
+    const membersMatched = memberAssignments.filter((m) => m.matched).length;
+    console.log(
+      `  Initial members: ${membersMatched} matched, ${memberAssignments.length - membersMatched} unmatched/ambiguous`,
+    );
+  }
+  console.log("");
+}
+
+// ─── Main ───────────────────────────────────────────────────────────
+async function main() {
+  const dotEnv = fs.readFileSync(
+    path.join(REPO_ROOT, "packages/api/.dev.vars"),
+    "utf8",
+  );
+  const dbUrl = dotEnv.match(/DATABASE_URL=['"]?([^'"\n]+)/)?.[1];
+  if (!dbUrl) throw new Error("DATABASE_URL not found in .dev.vars");
+  const sql = neon(dbUrl);
+
+  console.log(
+    COMMIT
+      ? "=== COMMIT mode — writes will land ===\n"
+      : "=== DRY-RUN mode (default) — no writes ===\n",
+  );
+
+  await importGroups(sql, "working_group", WORKING_CSV);
+  await importGroups(sql, "affinity_group", AFFINITY_CSV);
+
+  console.log(
+    COMMIT
+      ? "=== COMMITTED ==="
+      : "=== DRY-RUN — re-run with --commit to apply ===",
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/src/db/schema/groups.ts
+++ b/packages/api/src/db/schema/groups.ts
@@ -1,7 +1,8 @@
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import {
   boolean,
   index,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -11,21 +12,34 @@ import {
 import { groupMembershipRole, groupType } from "./enums";
 import { users } from "./users";
 
-export const groups = pgTable("groups", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  name: text("name").notNull(),
-  slug: text("slug").notNull().unique(),
-  type: groupType("type").notNull(),
-  description: text("description"),
-  isActive: boolean("is_active").notNull().default(true),
-  createdAt: timestamp("created_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-  deletedAt: timestamp("deleted_at", { withTimezone: true }),
-});
+export const groups = pgTable(
+  "groups",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    slug: text("slug").notNull().unique(),
+    type: groupType("type").notNull(),
+    description: text("description"),
+    isActive: boolean("is_active").notNull().default(true),
+    // New as of migration 0019:
+    slackChannel: text("slack_channel"),
+    charter: text("charter"),
+    links: jsonb("links").notNull().default(sql`'[]'::jsonb`),
+    isPublished: boolean("is_published").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+  },
+  (t) => [
+    index("groups_published_idx")
+      .on(t.id)
+      .where(sql`is_active = true AND is_published = true AND deleted_at IS NULL`),
+  ]
+);
 
 export const groupMemberships = pgTable(
   "group_memberships",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,6 +5,7 @@ import { meRoute } from "./routes/me";
 import { membersRoute } from "./routes/members";
 import { vocabRoute } from "./routes/vocab";
 import { webhooksRoute } from "./routes/webhooks";
+import { publicGroupsRoute } from "./routes/groups";
 import { adminApi } from "./routes/admin";
 import type { AppEnv } from "./types";
 
@@ -48,6 +49,7 @@ app.route("/webhooks", webhooksRoute);
 app.route("/me", meRoute);
 app.route("/members", membersRoute);
 app.route("/vocab", vocabRoute);
+app.route("/groups", publicGroupsRoute);
 app.route("/admin", adminApi);
 
 export default app;

--- a/packages/api/src/lib/errorChain.ts
+++ b/packages/api/src/lib/errorChain.ts
@@ -1,0 +1,29 @@
+/**
+ * Walk an Error's `cause` chain and collect every message in order.
+ *
+ * Drizzle wraps every Postgres error as a DrizzleQueryError whose outer
+ * `.message` is just `Failed query: <SQL>\nparams: ...` — useful for
+ * context, but the actual reason ("duplicate key value violates unique
+ * constraint", "value too long for type", etc.) lives in `err.cause`.
+ * Any code that wants to react to the *cause* — turning a unique-key
+ * violation into a clean 409, say — needs to read the whole chain, not
+ * just the outermost message.
+ */
+export function collectErrorMessages(err: unknown): string[] {
+  const out: string[] = [];
+  let cur: unknown = err;
+  while (cur instanceof Error) {
+    out.push(cur.message);
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  if (cur !== undefined && cur !== null) out.push(String(cur));
+  return out;
+}
+
+/**
+ * Convenience join — the full chain as one string. Equivalent to
+ * `collectErrorMessages(err).join(" | ")`.
+ */
+export function joinErrorChain(err: unknown): string {
+  return collectErrorMessages(err).join(" | ");
+}

--- a/packages/api/src/lib/member-id.ts
+++ b/packages/api/src/lib/member-id.ts
@@ -1,3 +1,5 @@
+import { buildSlug } from "./slug";
+
 const CROCKFORD_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const MEMBER_ID_LENGTH = 8;
 
@@ -33,16 +35,7 @@ export function buildProfileSlug(
   displayName: string,
   memberId: string
 ): string {
-  const namePart = slugify(displayName);
+  const namePart = buildSlug(displayName);
   const idPart = memberId.toLowerCase();
   return namePart ? `${namePart}-${idPart}` : idPart;
-}
-
-function slugify(s: string): string {
-  return s
-    .toLowerCase()
-    .normalize("NFD") // split accented chars into base + combining mark
-    .replace(/[̀-ͯ]/g, "") // strip combining marks
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
 }

--- a/packages/api/src/lib/policies/canCreateGroup.ts
+++ b/packages/api/src/lib/policies/canCreateGroup.ts
@@ -1,0 +1,10 @@
+import type { ActorContext } from "./types";
+
+/**
+ * Create a brand-new group. Super_admin only — creating a new group is
+ * a governance decision (it allocates admin privilege to whoever
+ * eventually chairs it). Chairs use canEditGroup to manage their
+ * existing groups but can't spin up new ones.
+ */
+export const canCreateGroup = (a: ActorContext): boolean =>
+  a.systemTier >= 2;

--- a/packages/api/src/lib/policies/index.ts
+++ b/packages/api/src/lib/policies/index.ts
@@ -2,6 +2,7 @@ export type { ActorContext } from "./types";
 export { canEnterAdminApp } from "./canEnterAdminApp";
 export { canApproveVocab } from "./canApproveVocab";
 export { canMergeUsers } from "./canMergeUsers";
+export { canCreateGroup } from "./canCreateGroup";
 export { canEditGroup } from "./canEditGroup";
 export { canEditEvent } from "./canEditEvent";
 export { canViewAuditLog } from "./canViewAuditLog";

--- a/packages/api/src/lib/policies/policies.test.ts
+++ b/packages/api/src/lib/policies/policies.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   canApproveVocab,
+  canCreateGroup,
   canEditEvent,
   canEditGroup,
   canEditMembers,
@@ -170,5 +171,17 @@ describe("canPromoteToRole", () => {
   });
   it("plain members cannot grant any role", () => {
     expect(canPromoteToRole(actor(), { newRole: "member" })).toBe(false);
+  });
+});
+
+describe("canCreateGroup", () => {
+  it("denies plain members", () => {
+    expect(canCreateGroup(actor())).toBe(false);
+  });
+  it("denies staff", () => {
+    expect(canCreateGroup(actor({ systemTier: 1 }))).toBe(false);
+  });
+  it("allows super_admin", () => {
+    expect(canCreateGroup(actor({ systemTier: 2 }))).toBe(true);
   });
 });

--- a/packages/api/src/lib/slug.ts
+++ b/packages/api/src/lib/slug.ts
@@ -1,0 +1,20 @@
+/**
+ * Slugify an arbitrary string into a URL-safe identifier:
+ *   - lowercase
+ *   - NFD normalize + strip combining marks (handles accented chars)
+ *   - replace non-[a-z0-9] runs with single hyphens
+ *   - trim leading/trailing hyphens
+ *   - cap at 80 chars
+ *
+ * Returns an empty string when the input has no slug-safe characters
+ * (e.g. "++" or pure punctuation).
+ */
+export function buildSlug(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}

--- a/packages/api/src/routes/admin/groups/byId.ts
+++ b/packages/api/src/routes/admin/groups/byId.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { createDb } from "../../../db";
 import { auditLog, groups, groupMemberships, profiles, users } from "../../../db/schema";
@@ -283,5 +283,125 @@ adminGroupsByIdRoute.post("/reopen", async (c) => {
   c.set("auditAction", "groups.reopen");
   c.set("auditTarget", { type: "groups", id });
   c.set("auditPayload", { name: existing.name });
+  return c.json({ ok: true });
+});
+
+const assignChairBodySchema = z.object({
+  userId: z.uuid(),
+  role: z.enum(["chair", "co_chair"]),
+});
+
+/**
+ * POST /api/admin/groups/:id/chairs
+ *
+ * Body: { userId, role: "chair" | "co_chair" }
+ *
+ * If a membership row exists, upgrade its role. Otherwise insert a
+ * new membership with the given role. Either way, the assigned user
+ * becomes a chair (their actor-context recomputes chairedGroupIds on
+ * the next request — and canEditGroup grants edit access to this
+ * group from that moment on).
+ */
+adminGroupsByIdRoute.post(
+  "/chairs",
+  zValidator("json", assignChairBodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        { ok: false, error: "invalid_input", issues: result.error.issues },
+        400
+      );
+    }
+  }),
+  async (c) => {
+    const id = c.req.param("id");
+    if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+      return c.json({ ok: false, error: "invalid_input" }, 400);
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const db = createDb(c.env.DATABASE_URL);
+    const body = c.req.valid("json");
+
+    const userRow = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, body.userId))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!userRow) return c.json({ ok: false, error: "user_not_found" }, 404);
+
+    const groupRow = await db
+      .select({ id: groups.id })
+      .from(groups)
+      .where(eq(groups.id, id))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!groupRow) return c.json({ ok: false, error: "not_found" }, 404);
+
+    const existing = await db
+      .select({ id: groupMemberships.id, role: groupMemberships.role })
+      .from(groupMemberships)
+      .where(and(eq(groupMemberships.groupId, id), eq(groupMemberships.userId, body.userId)))
+      .limit(1)
+      .then((r) => r[0]);
+
+    if (existing) {
+      if (existing.role === body.role) {
+        return c.json({ ok: true, noChange: true });
+      }
+      await db
+        .update(groupMemberships)
+        .set({ role: body.role })
+        .where(eq(groupMemberships.id, existing.id));
+    } else {
+      await db.insert(groupMemberships).values({
+        userId: body.userId,
+        groupId: id,
+        role: body.role,
+      });
+    }
+
+    c.set("auditAction", "groups.chair_assign");
+    c.set("auditTarget", { type: "groups", id });
+    c.set("auditPayload", { userId: body.userId, role: body.role });
+    return c.json({ ok: true });
+  }
+);
+
+/**
+ * DELETE /api/admin/groups/:id/chairs/:userId
+ *
+ * Demotes a chair to a regular member. Does NOT remove the membership
+ * entirely. Returns 404 not_chair if the user isn't currently a
+ * chair / co_chair of this group.
+ */
+adminGroupsByIdRoute.delete("/chairs/:userId", async (c) => {
+  const id = c.req.param("id");
+  const userId = c.req.param("userId");
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+    return c.json({ ok: false, error: "invalid_input" }, 400);
+  if (!userId || !/^[0-9a-f-]{36}$/i.test(userId))
+    return c.json({ ok: false, error: "invalid_input" }, 400);
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const existing = await db
+    .select({ id: groupMemberships.id, role: groupMemberships.role })
+    .from(groupMemberships)
+    .where(and(eq(groupMemberships.groupId, id), eq(groupMemberships.userId, userId)))
+    .limit(1)
+    .then((r) => r[0]);
+  if (!existing) return c.json({ ok: false, error: "not_chair" }, 404);
+  if (existing.role !== "chair" && existing.role !== "co_chair") {
+    return c.json({ ok: false, error: "not_chair" }, 404);
+  }
+
+  const previousRole = existing.role;
+  await db
+    .update(groupMemberships)
+    .set({ role: "member" })
+    .where(eq(groupMemberships.id, existing.id));
+
+  c.set("auditAction", "groups.chair_remove");
+  c.set("auditTarget", { type: "groups", id });
+  c.set("auditPayload", { userId, previousRole });
   return c.json({ ok: true });
 });

--- a/packages/api/src/routes/admin/groups/byId.ts
+++ b/packages/api/src/routes/admin/groups/byId.ts
@@ -1,0 +1,82 @@
+import { Hono } from "hono";
+import { desc, eq } from "drizzle-orm";
+import { createDb } from "../../../db";
+import { auditLog, groups, groupMemberships, profiles, users } from "../../../db/schema";
+import { canEditGroup } from "../../../lib/policies";
+import { requirePolicy } from "../../../middleware/policy";
+import type { AppEnv } from "../../../types";
+
+export const adminGroupsByIdRoute = new Hono<AppEnv>();
+
+// Apply canEditGroup scope-check on every nested route. The scope
+// extracts groupId from the URL parameter.
+adminGroupsByIdRoute.use(
+  "*",
+  requirePolicy(canEditGroup, (c) => ({ groupId: c.req.param("id") ?? "" }))
+);
+
+/**
+ * GET /api/admin/groups/:id
+ */
+adminGroupsByIdRoute.get("/", async (c) => {
+  const id = c.req.param("id");
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+    return c.json({ ok: false, error: "invalid_input" }, 400);
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const row = await db
+    .select()
+    .from(groups)
+    .where(eq(groups.id, id))
+    .limit(1)
+    .then((r) => r[0] ?? null);
+  if (!row) return c.json({ ok: false, error: "not_found" }, 404);
+
+  const members = await db
+    .select({
+      userId: groupMemberships.userId,
+      role: groupMemberships.role,
+      joinedAt: groupMemberships.joinedAt,
+      email: users.email,
+      displayName: profiles.displayName,
+    })
+    .from(groupMemberships)
+    .innerJoin(users, eq(users.id, groupMemberships.userId))
+    .leftJoin(profiles, eq(profiles.userId, groupMemberships.userId))
+    .where(eq(groupMemberships.groupId, id))
+    .orderBy(desc(groupMemberships.role), desc(groupMemberships.joinedAt));
+
+  const recentAudit = await db
+    .select({
+      id: auditLog.id,
+      actorId: auditLog.actorId,
+      actorRole: auditLog.actorRole,
+      action: auditLog.action,
+      targetType: auditLog.targetType,
+      targetId: auditLog.targetId,
+      createdAt: auditLog.createdAt,
+    })
+    .from(auditLog)
+    .where(eq(auditLog.targetId, id))
+    .orderBy(desc(auditLog.createdAt))
+    .limit(20);
+
+  return c.json({
+    ok: true,
+    group: {
+      ...row,
+      createdAt: row.createdAt instanceof Date ? row.createdAt.toISOString() : row.createdAt,
+      updatedAt: row.updatedAt instanceof Date ? row.updatedAt.toISOString() : row.updatedAt,
+      deletedAt: row.deletedAt instanceof Date ? row.deletedAt.toISOString() : row.deletedAt,
+    },
+    members: members.map((m) => ({
+      ...m,
+      joinedAt: m.joinedAt instanceof Date ? m.joinedAt.toISOString() : m.joinedAt,
+    })),
+    recentAudit: recentAudit.map((a) => ({
+      ...a,
+      createdAt: a.createdAt instanceof Date ? a.createdAt.toISOString() : a.createdAt,
+    })),
+  });
+});

--- a/packages/api/src/routes/admin/groups/byId.ts
+++ b/packages/api/src/routes/admin/groups/byId.ts
@@ -1,5 +1,7 @@
+import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { desc, eq } from "drizzle-orm";
+import { z } from "zod";
 import { createDb } from "../../../db";
 import { auditLog, groups, groupMemberships, profiles, users } from "../../../db/schema";
 import { canEditGroup } from "../../../lib/policies";
@@ -79,4 +81,207 @@ adminGroupsByIdRoute.get("/", async (c) => {
       createdAt: a.createdAt instanceof Date ? a.createdAt.toISOString() : a.createdAt,
     })),
   });
+});
+
+const patchBodySchema = z
+  .object({
+    name: z.string().min(1).max(120).optional(),
+    description: z.string().max(500).nullable().optional(),
+    charter: z.string().max(20000).nullable().optional(),
+    slackChannel: z.string().max(80).nullable().optional(),
+    links: z
+      .array(
+        z.object({
+          label: z.string().min(1).max(80),
+          url: z.string().url().max(500),
+        })
+      )
+      .max(20)
+      .optional(),
+  })
+  .strict();
+
+/**
+ * PATCH /api/admin/groups/:id
+ *
+ * Slug is NOT editable — permalink stability matters even though the
+ * URL itself uses id, because the slug shows up in admin display,
+ * page <title>, and any external link that grabbed it.
+ */
+adminGroupsByIdRoute.patch(
+  "/",
+  zValidator("json", patchBodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        { ok: false, error: "invalid_input", issues: result.error.issues },
+        400
+      );
+    }
+  }),
+  async (c) => {
+    const id = c.req.param("id");
+    if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+      return c.json({ ok: false, error: "invalid_input" }, 400);
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const db = createDb(c.env.DATABASE_URL);
+    const body = c.req.valid("json");
+
+    const existing = await db
+      .select()
+      .from(groups)
+      .where(eq(groups.id, id))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+
+    c.get("auditCapture")?.({ group: existing });
+
+    const next: Partial<typeof existing> = { updatedAt: new Date() };
+    const before: Record<string, unknown> = {};
+    const after: Record<string, unknown> = {};
+    if (body.name !== undefined && body.name !== existing.name) {
+      next.name = body.name;
+      before.name = existing.name;
+      after.name = body.name;
+    }
+    if (body.description !== undefined && body.description !== existing.description) {
+      next.description = body.description;
+      before.description = existing.description;
+      after.description = body.description;
+    }
+    if (body.charter !== undefined && body.charter !== existing.charter) {
+      next.charter = body.charter;
+      before.charter = existing.charter;
+      after.charter = body.charter;
+    }
+    if (body.slackChannel !== undefined && body.slackChannel !== existing.slackChannel) {
+      next.slackChannel = body.slackChannel;
+      before.slackChannel = existing.slackChannel;
+      after.slackChannel = body.slackChannel;
+    }
+    if (body.links !== undefined) {
+      next.links = body.links;
+      before.links = existing.links;
+      after.links = body.links;
+    }
+
+    if (Object.keys(after).length === 0) {
+      return c.json({ ok: true, noChange: true });
+    }
+
+    await db.update(groups).set(next).where(eq(groups.id, id));
+
+    c.set("auditAction", "groups.update");
+    c.set("auditTarget", { type: "groups", id });
+    c.set("auditPayload", { before, after });
+    return c.json({ ok: true });
+  }
+);
+
+/**
+ * POST /api/admin/groups/:id/publish
+ * POST /api/admin/groups/:id/unpublish
+ */
+for (const [path, isPublished, action] of [
+  ["/publish", true, "groups.publish"],
+  ["/unpublish", false, "groups.unpublish"],
+] as const) {
+  adminGroupsByIdRoute.post(path, async (c) => {
+    const id = c.req.param("id");
+    if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+      return c.json({ ok: false, error: "invalid_input" }, 400);
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const db = createDb(c.env.DATABASE_URL);
+
+    const existing = await db
+      .select({ id: groups.id, name: groups.name, isPublished: groups.isPublished })
+      .from(groups)
+      .where(eq(groups.id, id))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+
+    if (existing.isPublished === isPublished) {
+      return c.json({ ok: true, noChange: true });
+    }
+    c.get("auditCapture")?.({ group: existing });
+    await db
+      .update(groups)
+      .set({ isPublished, updatedAt: new Date() })
+      .where(eq(groups.id, id));
+
+    c.set("auditAction", action);
+    c.set("auditTarget", { type: "groups", id });
+    c.set("auditPayload", { name: existing.name });
+    return c.json({ ok: true });
+  });
+}
+
+/**
+ * POST /api/admin/groups/:id/archive
+ *
+ * Soft-archive — sets is_active=false. The deleted_at column is
+ * reserved for hard deletes (not exposed in v1).
+ */
+adminGroupsByIdRoute.post("/archive", async (c) => {
+  const id = c.req.param("id");
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+    return c.json({ ok: false, error: "invalid_input" }, 400);
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const existing = await db
+    .select({ id: groups.id, name: groups.name, isActive: groups.isActive })
+    .from(groups)
+    .where(eq(groups.id, id))
+    .limit(1)
+    .then((r) => r[0]);
+  if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+  if (!existing.isActive) {
+    return c.json(
+      { ok: false, error: "already_archived", message: "Group is already archived." },
+      409
+    );
+  }
+
+  c.get("auditCapture")?.({ group: existing });
+  await db.update(groups).set({ isActive: false, updatedAt: new Date() }).where(eq(groups.id, id));
+
+  c.set("auditAction", "groups.archive");
+  c.set("auditTarget", { type: "groups", id });
+  c.set("auditPayload", { name: existing.name });
+  return c.json({ ok: true });
+});
+
+/**
+ * POST /api/admin/groups/:id/reopen
+ */
+adminGroupsByIdRoute.post("/reopen", async (c) => {
+  const id = c.req.param("id");
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+    return c.json({ ok: false, error: "invalid_input" }, 400);
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const existing = await db
+    .select({ id: groups.id, name: groups.name, isActive: groups.isActive })
+    .from(groups)
+    .where(eq(groups.id, id))
+    .limit(1)
+    .then((r) => r[0]);
+  if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+  if (existing.isActive) {
+    return c.json(
+      { ok: false, error: "already_active", message: "Group is already active." },
+      409
+    );
+  }
+
+  c.get("auditCapture")?.({ group: existing });
+  await db.update(groups).set({ isActive: true, updatedAt: new Date() }).where(eq(groups.id, id));
+
+  c.set("auditAction", "groups.reopen");
+  c.set("auditTarget", { type: "groups", id });
+  c.set("auditPayload", { name: existing.name });
+  return c.json({ ok: true });
 });

--- a/packages/api/src/routes/admin/groups/index.ts
+++ b/packages/api/src/routes/admin/groups/index.ts
@@ -9,6 +9,7 @@ import { canCreateGroup } from "../../../lib/policies";
 import { requirePolicy } from "../../../middleware/policy";
 import { buildSlug } from "../../../lib/slug";
 import type { AppEnv } from "../../../types";
+import { adminGroupsByIdRoute } from "./byId";
 
 export const adminGroupsRoute = new Hono<AppEnv>();
 
@@ -184,6 +185,8 @@ adminGroupsRoute.post(
     }
   }
 );
+
+adminGroupsRoute.route("/:id", adminGroupsByIdRoute);
 
 function emptyCounts() {
   return { total: 0, active: 0, draft: 0, archived: 0 };

--- a/packages/api/src/routes/admin/groups/index.ts
+++ b/packages/api/src/routes/admin/groups/index.ts
@@ -1,0 +1,190 @@
+import { Hono } from "hono";
+import { and, asc, count, eq, inArray, isNull, isNotNull, or } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { createDb } from "../../../db";
+import { groups, groupMemberships } from "../../../db/schema";
+import { canCreateGroup } from "../../../lib/policies";
+import { requirePolicy } from "../../../middleware/policy";
+import { buildSlug } from "../../../lib/slug";
+import type { AppEnv } from "../../../types";
+
+export const adminGroupsRoute = new Hono<AppEnv>();
+
+/**
+ * GET /api/admin/groups
+ *
+ * Staff sees all groups (including unpublished, archived, soft-deleted).
+ * Chairs see only the groups they chair — server-side scope check
+ * uses actor.chairedGroupIds; chair-or-staff is the same gate that
+ * canEditGroup uses elsewhere, just applied list-side.
+ */
+adminGroupsRoute.get("/", async (c) => {
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const actor = c.get("actor");
+  if (!actor) return c.json({ ok: false, error: "internal" }, 500);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const typeFilter = c.req.query("type");
+  const statusFilter = c.req.query("status") ?? "active";
+  const visibilityFilter = c.req.query("visibility") ?? "all";
+
+  const conditions: SQL[] = [];
+  if (statusFilter === "active") conditions.push(isNull(groups.deletedAt));
+  if (statusFilter === "archived") conditions.push(isNotNull(groups.deletedAt));
+  if (visibilityFilter === "published") conditions.push(eq(groups.isPublished, true));
+  if (visibilityFilter === "draft") conditions.push(eq(groups.isPublished, false));
+  if (
+    typeFilter === "working_group" ||
+    typeFilter === "affinity_group" ||
+    typeFilter === "regional_group"
+  ) {
+    conditions.push(eq(groups.type, typeFilter));
+  }
+
+  if (actor.systemTier < 1) {
+    const chairedIds = [...actor.chairedGroupIds];
+    if (chairedIds.length === 0) {
+      return c.json({ ok: true, rows: [], counts: emptyCounts() });
+    }
+    conditions.push(inArray(groups.id, chairedIds));
+  }
+
+  const rows = await db
+    .select({
+      id: groups.id,
+      name: groups.name,
+      slug: groups.slug,
+      type: groups.type,
+      description: groups.description,
+      isActive: groups.isActive,
+      isPublished: groups.isPublished,
+      slackChannel: groups.slackChannel,
+      createdAt: groups.createdAt,
+      updatedAt: groups.updatedAt,
+      deletedAt: groups.deletedAt,
+    })
+    .from(groups)
+    .where(conditions.length ? and(...conditions) : undefined)
+    .orderBy(asc(groups.name));
+
+  const ids = rows.map((r) => r.id);
+  const memberCounts = ids.length
+    ? await db
+        .select({
+          groupId: groupMemberships.groupId,
+          n: count(groupMemberships.userId),
+        })
+        .from(groupMemberships)
+        .where(inArray(groupMemberships.groupId, ids))
+        .groupBy(groupMemberships.groupId)
+    : [];
+  const chairCounts = ids.length
+    ? await db
+        .select({
+          groupId: groupMemberships.groupId,
+          n: count(groupMemberships.userId),
+        })
+        .from(groupMemberships)
+        .where(
+          and(
+            inArray(groupMemberships.groupId, ids),
+            or(
+              eq(groupMemberships.role, "chair"),
+              eq(groupMemberships.role, "co_chair")
+            )!
+          )
+        )
+        .groupBy(groupMemberships.groupId)
+    : [];
+  const memberByGroup = new Map(memberCounts.map((r) => [r.groupId, Number(r.n)]));
+  const chairByGroup = new Map(chairCounts.map((r) => [r.groupId, Number(r.n)]));
+
+  return c.json({
+    ok: true,
+    rows: rows.map((r) => ({
+      ...r,
+      createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : r.createdAt,
+      updatedAt: r.updatedAt instanceof Date ? r.updatedAt.toISOString() : r.updatedAt,
+      deletedAt: r.deletedAt instanceof Date ? r.deletedAt.toISOString() : r.deletedAt,
+      memberCount: memberByGroup.get(r.id) ?? 0,
+      chairCount: chairByGroup.get(r.id) ?? 0,
+    })),
+    counts: {
+      total: rows.length,
+      active: rows.filter((r) => !r.deletedAt && r.isActive).length,
+      draft: rows.filter((r) => !r.isPublished).length,
+      archived: rows.filter((r) => !!r.deletedAt || !r.isActive).length,
+    },
+  });
+});
+
+const createBodySchema = z.object({
+  name: z.string().min(1).max(120),
+  type: z.enum(["working_group", "affinity_group", "regional_group"]),
+  description: z.string().max(500).optional(),
+  slackChannel: z.string().max(80).optional(),
+});
+
+/**
+ * POST /api/admin/groups
+ *
+ * Super_admin only. Slug auto-generated from name; collision → 409.
+ * Returns the new row with is_published=false (draft state).
+ */
+adminGroupsRoute.post(
+  "/",
+  requirePolicy(canCreateGroup, () => undefined),
+  zValidator("json", createBodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        { ok: false, error: "invalid_input", issues: result.error.issues },
+        400
+      );
+    }
+  }),
+  async (c) => {
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const db = createDb(c.env.DATABASE_URL);
+    const body = c.req.valid("json");
+    const slug = buildSlug(body.name);
+    if (!slug) {
+      return c.json({ ok: false, error: "invalid_input", message: "Name has no slug-safe characters." }, 400);
+    }
+
+    try {
+      const inserted = await db
+        .insert(groups)
+        .values({
+          name: body.name,
+          slug,
+          type: body.type,
+          description: body.description ?? null,
+          slackChannel: body.slackChannel ?? null,
+          isActive: true,
+          isPublished: false,
+        })
+        .returning({ id: groups.id, name: groups.name, slug: groups.slug, type: groups.type });
+
+      const row = inserted[0];
+      c.set("auditAction", "groups.create");
+      c.set("auditTarget", { type: "groups", id: row.id });
+      c.set("auditPayload", { name: row.name, slug: row.slug, type: row.type });
+      return c.json({ ok: true, group: row });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("unique") || message.includes("duplicate")) {
+        return c.json(
+          { ok: false, error: "slug_conflict", message: "Another group already uses that slug." },
+          409
+        );
+      }
+      throw err;
+    }
+  }
+);
+
+function emptyCounts() {
+  return { total: 0, active: 0, draft: 0, archived: 0 };
+}

--- a/packages/api/src/routes/admin/index.ts
+++ b/packages/api/src/routes/admin/index.ts
@@ -8,6 +8,7 @@ import { adminAuditRoute } from "./audit";
 import { adminUsersRoute } from "./users";
 import { adminOrganizationsRoute } from "./organizations";
 import { adminVocabRoute } from "./vocab";
+import { adminGroupsRoute } from "./groups";
 
 /**
  * Hono sub-app for /api/admin/*. Order matters:
@@ -28,4 +29,5 @@ adminApi.route("/me", adminMeRoute);
 adminApi.route("/audit", adminAuditRoute);
 adminApi.route("/users", adminUsersRoute);
 adminApi.route("/vocab", adminVocabRoute);
+adminApi.route("/groups", adminGroupsRoute);
 adminApi.route("/organizations", adminOrganizationsRoute);

--- a/packages/api/src/routes/admin/organizations/byId.ts
+++ b/packages/api/src/routes/admin/organizations/byId.ts
@@ -325,11 +325,23 @@ adminOrganizationsByIdRoute.patch(
       // Surface the underlying failure in the response body — this
       // endpoint is gated behind canEditOrganizations (staff+) so an
       // internal SQL error message isn't a security boundary; what IS
-      // a problem is an opaque 500 that makes the admin guess. console.error
-      // logs the keys patched so wrangler tail can identify which input
-      // shape tripped the error.
-      const message = err instanceof Error ? err.message : String(err);
-      const stack = err instanceof Error ? err.stack : undefined;
+      // a problem is an opaque 500 that makes the admin guess.
+      //
+      // Drizzle wraps Postgres errors as DrizzleQueryError where the
+      // outer .message is just "Failed query: <SQL>\nparams: ..." —
+      // the actual Postgres error ("column does not exist", "value too
+      // long", etc.) is in .cause. Walk the chain so the response
+      // includes the real reason.
+      const messages: string[] = [];
+      let cur: unknown = err;
+      let stack: string | undefined;
+      while (cur instanceof Error) {
+        messages.push(cur.message);
+        if (!stack && cur.stack) stack = cur.stack;
+        cur = (cur as { cause?: unknown }).cause;
+      }
+      if (cur !== undefined && cur !== null) messages.push(String(cur));
+      const message = messages.join(" | ");
       console.error(
         "[PATCH /admin/organizations/:id]",
         JSON.stringify({ id, inputKeys: Object.keys(input) }),
@@ -341,6 +353,7 @@ adminOrganizationsByIdRoute.patch(
           ok: false,
           error: "patch_failed",
           message,
+          messages,
           ...(stack ? { stack } : {}),
         },
         500

--- a/packages/api/src/routes/admin/organizations/byId.ts
+++ b/packages/api/src/routes/admin/organizations/byId.ts
@@ -282,44 +282,70 @@ adminOrganizationsByIdRoute.patch(
       return c.json({ ok: true, noop: true });
     }
 
-    const existing = await db
-      .select()
-      .from(organizations)
-      .where(eq(organizations.id, id))
-      .limit(1)
-      .then((r) => r[0]);
-    if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
-
-    c.get("auditCapture")?.({ organization: existing });
-
     try {
-      await db
-        .update(organizations)
-        .set({ ...input, updatedAt: new Date() })
-        .where(eq(organizations.id, id));
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      // The `name` and `slug` columns are unique — a collision should
-      // not 500 the request, it should tell the admin which field
-      // clashed so they can pick a different value.
-      if (/duplicate key value/i.test(msg) || /unique constraint/i.test(msg)) {
-        return c.json(
-          {
-            ok: false,
-            error: "conflict",
-            message:
-              "Another organization already uses that name or slug. Pick a different value.",
-          },
-          409
-        );
+      const existing = await db
+        .select()
+        .from(organizations)
+        .where(eq(organizations.id, id))
+        .limit(1)
+        .then((r) => r[0]);
+      if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+
+      c.get("auditCapture")?.({ organization: existing });
+
+      try {
+        await db
+          .update(organizations)
+          .set({ ...input, updatedAt: new Date() })
+          .where(eq(organizations.id, id));
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        // The `name` and `slug` columns are unique — a collision should
+        // not 500 the request, it should tell the admin which field
+        // clashed so they can pick a different value.
+        if (/duplicate key value/i.test(msg) || /unique constraint/i.test(msg)) {
+          return c.json(
+            {
+              ok: false,
+              error: "conflict",
+              message:
+                "Another organization already uses that name or slug. Pick a different value.",
+            },
+            409
+          );
+        }
+        throw e;
       }
-      throw e;
+
+      c.set("auditAction", "organizations.update");
+      c.set("auditTarget", { type: "organizations", id });
+
+      return c.json({ ok: true });
+    } catch (err) {
+      // Surface the underlying failure in the response body — this
+      // endpoint is gated behind canEditOrganizations (staff+) so an
+      // internal SQL error message isn't a security boundary; what IS
+      // a problem is an opaque 500 that makes the admin guess. console.error
+      // logs the keys patched so wrangler tail can identify which input
+      // shape tripped the error.
+      const message = err instanceof Error ? err.message : String(err);
+      const stack = err instanceof Error ? err.stack : undefined;
+      console.error(
+        "[PATCH /admin/organizations/:id]",
+        JSON.stringify({ id, inputKeys: Object.keys(input) }),
+        message,
+        stack
+      );
+      return c.json(
+        {
+          ok: false,
+          error: "patch_failed",
+          message,
+          ...(stack ? { stack } : {}),
+        },
+        500
+      );
     }
-
-    c.set("auditAction", "organizations.update");
-    c.set("auditTarget", { type: "organizations", id });
-
-    return c.json({ ok: true });
   }
 );
 

--- a/packages/api/src/routes/admin/organizations/byId.ts
+++ b/packages/api/src/routes/admin/organizations/byId.ts
@@ -30,6 +30,7 @@ import {
   validateOrgMerge,
   type PromotableOrgField,
 } from "../../../lib/admin/orgMerge";
+import { collectErrorMessages, joinErrorChain } from "../../../lib/errorChain";
 import type { AppEnv } from "../../../types";
 
 const SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
@@ -299,17 +300,19 @@ adminOrganizationsByIdRoute.patch(
           .set({ ...input, updatedAt: new Date() })
           .where(eq(organizations.id, id));
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
         // The `name` and `slug` columns are unique — a collision should
         // not 500 the request, it should tell the admin which field
-        // clashed so they can pick a different value.
-        if (/duplicate key value/i.test(msg) || /unique constraint/i.test(msg)) {
+        // clashed so they can pick a different value. Drizzle wraps the
+        // Postgres error so the duplicate-key signal lives in
+        // err.cause.message, not err.message — walk the whole chain.
+        const chain = joinErrorChain(e);
+        if (/duplicate key value/i.test(chain) || /unique constraint/i.test(chain)) {
+          const which = /name/i.test(chain) ? "name" : /slug/i.test(chain) ? "slug" : "value";
           return c.json(
             {
               ok: false,
               error: "conflict",
-              message:
-                "Another organization already uses that name or slug. Pick a different value.",
+              message: `Another organization already uses that ${which}. Pick a different value — or if a duplicate row exists, merge it via the duplicates queue first.`,
             },
             409
           );
@@ -326,33 +329,19 @@ adminOrganizationsByIdRoute.patch(
       // endpoint is gated behind canEditOrganizations (staff+) so an
       // internal SQL error message isn't a security boundary; what IS
       // a problem is an opaque 500 that makes the admin guess.
-      //
-      // Drizzle wraps Postgres errors as DrizzleQueryError where the
-      // outer .message is just "Failed query: <SQL>\nparams: ..." —
-      // the actual Postgres error ("column does not exist", "value too
-      // long", etc.) is in .cause. Walk the chain so the response
-      // includes the real reason.
-      const messages: string[] = [];
-      let cur: unknown = err;
-      let stack: string | undefined;
-      while (cur instanceof Error) {
-        messages.push(cur.message);
-        if (!stack && cur.stack) stack = cur.stack;
-        cur = (cur as { cause?: unknown }).cause;
-      }
-      if (cur !== undefined && cur !== null) messages.push(String(cur));
-      const message = messages.join(" | ");
+      const messages = collectErrorMessages(err);
+      const stack = err instanceof Error ? err.stack : undefined;
       console.error(
         "[PATCH /admin/organizations/:id]",
         JSON.stringify({ id, inputKeys: Object.keys(input) }),
-        message,
+        messages.join(" | "),
         stack
       );
       return c.json(
         {
           ok: false,
           error: "patch_failed",
-          message,
+          message: messages.join(" | "),
           messages,
           ...(stack ? { stack } : {}),
         },

--- a/packages/api/src/routes/admin/vocab/byKindId.ts
+++ b/packages/api/src/routes/admin/vocab/byKindId.ts
@@ -14,6 +14,7 @@ import {
 import { executeVocabMerge } from "../../../lib/admin/vocabMerge";
 import { findSimilarApproved } from "../../../lib/admin/vocabSimilarity";
 import { isVocabKind, vocabTableFor, type VocabKind } from "../../../lib/admin/vocabTables";
+import { joinErrorChain } from "../../../lib/errorChain";
 import { buildSlug } from "../../../lib/slug";
 import type { AppEnv } from "../../../types";
 
@@ -229,10 +230,14 @@ adminVocabByKindIdRoute.patch(
     try {
       await db.update(t).set(next).where(eq(t.id, id));
     } catch (err) {
-      // Catch Postgres unique-violation surfaced by Drizzle.
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes("unique") || message.includes("duplicate")) {
-        const which = message.includes("slug") ? "slug_conflict" : "name_conflict";
+      // Catch Postgres unique-violation surfaced by Drizzle. The
+      // duplicate-key signal lives in err.cause.message (Drizzle's
+      // outer .message is just the "Failed query: ..." preamble), so
+      // walk the chain — checking only err.message would miss it and
+      // surface as a generic 500.
+      const chain = joinErrorChain(err);
+      if (chain.includes("unique") || chain.includes("duplicate")) {
+        const which = chain.includes("slug") ? "slug_conflict" : "name_conflict";
         return c.json(
           { ok: false, error: which, message: "Another term already has that value." },
           409

--- a/packages/api/src/routes/admin/vocab/byKindId.ts
+++ b/packages/api/src/routes/admin/vocab/byKindId.ts
@@ -14,6 +14,7 @@ import {
 import { executeVocabMerge } from "../../../lib/admin/vocabMerge";
 import { findSimilarApproved } from "../../../lib/admin/vocabSimilarity";
 import { isVocabKind, vocabTableFor, type VocabKind } from "../../../lib/admin/vocabTables";
+import { buildSlug } from "../../../lib/slug";
 import type { AppEnv } from "../../../types";
 
 export const adminVocabByKindIdRoute = new Hono<AppEnv>();
@@ -412,17 +413,3 @@ adminVocabByKindIdRoute.post(
   }
 );
 
-/**
- * Local slug builder. The same shape lives inside lib/member-id.ts
- * as a private helper. Extracting it to a shared module would be a
- * separate, broader refactor — kept inline here so the vocab work
- * doesn't drag in unrelated changes.
- */
-function buildSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}

--- a/packages/api/src/routes/groups.ts
+++ b/packages/api/src/routes/groups.ts
@@ -1,0 +1,119 @@
+import { Hono } from "hono";
+import { and, asc, eq, isNull, or } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import { createDb } from "../db";
+import { groups, groupMemberships, profiles, users } from "../db/schema";
+import type { AppEnv } from "../types";
+
+export const publicGroupsRoute = new Hono<AppEnv>();
+
+/**
+ * GET /groups?type=<type>
+ *
+ * Public list of published, active, non-deleted groups. Minimal
+ * card shape — no charter, no links, no member roster.
+ */
+publicGroupsRoute.get("/", async (c) => {
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const typeFilter = c.req.query("type");
+  const conditions: SQL[] = [
+    eq(groups.isActive, true),
+    eq(groups.isPublished, true),
+    isNull(groups.deletedAt),
+  ];
+  if (
+    typeFilter === "working_group" ||
+    typeFilter === "affinity_group" ||
+    typeFilter === "regional_group"
+  ) {
+    conditions.push(eq(groups.type, typeFilter));
+  }
+
+  const rows = await db
+    .select({
+      id: groups.id,
+      name: groups.name,
+      slug: groups.slug,
+      type: groups.type,
+      description: groups.description,
+      slackChannel: groups.slackChannel,
+    })
+    .from(groups)
+    .where(and(...conditions))
+    .orderBy(asc(groups.name));
+
+  return c.json({ ok: true, rows });
+});
+
+/**
+ * GET /groups/:id
+ *
+ * Public per-group detail. Includes charter, links, and chair
+ * names/photos (no emails — that's admin-only).
+ */
+publicGroupsRoute.get("/:id", async (c) => {
+  const id = c.req.param("id");
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id))
+    return c.json({ ok: false, error: "invalid_input" }, 400);
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const row = await db
+    .select({
+      id: groups.id,
+      name: groups.name,
+      slug: groups.slug,
+      type: groups.type,
+      description: groups.description,
+      slackChannel: groups.slackChannel,
+      charter: groups.charter,
+      links: groups.links,
+      isActive: groups.isActive,
+      isPublished: groups.isPublished,
+      deletedAt: groups.deletedAt,
+    })
+    .from(groups)
+    .where(eq(groups.id, id))
+    .limit(1)
+    .then((r) => r[0] ?? null);
+
+  // Only published, active, non-deleted groups visible publicly.
+  if (!row || !row.isActive || !row.isPublished || row.deletedAt) {
+    return c.json({ ok: false, error: "not_found" }, 404);
+  }
+
+  const chairs = await db
+    .select({
+      displayName: profiles.displayName,
+      photoUrl: profiles.photoUrl,
+    })
+    .from(groupMemberships)
+    .innerJoin(users, eq(users.id, groupMemberships.userId))
+    .leftJoin(profiles, eq(profiles.userId, groupMemberships.userId))
+    .where(
+      and(
+        eq(groupMemberships.groupId, id),
+        or(
+          eq(groupMemberships.role, "chair"),
+          eq(groupMemberships.role, "co_chair")
+        )!
+      )
+    );
+
+  return c.json({
+    ok: true,
+    group: {
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      type: row.type,
+      description: row.description,
+      slackChannel: row.slackChannel,
+      charter: row.charter,
+      links: row.links,
+      chairs,
+    },
+  });
+});

--- a/packages/api/src/routes/me.ts
+++ b/packages/api/src/routes/me.ts
@@ -18,6 +18,7 @@ import {
 } from "../db/schema";
 import { loadMemberDossier } from "../lib/dossier";
 import { buildProfileSlug } from "../lib/member-id";
+import { buildSlug } from "../lib/slug";
 import { requireAuth } from "../middleware/auth";
 import {
   PhotoUploadError,
@@ -550,20 +551,6 @@ interface VocabResolved {
 }
 
 /**
- * Slugify a free-text name into the kebab-case form used by the
- * vocab tables. Strips anything outside [a-z0-9], collapses runs
- * of separators, and caps at 80 chars to fit the unique index.
- */
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 80);
-}
-
-/**
  * Resolve an "existing or proposed" vocab pick into a concrete row.
  *
  * - When `id` is supplied, validate it exists and is approved.
@@ -608,7 +595,7 @@ async function resolveVocabPick(
 
   const name = input.name!.trim();
   if (!name) return { ok: false, status: 400, message: "Name is empty." };
-  const slug = slugify(name);
+  const slug = buildSlug(name);
   if (!slug) {
     return {
       ok: false,
@@ -965,7 +952,7 @@ async function resolveOrganizationPick(
 
   const name = input.name!.trim();
   if (!name) return { ok: false, status: 400, message: "Name is empty." };
-  const slug = slugify(name);
+  const slug = buildSlug(name);
   if (!slug) {
     return {
       ok: false,


### PR DESCRIPTION
Closes #1960.

Lifecycle management for working / affinity / regional groups across both the admin app and the public site. Hardcoded public group lists become DB-driven; admin gains a list + 4-tab detail editor for every group.

Spec: \`docs/superpowers/specs/2026-05-14-admin-groups-design.md\`
Plan: \`docs/superpowers/plans/2026-05-14-admin-groups-implementation.md\`

## Summary

**Data model**
- Migration 0019 adds \`slack_channel\`, \`charter\`, \`links\` (jsonb), \`is_published\` to the existing \`groups\` table + partial index on the public hot path

**Policies**
- \`canCreateGroup\` (super_admin only) for new groups
- \`canEditGroup\` (existing, chairs+staff scoped) gates all admin mutations

**Library**
- Extracted shared \`buildSlug\` helper to \`lib/slug.ts\`; replaced three duplicates across me.ts, vocab/byKindId.ts, member-id.ts

**API (under \`/api/admin/groups/*\`)**
- \`GET /\` — list. Staff sees all; chairs see only chaired groups
- \`POST /\` — create (super_admin only)
- \`GET /:id\` — detail with members + audit
- \`PATCH /:id\` — edit name/description/charter/slackChannel/links
- \`POST /:id/publish\`, \`/:id/unpublish\`, \`/:id/archive\`, \`/:id/reopen\` — lifecycle
- \`POST /:id/chairs\` — assign chair or co-chair (upgrades existing membership or inserts new)
- \`DELETE /:id/chairs/:userId\` — demote chair to regular member

**Public API (no auth)**
- \`GET /groups?type=<type>\` — list of published, active, non-deleted groups
- \`GET /groups/:id\` — single group with charter + links + chair names/photos (no emails)

**Frontend**
- \`/groups\` admin list with kind/status/visibility filters + \`+ New group\` modal (super_admin only)
- \`/groups/:id\` admin detail with 4 tabs: Identity, Content, Roster + chairs, Lifecycle + audit
- \`WorkingGroupsPage\` + \`AffinityGroupsPage\` refactored to DB-driven via new \`useGroups\` hook
- New \`/community/groups/:id\` per-group public page
- New \`/community/regional-groups\` list page (graceful empty state — zero regional groups yet)
- \`/community/calls\` redirects to \`/community/working-groups\` as a placeholder (post-merge: swap to the Community Calls group's permalink once an admin knows its UUID)

**Audit log on every mutation**: groups.create / .update / .publish / .unpublish / .archive / .reopen / .chair_assign / .chair_remove

**Tests / CI**
- 3 new policy assertions for \`canCreateGroup\`
- Existing 67 vitest assertions all green
- Playwright smoke extended (8 → 10 cases)

**Seed data**
- Standalone TypeScript script at \`packages/api/scripts/import-groups.ts\` (\`--dry-run\` default, \`--commit\` to write)
- Already executed against dev DB: 28 groups (11 working + 17 affinity), 38 chair memberships, 21 initial-member rows

## Test plan
- [ ] Sign in as super_admin
- [ ] Browse \`/groups\` — see all 28 imported groups with chair/member counts
- [ ] Click + New group, create a draft, verify it lands with \`isPublished=false\`
- [ ] Edit charter + slack channel + links on the new group, publish
- [ ] Visit \`/community/groups/<new id>\` on the public site, verify it renders
- [ ] Assign a chair via the Roster tab; verify the assignee can edit the group on next request
- [ ] Demote that chair; verify they lose edit access
- [ ] Archive a group; verify it disappears from public list and shows archived in admin
- [ ] Reopen; verify visible again
- [ ] Sign in as a chair, verify the admin \`/groups\` list shows ONLY their chaired groups

## Known follow-ups (not blocking)
- 16 unmatched chair emails from the import (admins whose user rows don't exist yet) — see \`import-groups.ts\` output. Create user accounts, re-run \`--commit\` to fill in.
- \`/community/calls\` redirect target is the working-groups list. Swap to the Community Calls group's permalink once an admin confirms its UUID.
- Side-nav arrays in other public pages still link to \`/community/calls\` — they'll redirect cleanly via the placeholder but should point at the new permalink.
- Affinity sub-categorization (Leadership / Domain / Language / Organizational) was on the hardcoded data and isn't on the schema yet. The DB-driven cards show "Affinity group" generically. File as a schema addition if the subcategories are load-bearing.
- \`CommunityLayout\` sidebar still hardcodes "Community Calls" → \`/community/calls\` — follow-up update.