### PR TITLE
feat(db): add slack_username to profiles

### DIFF
--- a/packages/api/migrations/0021_profile_slack_username.sql
+++ b/packages/api/migrations/0021_profile_slack_username.sql
@@ -1,0 +1,15 @@
+-- Adds slack_username to profiles for member→Slack identity mapping.
+-- Used by the groups-slack reconciliation script to backfill from
+-- the .data/us-rse-groups.csv export and to surface a "Slack:
+-- @handle" affordance on the public member profile.
+
+ALTER TABLE profiles
+  ADD COLUMN slack_username text;--> statement-breakpoint
+
+-- Partial unique index — null/empty values don't collide. Postgres
+-- already treats NULLs as distinct in standard UNIQUE constraints,
+-- but the partial form makes the intent explicit and means future
+-- "(NULL = NULL handling) NULLS NOT DISTINCT" changes won't surprise us.
+CREATE UNIQUE INDEX profiles_slack_username_idx
+  ON profiles (lower(slack_username))
+  WHERE slack_username IS NOT NULL;

--- a/packages/api/src/db/schema/users.ts
+++ b/packages/api/src/db/schema/users.ts
@@ -134,6 +134,7 @@ export const profiles = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
+    slackUsername: text("slack_username"),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
   },
   (t) => [
@@ -141,6 +142,9 @@ export const profiles = pgTable(
     index("profiles_show_on_map_idx")
       .on(t.showOnMap)
       .where(sql`show_on_map = true`),
+    uniqueIndex("profiles_slack_username_idx")
+      .on(sql`lower(slack_username)`)
+      .where(sql`slack_username IS NOT NULL`),
   ]
 );
 


### PR DESCRIPTION
## Summary

Adds a `slack_username text` column to `profiles` (migration 0021) so the upcoming groups-slack reconciliation script can attribute Slack handles from `.data/us-rse-groups.csv` to US-RSE accounts. The column is optional, NULL-tolerant, and protected by a case-insensitive partial unique index via `lower(slack_username)`.

## Why now

`.data/us-rse-groups.csv` carries Slack usernames for ~700 members across the 36 working/affinity/regional channels. Without this column, we can't:
- Backfill the member→Slack mapping
- Surface a "Slack: @handle" link on the public profile
- Join (channel, slack_username) tuples from the CSV against existing users to write `group_memberships` rows

## Note

`regional_group` is **already** a value of the `group_type` enum (initial schema), so this PR doesn't include the enum migration originally scoped — verified in DB before writing.

## Test plan

- [ ] Migration applied locally
- [ ] Typecheck passes
- [ ] PATCH /api/admin/users/:id can write slack_username via the existing patch path (no separate admin UI yet — that comes in PR C)

## Follow-up PRs

- **PR B** — `reconcile-groups.ts` script: matches CSV channels to DB groups, updates descriptions, inserts missing regional groups
- **PR C** — `link-slack-users.ts` script: confidence-scored Slack→user matching + group_memberships backfill + admin profile-editor field