### PR TITLE
feat(scripts): reconcile groups from Slack CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ Thumbs.db
 
 # Project-specific
 /.data/
+
+# Backfill / reconcile script report CSVs (generated locally, not source)
+packages/api/org-*.csv
+packages/api/scripts/*.csv

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,8 @@
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx scripts/seed.ts",
     "db:apply": "tsx scripts/apply-migration.ts",
-    "import:orcid": "tsx scripts/import-orcid.ts"
+    "import:orcid": "tsx scripts/import-orcid.ts",
+    "reconcile:groups": "tsx scripts/reconcile-groups.ts"
   },
   "dependencies": {
     "@hono/zod-validator": "^0.7.6",

--- a/packages/api/scripts/cleanup-regional-groups.ts
+++ b/packages/api/scripts/cleanup-regional-groups.ts
@@ -1,0 +1,144 @@
+/**
+ * One-shot cleanup for the regional_group type drift surfaced by the
+ * reconcile-groups run on 2026-05-19:
+ *
+ *   - Soft-deletes 3 duplicate inserts that landed during the partial
+ *     --commit crash (bay-area-ca, chicago-rse, indiana). Their legacy
+ *     affinity_group counterparts are already published with member
+ *     history, so we keep those and retype them.
+ *   - Retypes 7 legacy affinity_group rows that should have been
+ *     regional_group from the start. The reconcile script flagged
+ *     these as `type_mismatch` but does not auto-retype.
+ *   - Repairs the DMV row's slack_channel value — it was set to an
+ *     apologetic note instead of the actual channel ("rg-dmv-rse").
+ *
+ * Dry-run by default; --commit applies.
+ */
+
+import { neon } from "@neondatabase/serverless";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+
+interface SoftDeleteAction {
+  kind: "soft_delete";
+  slug: string;
+  reason: string;
+}
+
+interface RetypeAction {
+  kind: "retype";
+  slug: string;
+  fixSlackChannel?: string;
+}
+
+type Action = SoftDeleteAction | RetypeAction;
+
+const ACTIONS: Action[] = [
+  // Soft-delete the duplicate auto-generated inserts.
+  {
+    kind: "soft_delete",
+    slug: "bay-area-ca",
+    reason: "Duplicate of legacy bay-area-california; legacy kept + retyped.",
+  },
+  {
+    kind: "soft_delete",
+    slug: "chicago-rse",
+    reason: "Duplicate of legacy regional-group-chicago; legacy kept + retyped.",
+  },
+  {
+    kind: "soft_delete",
+    slug: "indiana",
+    reason: "Duplicate of legacy indiana-regional-group; legacy kept + retyped.",
+  },
+
+  // Retype the 7 legacy affinity_group rows whose CSV channel is rg-*.
+  { kind: "retype", slug: "bay-area-california" },
+  { kind: "retype", slug: "regional-group-chicago" },
+  { kind: "retype", slug: "indiana-regional-group" },
+  { kind: "retype", slug: "north-carolina-research-software-engineers-nc-rse" },
+  { kind: "retype", slug: "new-york-city-rse-regional-group" },
+  { kind: "retype", slug: "st-louis-metro-regional-group" },
+  // DMV also needs slack_channel repaired — the legacy value embeds an
+  // apologetic admin note rather than a real channel handle.
+  { kind: "retype", slug: "dmv-rse", fixSlackChannel: "rg-dmv-rse" },
+];
+
+async function main() {
+  const commit = process.argv.includes("--commit");
+  const conn = process.env.DATABASE_URL;
+  if (!conn) {
+    console.error("DATABASE_URL not set");
+    process.exit(1);
+  }
+  const sql = neon(conn);
+
+  console.log(`=== ${commit ? "COMMIT" : "DRY-RUN"} mode ===\n`);
+
+  for (const action of ACTIONS) {
+    const [row] = await sql`
+      SELECT id, slug, name, type, slack_channel, deleted_at
+      FROM groups
+      WHERE slug = ${action.slug}
+    `;
+    if (!row) {
+      console.log(`SKIP  ${action.slug}: not found`);
+      continue;
+    }
+
+    if (action.kind === "soft_delete") {
+      if (row.deleted_at) {
+        console.log(`SKIP  ${action.slug}: already soft-deleted`);
+        continue;
+      }
+      console.log(
+        `DEL   ${action.slug} (${row.type}) — ${action.reason}`
+      );
+      if (commit) {
+        await sql`UPDATE groups SET deleted_at = now(), updated_at = now() WHERE id = ${row.id}`;
+      }
+    } else {
+      const updates: string[] = [];
+      if (row.type !== "regional_group") updates.push(`type→regional_group`);
+      if (action.fixSlackChannel && row.slack_channel !== action.fixSlackChannel) {
+        updates.push(`slack_channel→${action.fixSlackChannel}`);
+      }
+      if (updates.length === 0) {
+        console.log(`SKIP  ${action.slug}: already correct`);
+        continue;
+      }
+      console.log(`FIX   ${action.slug} — ${updates.join(", ")}`);
+      if (commit) {
+        if (action.fixSlackChannel) {
+          await sql`
+            UPDATE groups
+            SET type = 'regional_group',
+                slack_channel = ${action.fixSlackChannel},
+                updated_at = now()
+            WHERE id = ${row.id}
+          `;
+        } else {
+          await sql`
+            UPDATE groups
+            SET type = 'regional_group',
+                updated_at = now()
+            WHERE id = ${row.id}
+          `;
+        }
+      }
+    }
+  }
+
+  if (!commit) console.log("\n=== Re-run with --commit to apply ===");
+  else console.log("\n=== Done ===");
+}
+
+const isMain =
+  process.argv[1] && process.argv[1].endsWith(path.basename(__filename));
+if (isMain) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/packages/api/scripts/lib/groupReconcile.ts
+++ b/packages/api/scripts/lib/groupReconcile.ts
@@ -54,29 +54,45 @@ export interface ExistingGroup {
   description: string | null;
 }
 
+export interface GroupMatch {
+  group: ExistingGroup;
+  typeMismatch: boolean;
+}
+
 /**
  * Match a CSV channel to an existing DB group. Priority:
- *   1. Exact (normalized) slack_channel match
- *   2. Normalized type-suffix of channel matches normalized group slug
- *
- * Type mismatch (e.g. channel is rg-* but DB group is working_group) → return null.
+ *   1. Exact (normalized) slack_channel match — checked across ALL types,
+ *      since slack_channel is globally unique. A cross-type match returns
+ *      `typeMismatch: true` so the runner can flag it for admin review
+ *      without silently retyping the row.
+ *   2. Type-scoped slug match (no cross-type slug match — slugs can repeat).
  */
 export function matchExistingGroup(
   channel: { name: string; type: CsvType },
   groupsByType: Record<GroupType, ExistingGroup[]>
-): ExistingGroup | null {
+): GroupMatch | null {
   const expectedType = channelTypeToGroupType(channel.type);
-  const candidates = groupsByType[expectedType];
-  if (!candidates) return null;
-
   const normalizedChannel = normalizeForMatch(channel.name);
   const normalizedSuffix = normalizeForMatch(stripTypePrefix(channel.name));
 
-  return (
-    candidates.find(
-      (g) => g.slackChannel && normalizeForMatch(g.slackChannel) === normalizedChannel
-    ) ??
-    candidates.find((g) => normalizeForMatch(g.slug) === normalizedSuffix) ??
-    null
+  // Pass 1: slack_channel match across all types.
+  const allGroups = ([] as ExistingGroup[]).concat(
+    groupsByType.working_group,
+    groupsByType.affinity_group,
+    groupsByType.regional_group
   );
+  const bySlack = allGroups.find(
+    (g) => g.slackChannel && normalizeForMatch(g.slackChannel) === normalizedChannel
+  );
+  if (bySlack) {
+    return { group: bySlack, typeMismatch: bySlack.type !== expectedType };
+  }
+
+  // Pass 2: type-scoped slug match.
+  const candidates = groupsByType[expectedType];
+  if (!candidates) return null;
+  const bySlug = candidates.find((g) => normalizeForMatch(g.slug) === normalizedSuffix);
+  if (bySlug) return { group: bySlug, typeMismatch: false };
+
+  return null;
 }

--- a/packages/api/scripts/lib/groupReconcile.ts
+++ b/packages/api/scripts/lib/groupReconcile.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure helpers for group-reconciliation logic.
+ * Kept free of any DB imports so unit tests run without a connection.
+ */
+
+export type CsvType = "wg" | "ag" | "rg";
+export type GroupType = "working_group" | "affinity_group" | "regional_group";
+
+export function channelTypeToGroupType(t: CsvType): GroupType {
+  return t === "wg" ? "working_group" : t === "ag" ? "affinity_group" : "regional_group";
+}
+
+/**
+ * Strip the type prefix from a channel name.
+ * "wg-code-review" → "code-review"
+ */
+export function stripTypePrefix(name: string): string {
+  return name.replace(/^(wg|ag|rg)-/, "");
+}
+
+/**
+ * Normalize for fuzzy comparison: remove dashes/underscores/spaces, lowercase.
+ * Used to match CSV "rg-bay-area-ca" against DB "rg-bayareaca".
+ */
+export function normalizeForMatch(s: string): string {
+  return s.toLowerCase().replace(/[-_\s]+/g, "");
+}
+
+/**
+ * Title-case a slug suffix.
+ * "code-review" → "Code Review"
+ */
+export function deriveDisplayName(suffix: string): string {
+  return suffix
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/**
+ * Derive the URL slug for a new group from the CSV channel name.
+ * Strips the type prefix; buildSlug is called by the runner for final normalization.
+ * "rg-bay-area-ca" → "bay-area-ca"
+ */
+export function deriveSlug(channelName: string): string {
+  return stripTypePrefix(channelName);
+}
+
+export interface ExistingGroup {
+  id: string;
+  slug: string;
+  type: GroupType;
+  slackChannel: string | null;
+  description: string | null;
+}
+
+/**
+ * Match a CSV channel to an existing DB group. Priority:
+ *   1. Exact (normalized) slack_channel match
+ *   2. Normalized type-suffix of channel matches normalized group slug
+ *
+ * Type mismatch (e.g. channel is rg-* but DB group is working_group) → return null.
+ */
+export function matchExistingGroup(
+  channel: { name: string; type: CsvType },
+  groupsByType: Record<GroupType, ExistingGroup[]>
+): ExistingGroup | null {
+  const expectedType = channelTypeToGroupType(channel.type);
+  const candidates = groupsByType[expectedType];
+  if (!candidates) return null;
+
+  const normalizedChannel = normalizeForMatch(channel.name);
+  const normalizedSuffix = normalizeForMatch(stripTypePrefix(channel.name));
+
+  return (
+    candidates.find(
+      (g) => g.slackChannel && normalizeForMatch(g.slackChannel) === normalizedChannel
+    ) ??
+    candidates.find((g) => normalizeForMatch(g.slug) === normalizedSuffix) ??
+    null
+  );
+}

--- a/packages/api/scripts/reconcile-groups.test.ts
+++ b/packages/api/scripts/reconcile-groups.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  channelTypeToGroupType,
+  deriveDisplayName,
+  deriveSlug,
+  matchExistingGroup,
+  normalizeForMatch,
+  stripTypePrefix,
+} from "./lib/groupReconcile";
+
+describe("channelTypeToGroupType", () => {
+  it("maps wg/ag/rg to enum values", () => {
+    expect(channelTypeToGroupType("wg")).toBe("working_group");
+    expect(channelTypeToGroupType("ag")).toBe("affinity_group");
+    expect(channelTypeToGroupType("rg")).toBe("regional_group");
+  });
+});
+
+describe("stripTypePrefix", () => {
+  it("removes wg-/ag-/rg- prefixes", () => {
+    expect(stripTypePrefix("wg-code-review")).toBe("code-review");
+    expect(stripTypePrefix("ag-aiml")).toBe("aiml");
+    expect(stripTypePrefix("rg-bay-area-ca")).toBe("bay-area-ca");
+  });
+  it("returns unchanged when no prefix", () => {
+    expect(stripTypePrefix("plain")).toBe("plain");
+  });
+});
+
+describe("normalizeForMatch", () => {
+  it("strips dashes/underscores and lowercases", () => {
+    expect(normalizeForMatch("Bay-Area-CA")).toBe("bayareaca");
+    expect(normalizeForMatch("rg_nyc")).toBe("rgnyc");
+  });
+  it("strips multiple consecutive separators", () => {
+    expect(normalizeForMatch("foo--bar")).toBe("foobar");
+  });
+});
+
+describe("deriveDisplayName", () => {
+  it("title-cases a slug suffix", () => {
+    expect(deriveDisplayName("code-review")).toBe("Code Review");
+    expect(deriveDisplayName("bay-area-ca")).toBe("Bay Area Ca");
+  });
+  it("handles single-word suffix", () => {
+    expect(deriveDisplayName("aiml")).toBe("Aiml");
+  });
+});
+
+describe("deriveSlug", () => {
+  it("strips type prefix only", () => {
+    expect(deriveSlug("rg-new-england")).toBe("new-england");
+  });
+  it("strips wg prefix", () => {
+    expect(deriveSlug("wg-testing")).toBe("testing");
+  });
+});
+
+describe("matchExistingGroup", () => {
+  const groupsByType = {
+    working_group: [
+      {
+        id: "g1",
+        slug: "code-review",
+        type: "working_group" as const,
+        slackChannel: "wg-code-review",
+        description: null,
+      },
+      {
+        id: "g2",
+        slug: "user-experience-ux",
+        type: "working_group" as const,
+        slackChannel: "wg-ux",
+        description: "Existing.",
+      },
+    ],
+    affinity_group: [
+      {
+        id: "g3",
+        slug: "neuro-rse",
+        type: "affinity_group" as const,
+        slackChannel: null,
+        description: null,
+      },
+    ],
+    regional_group: [
+      {
+        id: "g4",
+        slug: "bay-area-california",
+        type: "regional_group" as const,
+        slackChannel: "rg-bayareaca",
+        description: null,
+      },
+    ],
+  };
+
+  it("matches by exact normalized slack_channel", () => {
+    const m = matchExistingGroup({ name: "wg-code-review", type: "wg" }, groupsByType);
+    expect(m?.id).toBe("g1");
+  });
+
+  it("matches rg-bay-area-ca against drifted DB value rg-bayareaca via normalization", () => {
+    const m = matchExistingGroup({ name: "rg-bay-area-ca", type: "rg" }, groupsByType);
+    expect(m?.id).toBe("g4");
+  });
+
+  it("matches by slug when slack_channel is null", () => {
+    const m = matchExistingGroup({ name: "ag-neuro-rse", type: "ag" }, groupsByType);
+    expect(m?.id).toBe("g3");
+  });
+
+  it("returns null when no candidate exists", () => {
+    const m = matchExistingGroup({ name: "rg-nowhere", type: "rg" }, groupsByType);
+    expect(m).toBeNull();
+  });
+
+  it("does not match across types (wg-* must not match affinity_group)", () => {
+    const m = matchExistingGroup({ name: "wg-neuro-rse", type: "wg" }, groupsByType);
+    expect(m).toBeNull();
+  });
+
+  it("prefers slack_channel match over slug match", () => {
+    // g2 has slack_channel "wg-ux" — a channel named "wg-ux" should hit it via
+    // slack_channel before trying slug.
+    const m = matchExistingGroup({ name: "wg-ux", type: "wg" }, groupsByType);
+    expect(m?.id).toBe("g2");
+  });
+});

--- a/packages/api/scripts/reconcile-groups.test.ts
+++ b/packages/api/scripts/reconcile-groups.test.ts
@@ -96,17 +96,20 @@ describe("matchExistingGroup", () => {
 
   it("matches by exact normalized slack_channel", () => {
     const m = matchExistingGroup({ name: "wg-code-review", type: "wg" }, groupsByType);
-    expect(m?.id).toBe("g1");
+    expect(m?.group.id).toBe("g1");
+    expect(m?.typeMismatch).toBe(false);
   });
 
   it("matches rg-bay-area-ca against drifted DB value rg-bayareaca via normalization", () => {
     const m = matchExistingGroup({ name: "rg-bay-area-ca", type: "rg" }, groupsByType);
-    expect(m?.id).toBe("g4");
+    expect(m?.group.id).toBe("g4");
+    expect(m?.typeMismatch).toBe(false);
   });
 
   it("matches by slug when slack_channel is null", () => {
     const m = matchExistingGroup({ name: "ag-neuro-rse", type: "ag" }, groupsByType);
-    expect(m?.id).toBe("g3");
+    expect(m?.group.id).toBe("g3");
+    expect(m?.typeMismatch).toBe(false);
   });
 
   it("returns null when no candidate exists", () => {
@@ -114,15 +117,37 @@ describe("matchExistingGroup", () => {
     expect(m).toBeNull();
   });
 
-  it("does not match across types (wg-* must not match affinity_group)", () => {
+  it("flags cross-type slack_channel match as typeMismatch", () => {
+    // A legacy affinity_group row has slack_channel 'rg-dmv-rse' but a
+    // CSV rg-* channel arrives — should match via slack_channel and flag.
+    const withLegacy = {
+      ...groupsByType,
+      affinity_group: [
+        ...groupsByType.affinity_group,
+        {
+          id: "g5",
+          slug: "dmv-rse",
+          type: "affinity_group" as const,
+          slackChannel: "rg-dmv-rse",
+          description: null,
+        },
+      ],
+    };
+    const m = matchExistingGroup({ name: "rg-dmv-rse", type: "rg" }, withLegacy);
+    expect(m?.group.id).toBe("g5");
+    expect(m?.typeMismatch).toBe(true);
+  });
+
+  it("slug match is type-scoped (wg-* must not match affinity_group via slug)", () => {
+    // g3 is an affinity_group with slug 'neuro-rse'. A wg-neuro-rse channel
+    // should not match it via slug (only via slack_channel if it were equal,
+    // which it isn't here).
     const m = matchExistingGroup({ name: "wg-neuro-rse", type: "wg" }, groupsByType);
     expect(m).toBeNull();
   });
 
   it("prefers slack_channel match over slug match", () => {
-    // g2 has slack_channel "wg-ux" — a channel named "wg-ux" should hit it via
-    // slack_channel before trying slug.
     const m = matchExistingGroup({ name: "wg-ux", type: "wg" }, groupsByType);
-    expect(m?.id).toBe("g2");
+    expect(m?.group.id).toBe("g2");
   });
 });

--- a/packages/api/scripts/reconcile-groups.ts
+++ b/packages/api/scripts/reconcile-groups.ts
@@ -1,0 +1,280 @@
+#!/usr/bin/env tsx
+/**
+ * Reconcile the Slack channel export (.data/us-rse-groups.csv) against the
+ * groups table.
+ *
+ * For each channel in the CSV the script will:
+ *   - Find a matching DB group (by normalized slack_channel or slug).
+ *   - If matched:
+ *       • Normalize slack_channel to the canonical CSV form if it has drifted.
+ *       • Backfill description from the channel purpose when the DB column is
+ *         null/empty and the CSV has content.
+ *   - If unmatched: insert a new group row (is_published=false so admins
+ *     review before the group appears publicly).
+ *
+ * Runs in dry-run mode by default.
+ * Pass --commit to write changes to the database.
+ *
+ * Usage:
+ *   npx tsx scripts/reconcile-groups.ts           # dry-run
+ *   npx tsx scripts/reconcile-groups.ts --commit  # apply
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { eq } from "drizzle-orm";
+import { createDb } from "../src/db";
+import { groups } from "../src/db/schema";
+import { buildSlug } from "../src/lib/slug";
+import {
+  channelTypeToGroupType,
+  deriveDisplayName,
+  matchExistingGroup,
+  stripTypePrefix,
+  type CsvType,
+  type GroupType,
+} from "./lib/groupReconcile";
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ─── CSV parser ──────────────────────────────────────────────────────────────
+// Minimal RFC 4180 parser: handles quoted fields with embedded commas/newlines
+// and escaped double-quotes (""). The `purpose` column commonly contains commas.
+function parseCsv(raw: string): Array<Record<string, string>> {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuote = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    if (inQuote) {
+      if (c === '"') {
+        if (raw[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuote = false;
+        }
+      } else {
+        field += c;
+      }
+    } else {
+      if (c === '"') {
+        inQuote = true;
+      } else if (c === ",") {
+        row.push(field);
+        field = "";
+      } else if (c === "\n") {
+        row.push(field);
+        field = "";
+        if (row.some((x) => x.length > 0)) rows.push(row);
+        row = [];
+      } else if (c === "\r") {
+        /* skip */
+      } else {
+        field += c;
+      }
+    }
+  }
+  // Flush final row.
+  if (field || row.length) {
+    row.push(field);
+    if (row.some((x) => x.length > 0)) rows.push(row);
+  }
+
+  if (!rows.length) return [];
+  const header = rows[0];
+  return rows.slice(1).map((r) => {
+    const obj: Record<string, string> = {};
+    header.forEach((h, i) => {
+      obj[h] = r[i] ?? "";
+    });
+    return obj;
+  });
+}
+
+// ─── Channel snapshot ────────────────────────────────────────────────────────
+interface ChannelSnapshot {
+  type: CsvType;
+  name: string;
+  channelId: string;
+  purpose: string;
+  memberCount: number;
+}
+
+/**
+ * Collapse the per-member rows into one snapshot per unique channel_name.
+ */
+function summarizeChannels(rows: Array<Record<string, string>>): ChannelSnapshot[] {
+  const map = new Map<string, ChannelSnapshot>();
+  for (const r of rows) {
+    const name = r.channel_name;
+    if (!name) continue;
+    const existing = map.get(name);
+    if (existing) {
+      existing.memberCount++;
+    } else {
+      map.set(name, {
+        type: r.channel_type as CsvType,
+        name,
+        channelId: r.channel_id ?? "",
+        purpose: r.purpose ?? "",
+        memberCount: 1,
+      });
+    }
+  }
+  return [...map.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ─── CLI flags ───────────────────────────────────────────────────────────────
+interface Flags {
+  commit: boolean;
+}
+
+function parseArgs(argv: string[]): Flags {
+  return { commit: argv.includes("--commit") };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+async function main() {
+  const flags = parseArgs(process.argv.slice(2));
+
+  const conn = process.env.DATABASE_URL;
+  if (!conn) {
+    console.error("DATABASE_URL not set");
+    process.exit(1);
+  }
+
+  // Locate the canonical CSV relative to the repo root.
+  const csvPath = path.resolve(
+    path.dirname(__filename),
+    "..",  // packages/api/
+    "..",  // packages/
+    "..",  // repo root
+    ".data/us-rse-groups.csv"
+  );
+  const raw = fs.readFileSync(csvPath, "utf8");
+  const rows = parseCsv(raw);
+  const channels = summarizeChannels(rows);
+
+  const db = createDb(conn);
+  const existing = await db
+    .select({
+      id: groups.id,
+      slug: groups.slug,
+      type: groups.type,
+      slackChannel: groups.slackChannel,
+      description: groups.description,
+    })
+    .from(groups);
+
+  const groupsByType: Record<GroupType, typeof existing> = {
+    working_group: [],
+    affinity_group: [],
+    regional_group: [],
+  };
+  for (const g of existing) {
+    groupsByType[g.type as GroupType].push(g);
+  }
+
+  console.log(`=== ${flags.commit ? "COMMIT" : "DRY-RUN"} mode ===`);
+  console.log(`Channels in CSV: ${channels.length}`);
+  console.log(`Existing DB groups: ${existing.length}`);
+  console.log("");
+
+  const csvOut: string[] = ["channel,group_slug,action,detail"];
+  let updated = 0;
+  let inserted = 0;
+  let unchanged = 0;
+
+  for (const ch of channels) {
+    const match = matchExistingGroup(ch, groupsByType);
+
+    if (match) {
+      const updates: Record<string, unknown> = {};
+
+      // Normalize slack_channel to the CSV canonical form when it has drifted.
+      if (match.slackChannel !== ch.name) {
+        updates.slackChannel = ch.name;
+      }
+
+      // Backfill description only when the DB is null/empty and CSV has content.
+      if (
+        (!match.description || match.description.trim() === "") &&
+        ch.purpose.trim() !== ""
+      ) {
+        updates.description = ch.purpose.trim();
+      }
+
+      if (Object.keys(updates).length === 0) {
+        unchanged++;
+        csvOut.push(`${ch.name},${match.slug},unchanged,`);
+      } else {
+        updated++;
+        const detail = Object.keys(updates).join("+");
+        csvOut.push(`${ch.name},${match.slug},update,"${detail}"`);
+        if (flags.commit) {
+          await db
+            .update(groups)
+            .set({ ...updates, updatedAt: new Date() })
+            .where(eq(groups.id, match.id));
+        }
+      }
+    } else {
+      // No matching group — insert a new one.
+      const groupType = channelTypeToGroupType(ch.type);
+      const suffix = stripTypePrefix(ch.name);
+      const baseSlug = buildSlug(suffix);
+      const displaySuffix = deriveDisplayName(suffix);
+      const label =
+        groupType === "working_group"
+          ? "Working Group"
+          : groupType === "affinity_group"
+          ? "Affinity Group"
+          : "Regional Group";
+      const name = `${displaySuffix} ${label}`;
+
+      inserted++;
+      csvOut.push(`${ch.name},${baseSlug},insert,"type=${groupType}"`);
+
+      if (flags.commit) {
+        await db.insert(groups).values({
+          name,
+          slug: baseSlug,
+          type: groupType,
+          slackChannel: ch.name,
+          description: ch.purpose.trim() || null,
+          isActive: true,
+          isPublished: false, // admin reviews before publishing
+        } as Parameters<typeof db.insert>[0] extends never ? never : any);
+      }
+    }
+  }
+
+  // Write the report CSV alongside the runner.
+  const reportName = `group-reconcile-${flags.commit ? "applied" : "dry-run"}.csv`;
+  const reportPath = path.resolve(path.dirname(__filename), reportName);
+  fs.writeFileSync(reportPath, csvOut.join("\n") + "\n");
+
+  console.log(`Summary:`);
+  console.log(`  Updated:   ${updated}`);
+  console.log(`  Inserted:  ${inserted}`);
+  console.log(`  Unchanged: ${unchanged}`);
+  console.log(`\nReport written to: ${reportPath}`);
+
+  if (!flags.commit) {
+    console.log("\n=== Re-run with --commit to apply ===");
+  }
+}
+
+// ─── Entry point guard ───────────────────────────────────────────────────────
+// Prevents main() from firing when this module is imported by tests.
+const isMain =
+  process.argv[1] && process.argv[1].endsWith(path.basename(__filename));
+if (isMain) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/packages/api/scripts/reconcile-groups.ts
+++ b/packages/api/scripts/reconcile-groups.ts
@@ -183,42 +183,58 @@ async function main() {
   console.log(`Existing DB groups: ${existing.length}`);
   console.log("");
 
+  // Pre-build a set of all existing slugs so we can skip inserts that would
+  // collide. Slug collisions are typically legacy rows whose type doesn't
+  // match the CSV channel (the legacy "dmv-rse" affinity row vs the new
+  // CSV "rg-dmv-rse" regional channel). We log + skip rather than crash.
+  const existingSlugs = new Set(existing.map((g) => g.slug));
+
   const csvOut: string[] = ["channel,group_slug,action,detail"];
   let updated = 0;
   let inserted = 0;
   let unchanged = 0;
+  let typeMismatches = 0;
+  let skipped = 0;
 
   for (const ch of channels) {
     const match = matchExistingGroup(ch, groupsByType);
 
     if (match) {
+      const g = match.group;
       const updates: Record<string, unknown> = {};
 
       // Normalize slack_channel to the CSV canonical form when it has drifted.
-      if (match.slackChannel !== ch.name) {
+      if (g.slackChannel !== ch.name) {
         updates.slackChannel = ch.name;
       }
 
       // Backfill description only when the DB is null/empty and CSV has content.
       if (
-        (!match.description || match.description.trim() === "") &&
+        (!g.description || g.description.trim() === "") &&
         ch.purpose.trim() !== ""
       ) {
         updates.description = ch.purpose.trim();
       }
 
+      const tagParts: string[] = [];
+      if (match.typeMismatch) {
+        typeMismatches++;
+        tagParts.push(`type_mismatch=${g.type}->${channelTypeToGroupType(ch.type)}`);
+      }
+
       if (Object.keys(updates).length === 0) {
         unchanged++;
-        csvOut.push(`${ch.name},${match.slug},unchanged,`);
+        const detail = tagParts.length ? `"${tagParts.join("+")}"` : "";
+        csvOut.push(`${ch.name},${g.slug},${match.typeMismatch ? "type_mismatch" : "unchanged"},${detail}`);
       } else {
         updated++;
-        const detail = Object.keys(updates).join("+");
-        csvOut.push(`${ch.name},${match.slug},update,"${detail}"`);
+        const detail = `"${[...Object.keys(updates), ...tagParts].join("+")}"`;
+        csvOut.push(`${ch.name},${g.slug},${match.typeMismatch ? "update_type_mismatch" : "update"},${detail}`);
         if (flags.commit) {
           await db
             .update(groups)
             .set({ ...updates, updatedAt: new Date() })
-            .where(eq(groups.id, match.id));
+            .where(eq(groups.id, g.id));
         }
       }
     } else {
@@ -235,8 +251,17 @@ async function main() {
           : "Regional Group";
       const name = `${displaySuffix} ${label}`;
 
+      if (existingSlugs.has(baseSlug)) {
+        // Slug collides with a legacy row whose type+slack_channel both
+        // differ. Skip rather than crash; admin can rename or merge.
+        skipped++;
+        csvOut.push(`${ch.name},${baseSlug},skip_slug_collision,"existing slug ${baseSlug} blocks insert"`);
+        continue;
+      }
+
       inserted++;
       csvOut.push(`${ch.name},${baseSlug},insert,"type=${groupType}"`);
+      existingSlugs.add(baseSlug);  // protect against duplicate slugs within the same run
 
       if (flags.commit) {
         await db.insert(groups).values({
@@ -258,9 +283,11 @@ async function main() {
   fs.writeFileSync(reportPath, csvOut.join("\n") + "\n");
 
   console.log(`Summary:`);
-  console.log(`  Updated:   ${updated}`);
-  console.log(`  Inserted:  ${inserted}`);
-  console.log(`  Unchanged: ${unchanged}`);
+  console.log(`  Updated:        ${updated}`);
+  console.log(`  Inserted:       ${inserted}`);
+  console.log(`  Unchanged:      ${unchanged}`);
+  console.log(`  Type mismatch:  ${typeMismatches}  (matched a slack_channel on a row whose type differs)`);
+  console.log(`  Skipped:        ${skipped}  (slug already taken by a legacy row)`);
   console.log(`\nReport written to: ${reportPath}`);
 
   if (!flags.commit) {


### PR DESCRIPTION
## Summary

`reconcile-groups.ts` reads `.data/us-rse-groups.csv` (Slack channel + member export) and brings the `groups` table into alignment with it:

- **Updates** existing groups when their `slack_channel` drifts from the canonical CSV form OR when their `description` is null/empty and the CSV `purpose` field has content
- **Inserts** new groups for channels with no DB match, with `is_active=true`, `is_published=false` (admin reviews before surfacing publicly)
- **Matches** are type-scoped (a `wg-*` channel never matches an affinity_group, etc.) and use exact normalized `slack_channel` first, then normalized slug fallback
- **Pure helpers** extracted into `lib/groupReconcile.ts` with 15 unit tests

## Dry-run against dev (current state)

- 36 channels in CSV
- 28 existing DB groups
- **20 inserts:** 13 regional + 6 working + 1 affinity (channels with no DB match)
- **16 unchanged:** matched existing groups, no description/slack_channel changes needed
- **0 updates:** nothing in the matched set required a description backfill or slack_channel normalization

## Known follow-up: legacy mistyped groups

Some of the 28 existing DB groups were imported in PR #1981 as `affinity_group` even though they're conceptually regional (the schema didn't surface the type distinction cleanly at the time). The most visible case: an existing `bay-area-california` row with `type=affinity_group, slack_channel='rg-bayareaca'`. Because this script enforces type-scoped matching (no silent retyping), it inserts a *new* `bay-area-ca` regional_group, leaving the legacy affinity record in place. Result: two cards on the public page for the same community.

**Cleanup path (post-merge):** admin uses the existing soft-delete on the legacy affinity records, or uses the org-merge wizard pattern (currently org-only — a sibling `groups-merge` would close this fully).

## Test plan

- [ ] Tests pass (15/15)
- [ ] Typecheck passes
- [ ] `--dry-run` produces a CSV at `group-reconcile-dry-run.csv` matching the summary above
- [ ] Spot-check 3 generated slugs and names look correct for regional groups (e.g. `rg-new-england` → slug `new-england`, name "New England Regional Group")

## Followers

- **PR C** — link Slack usernames to user accounts + insert `group_memberships` rows + admin profile-editor field for Slack handle