### PR TITLE
feat: events subsystem (admin + member submit + public)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -21,6 +21,7 @@ import { VocabQueuePage } from "./pages/vocab/VocabQueuePage";
 import { GroupDetailPage } from "./pages/groups/GroupDetailPage";
 import { GroupsListPage } from "./pages/groups/GroupsListPage";
 import { EventsListPage } from "./pages/events/EventsListPage";
+import { NewEventPage } from "./pages/events/NewEventPage";
 
 export function App() {
   const { user: workosUser, isLoading: authLoading } = useAuth();
@@ -70,6 +71,7 @@ export function App() {
         <Route path="groups/:id" element={<GroupDetailPage />} />
         <Route path="groups" element={<GroupsListPage />} />
         <Route path="events" element={<EventsListPage />} />
+        <Route path="events/new" element={<NewEventPage />} />
         <Route path="recognition" element={<ComingSoon number="06" label="Recognition" blurb="Awards lifecycle, mentorship pairings, and community contribution logging — the source of dossier badges." />} />
         <Route path="settings" element={<ComingSoon number="07" label="Settings" blurb="Super-admin operations, integration toggles, and global flags." />} />
         <Route path="audit" element={<AuditPage />} />

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -22,6 +22,7 @@ import { GroupDetailPage } from "./pages/groups/GroupDetailPage";
 import { GroupsListPage } from "./pages/groups/GroupsListPage";
 import { EventsListPage } from "./pages/events/EventsListPage";
 import { NewEventPage } from "./pages/events/NewEventPage";
+import { EventDetailPage } from "./pages/events/EventDetailPage";
 
 export function App() {
   const { user: workosUser, isLoading: authLoading } = useAuth();
@@ -72,6 +73,7 @@ export function App() {
         <Route path="groups" element={<GroupsListPage />} />
         <Route path="events" element={<EventsListPage />} />
         <Route path="events/new" element={<NewEventPage />} />
+        <Route path="events/:id" element={<EventDetailPage />} />
         <Route path="recognition" element={<ComingSoon number="06" label="Recognition" blurb="Awards lifecycle, mentorship pairings, and community contribution logging — the source of dossier badges." />} />
         <Route path="settings" element={<ComingSoon number="07" label="Settings" blurb="Super-admin operations, integration toggles, and global flags." />} />
         <Route path="audit" element={<AuditPage />} />

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -20,6 +20,7 @@ import { VocabListPage } from "./pages/vocab/VocabListPage";
 import { VocabQueuePage } from "./pages/vocab/VocabQueuePage";
 import { GroupDetailPage } from "./pages/groups/GroupDetailPage";
 import { GroupsListPage } from "./pages/groups/GroupsListPage";
+import { EventsListPage } from "./pages/events/EventsListPage";
 
 export function App() {
   const { user: workosUser, isLoading: authLoading } = useAuth();
@@ -68,7 +69,7 @@ export function App() {
         <Route path="vocab" element={<VocabQueuePage />} />
         <Route path="groups/:id" element={<GroupDetailPage />} />
         <Route path="groups" element={<GroupsListPage />} />
-        <Route path="events" element={<ComingSoon number="05" label="Events" blurb="Event creation and approval, committee assignment, session scheduling, attendance, and sponsor wiring." />} />
+        <Route path="events" element={<EventsListPage />} />
         <Route path="recognition" element={<ComingSoon number="06" label="Recognition" blurb="Awards lifecycle, mentorship pairings, and community contribution logging — the source of dossier badges." />} />
         <Route path="settings" element={<ComingSoon number="07" label="Settings" blurb="Super-admin operations, integration toggles, and global flags." />} />
         <Route path="audit" element={<AuditPage />} />

--- a/apps/admin/src/hooks/useEvents.ts
+++ b/apps/admin/src/hooks/useEvents.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from "react";
+import { useApi } from "@us-rse/auth-shell";
+
+export interface EventRow {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  status: string;
+  revision: number;
+  scope: string;
+  authorId: string | null;
+  hostGroupId: string | null;
+  hostOrgId: string | null;
+  startDate: string;
+  endDate: string | null;
+  createdAt: string;
+}
+
+export function useEventsList(filters?: {
+  status?: string;
+  type?: string;
+  scope?: string;
+  q?: string;
+}) {
+  const apiFetch = useApi();
+  const [data, setData] = useState<EventRow[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (filters?.status) params.set("status", filters.status);
+      if (filters?.type) params.set("type", filters.type);
+      if (filters?.scope) params.set("scope", filters.scope);
+      if (filters?.q) params.set("q", filters.q);
+      const res = await apiFetch(`/admin/events?${params}`);
+      if (!res.ok) {
+        setError(`/admin/events responded ${res.status}`);
+        return;
+      }
+      const body = (await res.json()) as { rows: EventRow[] };
+      setData(body.rows);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch, filters?.status, filters?.type, filters?.scope, filters?.q]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { data, error, loading, refetch: load };
+}

--- a/apps/admin/src/pages/events/EventDetailPage.tsx
+++ b/apps/admin/src/pages/events/EventDetailPage.tsx
@@ -1,0 +1,456 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useApi } from "@us-rse/auth-shell";
+import { useShellActor } from "../../layout/AdminShell";
+import { EditorialInput } from "../../components/EditorialInput";
+import { EditorialTextarea } from "../../components/EditorialTextarea";
+
+type Tab = "identity" | "content" | "review" | "audit";
+
+interface EventDetail {
+  ok: true;
+  event: {
+    id: string;
+    slug: string;
+    name: string;
+    type: string;
+    status: string;
+    revision: number;
+    scope: string;
+    authorId: string | null;
+    hostGroupId: string | null;
+    hostOrgId: string | null;
+    startDate: string;
+    endDate: string | null;
+    location: string | null;
+    url: string | null;
+    description: string | null;
+    externalUrl: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  reviews: Array<{
+    id: string;
+    reviewerId: string;
+    reviewerName: string | null;
+    decision: "approve" | "reject" | "request_changes";
+    comment: string | null;
+    entityRevision: number;
+    createdAt: string;
+  }>;
+  comments: Array<{
+    id: string;
+    authorId: string;
+    authorName: string | null;
+    body: string;
+    createdAt: string;
+  }>;
+  audit: Array<{
+    id: string;
+    action: string;
+    actorId: string;
+    payload: unknown;
+    createdAt: string;
+  }>;
+}
+
+export function EventDetailPage() {
+  const apiFetch = useApi();
+  const actor = useShellActor();
+  const { id } = useParams<{ id: string }>();
+
+  const [data, setData] = useState<EventDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("identity");
+  const [acting, setActing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Identity drafts
+  const [draftName, setDraftName] = useState("");
+  const [draftLocation, setDraftLocation] = useState("");
+  const [draftExternalUrl, setDraftExternalUrl] = useState("");
+
+  // Content drafts
+  const [draftDescription, setDraftDescription] = useState("");
+  const [draftStartDate, setDraftStartDate] = useState("");
+  const [draftEndDate, setDraftEndDate] = useState("");
+
+  // Comment composer
+  const [newComment, setNewComment] = useState("");
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    setError(null);
+    try {
+      const res = await apiFetch(`/admin/events/${id}`);
+      if (!res.ok) {
+        setError(`/admin/events/${id} responded ${res.status}`);
+        return;
+      }
+      const body = (await res.json()) as EventDetail;
+      setData(body);
+      setDraftName(body.event.name);
+      setDraftLocation(body.event.location ?? "");
+      setDraftExternalUrl(body.event.externalUrl ?? "");
+      setDraftDescription(body.event.description ?? "");
+      setDraftStartDate(body.event.startDate);
+      setDraftEndDate(body.event.endDate ?? "");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, [apiFetch, id]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function patchEvent(body: Record<string, unknown>) {
+    if (!data) return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const res = await apiFetch(`/admin/events/${data.event.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { error?: string } | null;
+        setActionError(err?.error ?? `PATCH responded ${res.status}`);
+        return;
+      }
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function transition(action: string, comment?: string) {
+    if (!data) return;
+    if (
+      (action === "reject" || action === "request_changes") &&
+      !comment?.trim()
+    ) {
+      setActionError("A comment is required for this action.");
+      return;
+    }
+    setActing(true);
+    setActionError(null);
+    try {
+      const res = await apiFetch(`/admin/events/${data.event.id}/transitions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, comment }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { error?: string } | null;
+        setActionError(err?.error ?? `POST responded ${res.status}`);
+        return;
+      }
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function postComment() {
+    if (!data || !newComment.trim()) return;
+    setActing(true);
+    setActionError(null);
+    try {
+      const res = await apiFetch(`/admin/events/${data.event.id}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body: newComment }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { error?: string } | null;
+        setActionError(err?.error ?? `POST responded ${res.status}`);
+        return;
+      }
+      setNewComment("");
+      await load();
+    } finally {
+      setActing(false);
+    }
+  }
+
+  if (error)
+    return (
+      <p className="admin-classification" style={{ color: "var(--color-danger-700)" }}>
+        {error}
+      </p>
+    );
+  if (!data) return <p className="admin-marginalia">Loading…</p>;
+
+  const e = data.event;
+  const isStaff = actor.systemTier >= 1;
+  const isAuthor = actor.user.id === e.authorId;
+  const canTransition = isStaff || (isAuthor && (e.status === "draft" || e.status === "changes_requested"));
+
+  // Approval count on current revision
+  const currentRevApprovals = data.reviews
+    .filter((r) => r.decision === "approve" && r.entityRevision === e.revision)
+    .map((r) => r.reviewerId);
+  const uniqueApprovals = new Set(currentRevApprovals).size;
+
+  return (
+    <div className="admin-animate-reveal">
+      <p className="admin-classification mb-6">US-RSE · Admin · Events · {e.name}</p>
+      <h2 className="admin-display mb-2" style={{ fontSize: "clamp(2rem, 3vw + 0.5rem, 3rem)" }}>
+        {e.name}
+      </h2>
+      <div className="flex items-center gap-4 mb-10">
+        <span className="admin-classification">{e.type}</span>
+        <span className="admin-classification">{e.scope}</span>
+        <span className="admin-classification">{e.status}</span>
+        <span className="admin-classification">rev {e.revision}</span>
+      </div>
+
+      <nav
+        className="flex items-baseline gap-8 mb-8"
+        style={{ borderBottom: "1px solid var(--admin-rule)" }}
+      >
+        {(["identity", "content", "review", "audit"] as Tab[]).map((t, i) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => setTab(t)}
+            className="pb-3 admin-classification transition-colors"
+            style={{
+              color: tab === t ? "var(--admin-ribbon)" : "var(--admin-ink-medium)",
+              borderBottom: tab === t ? "2px solid var(--admin-ribbon)" : "2px solid transparent",
+              marginBottom: "-1px",
+            }}
+          >
+            <span className="tabular-nums mr-2">{String(i + 1).padStart(2, "0")}</span>
+            <span>{t[0].toUpperCase() + t.slice(1)}</span>
+          </button>
+        ))}
+      </nav>
+
+      {actionError && (
+        <p className="mb-4 admin-classification" style={{ color: "var(--color-danger-700)" }}>
+          {actionError}
+        </p>
+      )}
+
+      {tab === "identity" && (
+        <section className="max-w-2xl space-y-6">
+          <EditorialInput
+            label="Name"
+            value={draftName}
+            onChange={(e) => setDraftName(e.target.value)}
+          />
+          <EditorialInput
+            label="Location"
+            value={draftLocation}
+            onChange={(e) => setDraftLocation(e.target.value)}
+          />
+          <EditorialInput
+            label="External registration URL"
+            value={draftExternalUrl}
+            onChange={(e) => setDraftExternalUrl(e.target.value)}
+            hint="When set, the public event page links here instead of showing internal signup"
+          />
+          <button
+            type="button"
+            disabled={acting}
+            onClick={() => patchEvent({
+              name: draftName.trim() || undefined,
+              location: draftLocation.trim() || null,
+              externalUrl: draftExternalUrl.trim() || null,
+            })}
+            className="inline-flex items-center px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm hover:bg-purple-600 disabled:opacity-50"
+          >
+            Save identity
+          </button>
+        </section>
+      )}
+
+      {tab === "content" && (
+        <section className="max-w-2xl space-y-6">
+          <EditorialInput
+            label="Start date"
+            type="date"
+            value={draftStartDate}
+            onChange={(e) => setDraftStartDate(e.target.value)}
+          />
+          <EditorialInput
+            label="End date"
+            type="date"
+            value={draftEndDate}
+            onChange={(e) => setDraftEndDate(e.target.value)}
+          />
+          <EditorialTextarea
+            label="Description"
+            value={draftDescription}
+            onChange={(e) => setDraftDescription(e.target.value)}
+            rows={8}
+          />
+          <button
+            type="button"
+            disabled={acting}
+            onClick={() => patchEvent({
+              startDate: draftStartDate,
+              endDate: draftEndDate || null,
+              description: draftDescription.trim() || null,
+            })}
+            className="inline-flex items-center px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm hover:bg-purple-600 disabled:opacity-50"
+          >
+            Save content
+          </button>
+        </section>
+      )}
+
+      {tab === "review" && (
+        <section className="max-w-3xl space-y-8">
+          <div>
+            <p className="admin-classification mb-3">
+              Approvals on revision {e.revision}: {uniqueApprovals} of 2
+            </p>
+            <div className="flex gap-3 flex-wrap">
+              {canTransition && e.status === "draft" && (
+                <button
+                  type="button"
+                  disabled={acting}
+                  onClick={() => transition("submit_for_review")}
+                  className="px-5 py-2 rounded-md bg-purple-500 text-white text-sm font-semibold disabled:opacity-50"
+                >
+                  Submit for review
+                </button>
+              )}
+              {canTransition && e.status === "changes_requested" && (
+                <button
+                  type="button"
+                  disabled={acting}
+                  onClick={() => transition("submit_for_review")}
+                  className="px-5 py-2 rounded-md bg-purple-500 text-white text-sm font-semibold disabled:opacity-50"
+                >
+                  Resubmit
+                </button>
+              )}
+              {isStaff && e.status === "in_review" && !isAuthor && (
+                <>
+                  <button
+                    type="button"
+                    disabled={acting}
+                    onClick={() => transition("approve")}
+                    className="px-5 py-2 rounded-md bg-green-600 text-white text-sm font-semibold disabled:opacity-50"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    disabled={acting}
+                    onClick={() => {
+                      const c = window.prompt("Comment (required):");
+                      if (c) void transition("request_changes", c);
+                    }}
+                    className="px-5 py-2 rounded-md bg-amber-600 text-white text-sm font-semibold disabled:opacity-50"
+                  >
+                    Request changes
+                  </button>
+                  <button
+                    type="button"
+                    disabled={acting}
+                    onClick={() => {
+                      const c = window.prompt("Reason (required):");
+                      if (c) void transition("reject", c);
+                    }}
+                    className="px-5 py-2 rounded-md bg-red-600 text-white text-sm font-semibold disabled:opacity-50"
+                  >
+                    Reject
+                  </button>
+                </>
+              )}
+              {isStaff && e.status === "published" && (
+                <>
+                  <button
+                    type="button"
+                    disabled={acting}
+                    onClick={() => {
+                      if (window.confirm("Cancel this event?")) void transition("cancel");
+                    }}
+                    className="px-5 py-2 rounded-md bg-red-600 text-white text-sm font-semibold disabled:opacity-50"
+                  >
+                    Cancel event
+                  </button>
+                  <button
+                    type="button"
+                    disabled={acting}
+                    onClick={() => transition("archive")}
+                    className="px-5 py-2 rounded-md bg-gray-600 text-white text-sm font-semibold disabled:opacity-50"
+                  >
+                    Archive
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p className="admin-classification mb-3">Review history</p>
+            {data.reviews.length === 0 && <p className="admin-marginalia">No reviews yet.</p>}
+            <ul className="space-y-3">
+              {data.reviews.map((r) => (
+                <li key={r.id} className="text-sm">
+                  <span className="font-mono">[{r.decision}]</span>{" "}
+                  <span>{r.reviewerName ?? r.reviewerId}</span>{" "}
+                  <span className="admin-marginalia">on rev {r.entityRevision}</span>
+                  {r.comment && <p className="ml-6 mt-1 text-gray-700">{r.comment}</p>}
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <p className="admin-classification mb-3">Comments</p>
+            <ul className="space-y-3 mb-4">
+              {data.comments.map((c) => (
+                <li key={c.id} className="text-sm">
+                  <span className="font-semibold">{c.authorName ?? c.authorId}</span>{" "}
+                  <span className="admin-marginalia">{new Date(c.createdAt).toLocaleString()}</span>
+                  <p className="mt-1 text-gray-800">{c.body}</p>
+                </li>
+              ))}
+            </ul>
+            <EditorialTextarea
+              label="Add comment"
+              value={newComment}
+              onChange={(e) => setNewComment(e.target.value)}
+              rows={3}
+            />
+            <button
+              type="button"
+              disabled={acting || !newComment.trim()}
+              onClick={postComment}
+              className="mt-2 px-5 py-2 rounded-md bg-purple-500 text-white text-sm font-semibold disabled:opacity-50"
+            >
+              Post comment
+            </button>
+          </div>
+        </section>
+      )}
+
+      {tab === "audit" && (
+        <section className="max-w-3xl">
+          {data.audit.length === 0 && <p className="admin-marginalia">No audit entries yet.</p>}
+          <ul className="space-y-2">
+            {data.audit.map((a) => (
+              <li key={a.id} className="text-sm font-mono">
+                <span className="admin-marginalia">{new Date(a.createdAt).toLocaleString()}</span>{" "}
+                <span className="font-semibold">{a.action}</span>
+                <span className="admin-marginalia"> by {a.actorId}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <p className="mt-12 admin-marginalia">
+        <Link to="/admin/events">← Back to events</Link>
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/pages/events/EventsListPage.tsx
+++ b/apps/admin/src/pages/events/EventsListPage.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useEventsList } from "../../hooks/useEvents";
+
+const STATUS_OPTIONS = [
+  "", "draft", "in_review", "changes_requested", "rejected",
+  "published", "cancelled", "completed", "archived",
+];
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: "Draft",
+  in_review: "In review",
+  changes_requested: "Changes requested",
+  rejected: "Rejected",
+  published: "Published",
+  cancelled: "Cancelled",
+  completed: "Completed",
+  archived: "Archived",
+};
+
+export function EventsListPage() {
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [query, setQuery] = useState<string>("");
+  const { data, error, loading } = useEventsList({
+    status: statusFilter || undefined,
+    q: query || undefined,
+  });
+
+  return (
+    <div className="admin-animate-reveal">
+      <p className="admin-classification mb-6">US-RSE · Admin · Events</p>
+      <div className="flex items-baseline justify-between mb-10">
+        <h2 className="admin-display" style={{ fontSize: "clamp(2rem, 3vw + 0.5rem, 3rem)" }}>
+          Events
+        </h2>
+        <Link
+          to="/admin/events/new"
+          className="inline-flex items-center px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm hover:bg-purple-600"
+        >
+          + New event
+        </Link>
+      </div>
+
+      <div className="flex gap-4 mb-8">
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="px-3 py-2 rounded-md border admin-input"
+        >
+          {STATUS_OPTIONS.map((s) => (
+            <option key={s} value={s}>
+              {s ? STATUS_LABEL[s] : "All statuses"}
+            </option>
+          ))}
+        </select>
+        <input
+          type="search"
+          placeholder="Search name…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="flex-1 px-3 py-2 rounded-md border admin-input"
+        />
+      </div>
+
+      {error && (
+        <p className="admin-classification" style={{ color: "var(--color-danger-700)" }}>
+          {error}
+        </p>
+      )}
+      {loading && <p className="admin-marginalia">Loading…</p>}
+
+      {data && data.length === 0 && (
+        <p className="admin-marginalia">No events match the filters.</p>
+      )}
+
+      {data && data.length > 0 && (
+        <ul className="divide-y" style={{ borderColor: "var(--admin-rule)" }}>
+          {data.map((e) => (
+            <li key={e.id} className="py-4">
+              <Link to={`/admin/events/${e.id}`} className="block hover:bg-gray-50 -mx-3 px-3 py-2 rounded-md">
+                <div className="flex items-baseline justify-between gap-4">
+                  <span className="font-semibold">{e.name}</span>
+                  <span className="admin-classification">{STATUS_LABEL[e.status] ?? e.status}</span>
+                </div>
+                <div className="flex gap-3 mt-1">
+                  <span className="admin-classification">{e.type}</span>
+                  <span className="admin-classification">{e.scope}</span>
+                  <span className="admin-classification">{e.startDate}</span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/pages/events/NewEventPage.tsx
+++ b/apps/admin/src/pages/events/NewEventPage.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useApi } from "@us-rse/auth-shell";
+import { EditorialInput } from "../../components/EditorialInput";
+import { EditorialTextarea } from "../../components/EditorialTextarea";
+
+const EVENT_TYPES = [
+  { value: "conference", label: "Conference" },
+  { value: "workshop", label: "Workshop" },
+  { value: "meetup", label: "Meetup" },
+  { value: "webinar", label: "Webinar" },
+  { value: "community_call", label: "Community call" },
+  { value: "other", label: "Other" },
+];
+
+export function NewEventPage() {
+  const apiFetch = useApi();
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [type, setType] = useState("workshop");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
+  const [externalUrl, setExternalUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await apiFetch("/admin/events", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          type,
+          startDate,
+          endDate: endDate || undefined,
+          location: location.trim() || undefined,
+          description: description.trim() || undefined,
+          externalUrl: externalUrl.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => null)) as { message?: string; error?: string } | null;
+        setError(err?.error ?? err?.message ?? `POST responded ${res.status}`);
+        return;
+      }
+      const body = (await res.json()) as { event: { id: string } };
+      navigate(`/admin/events/${body.event.id}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="admin-animate-reveal max-w-2xl">
+      <p className="admin-classification mb-6">US-RSE · Admin · Events · New</p>
+      <h2 className="admin-display mb-8" style={{ fontSize: "clamp(2rem, 3vw + 0.5rem, 3rem)" }}>
+        New event
+      </h2>
+      {error && (
+        <p className="mb-6 admin-classification" style={{ color: "var(--color-danger-700)" }}>
+          {error}
+        </p>
+      )}
+      <form onSubmit={onSubmit} className="space-y-6">
+        <EditorialInput
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <div>
+          <label className="admin-classification block mb-2">Type</label>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="px-3 py-2 rounded-md border admin-input w-full"
+          >
+            {EVENT_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+        </div>
+        <EditorialInput
+          label="Start date"
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          required
+        />
+        <EditorialInput
+          label="End date (optional)"
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+        />
+        <EditorialInput
+          label="Location (optional)"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+        />
+        <EditorialInput
+          label="External registration URL (optional)"
+          type="url"
+          value={externalUrl}
+          onChange={(e) => setExternalUrl(e.target.value)}
+          hint="Use this when registration is hosted elsewhere"
+        />
+        <EditorialTextarea
+          label="Description (optional)"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={5}
+        />
+        <button
+          type="submit"
+          disabled={saving || !name || !startDate}
+          className="inline-flex items-center px-6 py-3 rounded-md bg-purple-500 text-white font-semibold text-sm shadow-sm hover:bg-purple-600 disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save as draft"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,7 @@ import { CommunityFundsPage } from "@/pages/community/CommunityFundsPage";
 import { UpcomingEventsPage } from "@/pages/events/UpcomingEventsPage";
 import { CalendarPage } from "@/pages/events/CalendarPage";
 import { ConferencePage } from "@/pages/events/ConferencePage";
+import { SubmitEventPage } from "@/pages/events/SubmitEventPage";
 import { BrowseJobsPage } from "@/pages/jobs/BrowseJobsPage";
 import { SubmitJobPage } from "@/pages/jobs/SubmitJobPage";
 import { VolunteerPage } from "@/pages/jobs/VolunteerPage";
@@ -84,6 +85,7 @@ export function App() {
             <Route path="/events" element={<UpcomingEventsPage />} />
             <Route path="/events/calendar" element={<CalendarPage />} />
             <Route path="/events/usrse26" element={<ConferencePage />} />
+            <Route path="/events/submit" element={<SubmitEventPage />} />
             <Route path="/jobs" element={<BrowseJobsPage />} />
             <Route path="/jobs/submit" element={<SubmitJobPage />} />
             <Route path="/jobs/volunteer" element={<VolunteerPage />} />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,6 +24,7 @@ import { UpcomingEventsPage } from "@/pages/events/UpcomingEventsPage";
 import { CalendarPage } from "@/pages/events/CalendarPage";
 import { ConferencePage } from "@/pages/events/ConferencePage";
 import { SubmitEventPage } from "@/pages/events/SubmitEventPage";
+import { EventDetailPage as PublicEventDetail } from "@/pages/events/EventDetailPage";
 import { BrowseJobsPage } from "@/pages/jobs/BrowseJobsPage";
 import { SubmitJobPage } from "@/pages/jobs/SubmitJobPage";
 import { VolunteerPage } from "@/pages/jobs/VolunteerPage";
@@ -86,6 +87,7 @@ export function App() {
             <Route path="/events/calendar" element={<CalendarPage />} />
             <Route path="/events/usrse26" element={<ConferencePage />} />
             <Route path="/events/submit" element={<SubmitEventPage />} />
+            <Route path="/events/:slug" element={<PublicEventDetail />} />
             <Route path="/jobs" element={<BrowseJobsPage />} />
             <Route path="/jobs/submit" element={<SubmitJobPage />} />
             <Route path="/jobs/volunteer" element={<VolunteerPage />} />

--- a/apps/web/src/hooks/useEvents.ts
+++ b/apps/web/src/hooks/useEvents.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { useApi } from "@us-rse/auth-shell";
+
+export interface PublicEvent {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  startDate: string;
+  endDate: string | null;
+  location: string | null;
+  description: string | null;
+  scope: string;
+  externalUrl: string | null;
+  authorId: string | null;
+}
+
+export function useEvents() {
+  const apiFetch = useApi();
+  const [events, setEvents] = useState<PublicEvent[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch("/events");
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(`/events responded ${res.status}`);
+          return;
+        }
+        const body = (await res.json()) as { events: PublicEvent[] };
+        setEvents(body.events);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [apiFetch]);
+
+  return { events, error };
+}

--- a/apps/web/src/pages/events/EventDetailPage.tsx
+++ b/apps/web/src/pages/events/EventDetailPage.tsx
@@ -1,0 +1,424 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { useApi } from "@us-rse/auth-shell";
+import { EventsLayout } from "@/components/events/EventsLayout";
+import { useInView } from "@/hooks/useInView";
+
+interface HostGroup {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+interface HostOrg {
+  id: string;
+  name: string;
+}
+
+interface EventDetail {
+  id: string;
+  slug: string;
+  name: string;
+  type: string;
+  startDate: string;
+  endDate: string | null;
+  location: string | null;
+  url: string | null;
+  description: string | null;
+  scope: string;
+  externalUrl: string | null;
+  hostGroup: HostGroup | null;
+  hostOrg: HostOrg | null;
+  author: { id: string } | null;
+}
+
+const MONTH_ABBR = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+interface FormattedEventDate {
+  month: string;
+  day: string;
+  year: string;
+  full: string;
+}
+
+function formatEventDate(
+  startDate: string,
+  endDate: string | null,
+): FormattedEventDate {
+  const start = new Date(startDate);
+  const end = endDate ? new Date(endDate) : null;
+  const month = MONTH_ABBR[start.getUTCMonth()] ?? "";
+  const startDay = String(start.getUTCDate());
+  const year = String(start.getUTCFullYear());
+
+  let day = startDay;
+  let full = `${month} ${startDay}, ${year}`;
+  if (end) {
+    const endDay = String(end.getUTCDate());
+    const sameMonth =
+      end.getUTCMonth() === start.getUTCMonth() &&
+      end.getUTCFullYear() === start.getUTCFullYear();
+    if (sameMonth) {
+      day = `${startDay}–${endDay}`;
+      full = `${month} ${startDay}–${endDay}, ${year}`;
+    } else {
+      const endMonth = MONTH_ABBR[end.getUTCMonth()] ?? "";
+      day = `${startDay}–${endMonth} ${endDay}`;
+      full = `${month} ${startDay} – ${endMonth} ${endDay}, ${year}`;
+    }
+  }
+  return { month, day, year, full };
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  conference: "Conference",
+  workshop: "Workshop",
+  meetup: "Meetup",
+  community_call: "Community call",
+  webinar: "Webinar",
+  hackathon: "Hackathon",
+  training: "Training",
+  other: "Event",
+};
+
+function formatType(t: string): string {
+  return TYPE_LABEL[t] ?? t.replace(/_/g, " ");
+}
+
+export function EventDetailPage() {
+  const { slug } = useParams<{ slug: string }>();
+  const apiFetch = useApi();
+  const [event, setEvent] = useState<EventDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) {
+      setNotFound(true);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setNotFound(false);
+    setError(null);
+    setEvent(null);
+
+    void (async () => {
+      try {
+        const res = await apiFetch(`/events/${slug}`);
+        if (cancelled) return;
+        if (res.status === 404) {
+          setNotFound(true);
+          setLoading(false);
+          return;
+        }
+        if (!res.ok) {
+          setError(`/events/${slug} responded ${res.status}`);
+          setLoading(false);
+          return;
+        }
+        const body = (await res.json()) as { event: EventDetail };
+        setEvent(body.event);
+        setLoading(false);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, apiFetch]);
+
+  if (loading) {
+    return (
+      <EventsLayout title="Loading…">
+        <div className="animate-pulse space-y-6">
+          <div className="h-3 w-32 bg-neutral-100 rounded" />
+          <div className="h-10 w-3/4 bg-neutral-100 rounded" />
+          <div className="h-4 w-1/2 bg-neutral-100 rounded" />
+          <div className="h-40 w-full bg-neutral-100 rounded mt-8" />
+        </div>
+      </EventsLayout>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <EventsLayout
+        title="Event not found"
+        prevPage={{ path: "/events", label: "Upcoming Events" }}
+      >
+        <p className="font-mono text-xs uppercase tracking-[0.25em] text-purple-600 mb-6">
+          404 · not published
+        </p>
+        <p className="font-display text-2xl lg:text-3xl font-bold text-neutral-900 tracking-tight leading-tight mb-6 max-w-2xl">
+          This event may have been archived, unpublished, or never existed at
+          this address.
+        </p>
+        <Link
+          to="/events"
+          className="group inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-purple-600 hover:text-purple-700 transition-colors"
+        >
+          <svg
+            className="w-3.5 h-3.5 transition-transform group-hover:-translate-x-0.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2.5}
+            aria-hidden="true"
+          >
+            <path d="M11 17l-5-5m0 0l5-5m-5 5h12" />
+          </svg>
+          Back to upcoming events
+        </Link>
+      </EventsLayout>
+    );
+  }
+
+  if (error || !event) {
+    return (
+      <EventsLayout title="Event">
+        <p className="font-mono text-sm text-neutral-500 py-6 px-6 border border-neutral-200 bg-neutral-50 rounded-lg">
+          {error ?? "This event is temporarily unavailable."}
+        </p>
+      </EventsLayout>
+    );
+  }
+
+  return <EventDetailBody event={event} />;
+}
+
+function EventDetailBody({ event }: { event: EventDetail }) {
+  const { ref: headerRef, isInView: headerInView } = useInView(0.2);
+  const { ref: dateRef, isInView: dateInView } = useInView(0.15);
+  const { ref: hostRef, isInView: hostInView } = useInView(0.1);
+  const { ref: descRef, isInView: descInView } = useInView(0.05);
+  const { ref: ctaRef, isInView: ctaInView } = useInView(0.1);
+
+  const date = formatEventDate(event.startDate, event.endDate);
+  const ctaLabel = event.externalUrl
+    ? `Register at ${event.hostOrg?.name ?? "external site"}`
+    : event.url
+      ? "Event link"
+      : null;
+  const ctaHref = event.externalUrl ?? event.url ?? null;
+
+  return (
+    <EventsLayout
+      title={event.name}
+      prevPage={{ path: "/events", label: "Upcoming Events" }}
+    >
+      {/* ── Header — type chip + location ────────────────────────── */}
+      <section
+        ref={headerRef}
+        className={`mb-12 ${headerInView ? "animate-slide-up" : "opacity-0"}`}
+      >
+        <div className="flex flex-wrap items-center gap-3 mb-6">
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] px-2.5 py-1 rounded-full bg-purple-50 text-purple-700 border border-purple-100">
+            {formatType(event.type)}
+          </span>
+          {event.location ? (
+            <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-neutral-500 flex items-center gap-1.5">
+              <svg
+                className="w-3.5 h-3.5 text-neutral-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                aria-hidden="true"
+              >
+                <path d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+                <path d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1115 0z" />
+              </svg>
+              {event.location}
+            </span>
+          ) : null}
+        </div>
+
+        <h1 className="font-display text-3xl lg:text-5xl font-bold text-neutral-900 tracking-tight leading-[1.05] mb-6 text-balance max-w-4xl">
+          {event.name}
+        </h1>
+      </section>
+
+      {/* ── Date — magazine-cover treatment ──────────────────────── */}
+      <section
+        ref={dateRef}
+        className={`mb-16 ${dateInView ? "animate-slide-up" : "opacity-0"}`}
+      >
+        <div className="flex flex-col sm:flex-row sm:items-end gap-6 sm:gap-10 py-8 border-y border-neutral-200">
+          <div className="shrink-0">
+            <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-purple-600 mb-3">
+              When
+            </p>
+            <div className="flex items-end gap-3">
+              <span className="font-display text-6xl lg:text-7xl font-black text-neutral-900 leading-none tracking-tight tabular-nums">
+                {date.day}
+              </span>
+              <span className="font-display text-2xl lg:text-3xl font-bold text-neutral-300 leading-none mb-1.5 tabular-nums">
+                {date.month}
+              </span>
+            </div>
+            <p className="font-mono text-xs text-neutral-400 mt-2 tabular-nums">
+              {date.year}
+            </p>
+          </div>
+
+          <div className="flex-1 sm:pb-2">
+            <p className="font-mono text-[10px] uppercase tracking-[0.25em] text-neutral-400 mb-2">
+              Full date
+            </p>
+            <p className="font-display text-lg lg:text-xl font-bold text-neutral-900 tracking-tight tabular-nums">
+              {date.full}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Host attribution ─────────────────────────────────────── */}
+      {(event.hostGroup || event.hostOrg) && (
+        <section
+          ref={hostRef}
+          className={`mb-16 ${hostInView ? "animate-slide-up" : "opacity-0"}`}
+        >
+          <div className="flex items-baseline gap-3 mb-5">
+            <p className="font-mono text-xs uppercase tracking-[0.25em] text-teal-700">
+              Hosted by
+            </p>
+            <span className="flex-1 h-px bg-neutral-200" aria-hidden="true" />
+          </div>
+          <ul className="space-y-3">
+            {event.hostGroup ? (
+              <li>
+                <Link
+                  to={`/community/groups/${event.hostGroup.id}`}
+                  className="group inline-flex items-center gap-2 font-display text-xl lg:text-2xl font-bold text-neutral-900 tracking-tight hover:text-teal-700 transition-colors"
+                >
+                  {event.hostGroup.name}
+                  <svg
+                    className="w-4 h-4 text-neutral-300 group-hover:text-teal-700 transition-all group-hover:translate-x-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                  </svg>
+                </Link>
+              </li>
+            ) : null}
+            {event.hostOrg ? (
+              <li>
+                <Link
+                  to={`/orgs/${event.hostOrg.id}`}
+                  className="group inline-flex items-center gap-2 font-display text-xl lg:text-2xl font-bold text-neutral-900 tracking-tight hover:text-teal-700 transition-colors"
+                >
+                  {event.hostOrg.name}
+                  <svg
+                    className="w-4 h-4 text-neutral-300 group-hover:text-teal-700 transition-all group-hover:translate-x-0.5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                  </svg>
+                </Link>
+              </li>
+            ) : null}
+          </ul>
+        </section>
+      )}
+
+      {/* ── Description ──────────────────────────────────────────── */}
+      {event.description ? (
+        <section
+          ref={descRef}
+          className={`mb-16 ${descInView ? "animate-slide-up" : "opacity-0"}`}
+        >
+          <div className="flex items-baseline gap-3 mb-5">
+            <p className="font-mono text-xs uppercase tracking-[0.25em] text-neutral-400">
+              About
+            </p>
+            <span className="flex-1 h-px bg-neutral-200" aria-hidden="true" />
+          </div>
+          <div className="whitespace-pre-wrap text-base text-neutral-700 leading-relaxed max-w-2xl">
+            {event.description}
+          </div>
+        </section>
+      ) : null}
+
+      {/* ── CTA + back ───────────────────────────────────────────── */}
+      <section
+        ref={ctaRef}
+        className={`mb-4 pt-12 border-t border-neutral-100 ${
+          ctaInView ? "animate-slide-up" : "opacity-0"
+        }`}
+      >
+        {ctaHref && ctaLabel ? (
+          <div className="flex flex-wrap items-center gap-5 mb-8">
+            <a
+              href={ctaHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-2 px-7 py-3.5 bg-purple-600 text-white text-sm font-bold rounded-xl hover:bg-purple-700 shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all"
+            >
+              {ctaLabel}
+              <svg
+                className="w-4 h-4 transition-transform group-hover:translate-x-1"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2.5}
+                aria-hidden="true"
+              >
+                <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+            </a>
+            {event.externalUrl ? (
+              <p className="font-mono text-[11px] uppercase tracking-wider text-neutral-400">
+                Opens on the host&rsquo;s site
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        <Link
+          to="/events"
+          className="group inline-flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-neutral-500 hover:text-purple-700 transition-colors"
+        >
+          <svg
+            className="w-3.5 h-3.5 transition-transform group-hover:-translate-x-0.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2.5}
+            aria-hidden="true"
+          >
+            <path d="M11 17l-5-5m0 0l5-5m-5 5h12" />
+          </svg>
+          Back to events
+        </Link>
+      </section>
+    </EventsLayout>
+  );
+}

--- a/apps/web/src/pages/events/SubmitEventPage.tsx
+++ b/apps/web/src/pages/events/SubmitEventPage.tsx
@@ -1,0 +1,346 @@
+import { useState, type FormEvent } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "@workos-inc/authkit-react";
+import { EventsLayout } from "@/components/events/EventsLayout";
+import { useApi } from "@/lib/api";
+
+/**
+ * Public, auth-gated member submission for the Events lifecycle.
+ *
+ * Anonymous visitors see a sign-in pitch (matching the AccountPage
+ * SignedOutState pattern); signed-in members see the submission form.
+ *
+ * On success the page navigates to /events?submitted=1 so the index
+ * page can show a confirmation banner. We don't try to deep-link to
+ * the new event — at submit time it's only in_review, not yet public.
+ */
+
+type EventType =
+  | "conference"
+  | "workshop"
+  | "meetup"
+  | "webinar"
+  | "community_call"
+  | "other";
+
+const EVENT_TYPES: { value: EventType; label: string }[] = [
+  { value: "conference", label: "Conference" },
+  { value: "workshop", label: "Workshop" },
+  { value: "meetup", label: "Meetup" },
+  { value: "webinar", label: "Webinar" },
+  { value: "community_call", label: "Community call" },
+  { value: "other", label: "Other" },
+];
+
+export function SubmitEventPage() {
+  const { user, isLoading: authLoading } = useAuth();
+
+  if (authLoading) return <LoadingState />;
+  if (!user) return <SignedOutState />;
+
+  return (
+    <EventsLayout
+      title="Submit an Event"
+      subtitle="Add your event to the community calendar — staff will review before it goes live."
+      prevPage={{ path: "/events", label: "Upcoming Events" }}
+      nextPage={{
+        path: "/events/calendar",
+        label: "Calendar",
+        teaser: "See the full schedule",
+      }}
+    >
+      <SubmitForm />
+    </EventsLayout>
+  );
+}
+
+// ─── The form ─────────────────────────────────────────────────────────
+
+interface FormState {
+  name: string;
+  type: EventType;
+  startDate: string;
+  endDate: string;
+  location: string;
+  externalUrl: string;
+  description: string;
+}
+
+const INITIAL_STATE: FormState = {
+  name: "",
+  type: "workshop",
+  startDate: "",
+  endDate: "",
+  location: "",
+  externalUrl: "",
+  description: "",
+};
+
+function SubmitForm() {
+  const apiFetch = useApi();
+  const navigate = useNavigate();
+  const [state, setState] = useState<FormState>(INITIAL_STATE);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setState((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setError(null);
+
+    // Trim & strip empty optionals before serializing so the worker's
+    // zod schema doesn't trip on "" for fields like externalUrl (URL
+    // validator) or endDate (date-format validator).
+    const payload: Record<string, unknown> = {
+      name: state.name.trim(),
+      type: state.type,
+      startDate: state.startDate,
+    };
+    if (state.endDate) payload.endDate = state.endDate;
+    if (state.location.trim()) payload.location = state.location.trim();
+    if (state.externalUrl.trim()) payload.externalUrl = state.externalUrl.trim();
+    if (state.description.trim()) payload.description = state.description.trim();
+
+    setSubmitting(true);
+    try {
+      const res = await apiFetch("/events/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as
+          | { error?: string; message?: string }
+          | null;
+        throw new Error(
+          body?.message ?? body?.error ?? `Submission failed (${res.status})`
+        );
+      }
+      navigate("/events?submitted=1");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="mb-16 max-w-3xl">
+      <p className="font-mono text-xs uppercase tracking-[0.25em] text-teal-700 mb-6">
+        Member submission · staff-reviewed
+      </p>
+      <p className="font-display text-3xl lg:text-4xl font-bold text-neutral-900 tracking-tight leading-[1.1] mb-6 text-balance">
+        Tell us about your event.
+      </p>
+      <p className="text-base text-neutral-600 leading-relaxed mb-10 max-w-2xl">
+        Submissions enter a staff review queue. Once approved, the event will
+        appear on the Upcoming Events page and the community calendar.
+        Required fields are marked with{" "}
+        <span className="text-purple-600">*</span>.
+      </p>
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-2xl border border-neutral-200 bg-neutral-50/40 p-6 lg:p-8 space-y-6"
+        noValidate
+      >
+        <Field
+          label="Event name"
+          required
+          hint="The public title members will see."
+        >
+          <input
+            type="text"
+            required
+            maxLength={200}
+            value={state.name}
+            onChange={(e) => update("name", e.target.value)}
+            className={inputClass}
+          />
+        </Field>
+
+        <Field label="Type" required>
+          <select
+            required
+            value={state.type}
+            onChange={(e) => update("type", e.target.value as EventType)}
+            className={inputClass}
+          >
+            {EVENT_TYPES.map((t) => (
+              <option key={t.value} value={t.value}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <Field label="Start date" required>
+            <input
+              type="date"
+              required
+              value={state.startDate}
+              onChange={(e) => update("startDate", e.target.value)}
+              className={inputClass}
+            />
+          </Field>
+          <Field label="End date" hint="Leave blank for a single-day event.">
+            <input
+              type="date"
+              value={state.endDate}
+              onChange={(e) => update("endDate", e.target.value)}
+              className={inputClass}
+            />
+          </Field>
+        </div>
+
+        <Field
+          label="Location"
+          hint="City, venue, or 'Virtual' / 'Online'."
+        >
+          <input
+            type="text"
+            maxLength={200}
+            value={state.location}
+            onChange={(e) => update("location", e.target.value)}
+            className={inputClass}
+            placeholder="e.g. Chicago, IL — or Online"
+          />
+        </Field>
+
+        <Field
+          label="External URL"
+          hint="Official event page, registration link, or call for participation."
+        >
+          <input
+            type="url"
+            maxLength={500}
+            value={state.externalUrl}
+            onChange={(e) => update("externalUrl", e.target.value)}
+            className={inputClass}
+            placeholder="https://"
+          />
+        </Field>
+
+        <Field
+          label="Description"
+          hint="A short paragraph describing the event for members."
+        >
+          <textarea
+            rows={5}
+            maxLength={5000}
+            value={state.description}
+            onChange={(e) => update("description", e.target.value)}
+            className={`${inputClass} resize-y min-h-[8rem]`}
+          />
+        </Field>
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-4 pt-2">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex items-center gap-2 px-7 py-3.5 bg-teal-600 text-white text-sm font-bold rounded-xl hover:bg-teal-700 shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+          >
+            {submitting ? "Submitting…" : "Submit for review"}
+          </button>
+          <Link
+            to="/events"
+            className="font-mono text-[11px] uppercase tracking-[0.25em] text-neutral-500 hover:text-neutral-900 transition-colors"
+          >
+            ← cancel
+          </Link>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+const inputClass =
+  "w-full rounded-lg border border-neutral-300 bg-white px-3 py-2.5 text-sm text-neutral-900 placeholder:text-neutral-400 focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-200 transition-colors";
+
+function Field({
+  label,
+  required,
+  hint,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block">
+      <span className="block font-display text-sm font-bold text-neutral-900 tracking-tight mb-1.5">
+        {label}
+        {required && (
+          <span className="text-purple-600 ml-1" aria-label="required">
+            *
+          </span>
+        )}
+      </span>
+      {children}
+      {hint && (
+        <span className="block text-xs text-neutral-500 mt-1.5">{hint}</span>
+      )}
+    </label>
+  );
+}
+
+// ─── States ──────────────────────────────────────────────────────────
+
+function LoadingState() {
+  return (
+    <article
+      className="max-w-3xl mx-auto px-6 lg:px-10 py-24 lg:py-32 animate-pulse"
+      aria-hidden="true"
+    >
+      <div className="h-3 w-32 bg-neutral-100 mb-6" />
+      <div className="h-12 w-2/3 bg-neutral-100 mb-4" />
+      <div className="h-5 w-1/2 bg-neutral-100" />
+    </article>
+  );
+}
+
+function SignedOutState() {
+  return (
+    <article className="max-w-3xl mx-auto px-6 lg:px-10 py-24 lg:py-32 text-center">
+      <p className="font-mono text-xs uppercase tracking-[0.25em] text-teal-700 mb-6">
+        Submit an event
+      </p>
+      <h1 className="font-display text-3xl lg:text-5xl font-bold text-neutral-900 tracking-tight leading-[1.1] mb-6">
+        Sign in to submit an event.
+      </h1>
+      <p className="text-lg text-neutral-600 leading-relaxed mb-10 max-w-xl mx-auto">
+        Event submissions are open to US-RSE members. Sign in with your
+        member account to add your event to the community calendar.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <Link
+          to="/sign-in"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-teal-600 text-white font-semibold rounded-lg hover:bg-teal-700 transition-colors"
+        >
+          Sign in
+        </Link>
+        <Link
+          to="/events"
+          className="font-mono text-[11px] uppercase tracking-[0.25em] text-neutral-500 hover:text-neutral-900 transition-colors"
+        >
+          ← back to events
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/src/pages/events/UpcomingEventsPage.tsx
+++ b/apps/web/src/pages/events/UpcomingEventsPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { EventsLayout } from "@/components/events/EventsLayout";
 import { useInView } from "@/hooks/useInView";
+import { useEvents, type PublicEvent } from "@/hooks/useEvents";
 
 interface Fact {
   value: string;
@@ -63,6 +64,62 @@ const eventAccent = {
   },
 };
 
+const MONTH_ABBR = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+interface FormattedEventDate {
+  month: string;
+  day: string;
+  year: string;
+  full: string;
+}
+
+function formatEventDate(startDate: string, endDate: string | null): FormattedEventDate {
+  const start = new Date(startDate);
+  const end = endDate ? new Date(endDate) : null;
+  const month = MONTH_ABBR[start.getUTCMonth()] ?? "";
+  const startDay = String(start.getUTCDate());
+  const year = String(start.getUTCFullYear());
+
+  let day = startDay;
+  let full = `${month} ${startDay}, ${year}`;
+  if (end) {
+    const endDay = String(end.getUTCDate());
+    const sameMonth =
+      end.getUTCMonth() === start.getUTCMonth() &&
+      end.getUTCFullYear() === start.getUTCFullYear();
+    if (sameMonth) {
+      day = `${startDay}–${endDay}`;
+      full = `${month} ${startDay}–${endDay}, ${year}`;
+    } else {
+      const endMonth = MONTH_ABBR[end.getUTCMonth()] ?? "";
+      day = `${startDay}–${endMonth} ${endDay}`;
+      full = `${month} ${startDay} – ${endMonth} ${endDay}, ${year}`;
+    }
+  }
+  return { month, day, year, full };
+}
+
+function isUpcoming(e: PublicEvent): boolean {
+  const ref = e.endDate ?? e.startDate;
+  const t = new Date(ref).getTime();
+  if (Number.isNaN(t)) return false;
+  // Inclusive: events ending today still count as upcoming
+  return t >= Date.now() - 24 * 60 * 60 * 1000;
+}
+
 interface Bridge {
   eyebrow: string;
   title: string;
@@ -101,9 +158,21 @@ export function UpcomingEventsPage() {
   const { ref: stanceRef, isInView: stanceInView } = useInView(0.2);
   const { ref: factsRef, isInView: factsInView } = useInView(0.3);
   const { ref: featuredRef, isInView: featuredInView } = useInView(0.15);
+  const { ref: dynamicRef, isInView: dynamicInView } = useInView(0.05);
   const { ref: recurringRef, isInView: recurringInView } = useInView(0.05);
   const { ref: ctaRef, isInView: ctaInView } = useInView(0.2);
   const { ref: bridgeRef, isInView: bridgeInView } = useInView(0.1);
+
+  const { events, error: eventsError } = useEvents();
+  // Hide the dedicated featured-event entry (USRSE'26) so it doesn't
+  // duplicate the hand-curated featured section above.
+  const dynamicEvents = (events ?? [])
+    .filter(isUpcoming)
+    .filter((e) => e.slug !== "usrse26")
+    .sort(
+      (a, b) =>
+        new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
+    );
 
   return (
     <EventsLayout
@@ -250,6 +319,151 @@ export function UpcomingEventsPage() {
               </svg>
             </Link>
           </div>
+        </div>
+      </section>
+
+      {/* ── Dynamic upcoming events — from API ───────────────────── */}
+      <section ref={dynamicRef} className="mb-20">
+        <div className="flex items-baseline gap-3 mb-4">
+          <p className="font-mono text-xs uppercase tracking-[0.25em] text-purple-600">
+            From the community
+          </p>
+          <span className="flex-1 h-px bg-neutral-200" aria-hidden="true" />
+          <span className="font-mono text-[11px] text-neutral-400 tabular-nums">
+            {events === null && !eventsError
+              ? "loading…"
+              : `${dynamicEvents.length.toString().padStart(2, "0")} upcoming`}
+          </span>
+        </div>
+        <h2 className="font-display text-3xl lg:text-4xl font-bold text-neutral-900 tracking-tight mb-4">
+          What&rsquo;s on the calendar.
+        </h2>
+        <p className="text-neutral-500 leading-relaxed max-w-2xl mb-12">
+          Workshops, meetups, sponsored sessions, and community-submitted
+          gatherings &mdash; the latest updates from across the network.
+        </p>
+
+        {eventsError ? (
+          <p className="font-mono text-sm text-neutral-500 py-6 px-6 border border-neutral-200 bg-neutral-50 rounded-lg">
+            We couldn&rsquo;t load the latest events right now. Please try
+            again shortly.
+          </p>
+        ) : events === null ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-neutral-200">
+            {[0, 1].map((i) => (
+              <div
+                key={i}
+                className="bg-white py-10 px-6 md:px-7 border-t-2 border-neutral-200 animate-pulse"
+              >
+                <div className="h-3 w-24 bg-neutral-100 rounded mb-4" />
+                <div className="h-6 w-2/3 bg-neutral-100 rounded mb-3" />
+                <div className="h-4 w-1/2 bg-neutral-100 rounded" />
+              </div>
+            ))}
+          </div>
+        ) : dynamicEvents.length === 0 ? (
+          <p className="font-mono text-sm text-neutral-500 py-6 px-6 border border-neutral-200 bg-neutral-50 rounded-lg">
+            No additional upcoming events have been posted yet &mdash; check
+            back soon or submit one of your own.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-px bg-neutral-200">
+            {dynamicEvents.map((e, i) => {
+              const d = formatEventDate(e.startDate, e.endDate);
+              const accent = i % 2 === 0 ? "purple" : "teal";
+              const borderClass =
+                accent === "purple" ? "border-purple-500" : "border-teal-500";
+              const eyebrowClass =
+                accent === "purple" ? "text-purple-600" : "text-teal-700";
+              return (
+                <article
+                  key={e.id}
+                  className={`bg-white pt-8 pb-9 px-6 md:px-7 border-t-2 ${borderClass} flex flex-col sm:flex-row gap-6 ${
+                    dynamicInView ? "animate-slide-up" : "opacity-0"
+                  }`}
+                  style={{ animationDelay: `${i * 80}ms` }}
+                >
+                  {/* Date column — echoes the featured event treatment */}
+                  <div className="shrink-0 sm:w-24">
+                    <p className="font-display text-3xl font-black text-neutral-900 leading-none tracking-tight">
+                      {d.month}
+                    </p>
+                    <p className="font-display text-2xl font-bold text-neutral-300 leading-none mt-1 tabular-nums">
+                      {d.day}
+                    </p>
+                    <p className="font-mono text-[10px] text-neutral-400 mt-2 tabular-nums">
+                      {d.year}
+                    </p>
+                  </div>
+
+                  {/* Details */}
+                  <div className="flex-1 min-w-0">
+                    <p
+                      className={`font-mono text-[10px] uppercase tracking-[0.2em] ${eyebrowClass} mb-2`}
+                    >
+                      {e.type.replace(/_/g, " ")}
+                    </p>
+                    <h3 className="font-display text-lg lg:text-xl font-bold text-neutral-900 tracking-tight leading-[1.2] mb-3 text-balance">
+                      {e.name}
+                    </h3>
+                    {e.description ? (
+                      <p className="text-sm text-neutral-600 leading-relaxed mb-4 line-clamp-3">
+                        {e.description}
+                      </p>
+                    ) : null}
+                    <div className="flex flex-wrap gap-x-5 gap-y-1.5 text-xs text-neutral-500 font-mono">
+                      <span className="tabular-nums">{d.full}</span>
+                      {e.location ? <span>{e.location}</span> : null}
+                    </div>
+                    {e.externalUrl ? (
+                      <a
+                        href={e.externalUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group mt-5 inline-flex items-center gap-1.5 text-sm font-bold text-neutral-900 hover:text-purple-700 transition-colors"
+                      >
+                        Event details
+                        <svg
+                          className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth={2.5}
+                          aria-hidden="true"
+                        >
+                          <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                        </svg>
+                      </a>
+                    ) : null}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Submit an event CTA — anonymous click is redirected to sign-in
+            by SubmitEventPage itself, so we always render the link. */}
+        <div className="mt-10 flex flex-wrap items-center gap-4">
+          <Link
+            to="/events/submit"
+            className="group inline-flex items-center gap-2 px-6 py-3 bg-neutral-900 text-white text-sm font-bold rounded-xl hover:bg-purple-700 shadow-md hover:shadow-lg hover:-translate-y-0.5 transition-all"
+          >
+            Submit an event
+            <svg
+              className="w-4 h-4 transition-transform group-hover:translate-x-1"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2.5}
+              aria-hidden="true"
+            >
+              <path d="M13 7l5 5m0 0l-5 5m5-5H6" />
+            </svg>
+          </Link>
+          <p className="font-mono text-[11px] uppercase tracking-wider text-neutral-400">
+            Hosting something? Send it to the community.
+          </p>
         </div>
       </section>
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,6 +9,8 @@ import { publicGroupsRoute } from "./routes/groups";
 import { organizationsRoute } from "./routes/organizations";
 import { adminApi } from "./routes/admin";
 import { announcementsRoute } from "./routes/announcements";
+import { eventsRoute } from "./routes/events";
+import { optionalActor } from "./middleware/optionalActor";
 import type { AppEnv } from "./types";
 
 const app = new Hono<AppEnv>();
@@ -54,6 +56,9 @@ app.route("/vocab", vocabRoute);
 app.route("/groups", publicGroupsRoute);
 app.route("/organizations", organizationsRoute);
 app.route("/announcements", announcementsRoute);
+app.use("/events", optionalActor);
+app.use("/events/*", optionalActor);
+app.route("/events", eventsRoute);
 app.route("/admin", adminApi);
 
 export default app;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,7 +10,10 @@ import { organizationsRoute } from "./routes/organizations";
 import { adminApi } from "./routes/admin";
 import { announcementsRoute } from "./routes/announcements";
 import { eventsRoute } from "./routes/events";
+import { eventsSubmitRoute } from "./routes/eventsSubmit";
 import { optionalActor } from "./middleware/optionalActor";
+import { requireAuth } from "./middleware/auth";
+import { requireActorContext } from "./middleware/actorContext";
 import type { AppEnv } from "./types";
 
 const app = new Hono<AppEnv>();
@@ -56,6 +59,13 @@ app.route("/vocab", vocabRoute);
 app.route("/groups", publicGroupsRoute);
 app.route("/organizations", organizationsRoute);
 app.route("/announcements", announcementsRoute);
+// `/events/submit` is auth-gated; mount BEFORE the optionalActor middleware
+// so route resolution picks the specific path first and the optional-actor
+// middleware doesn't get a chance to silently no-op the auth check.
+app.use("/events/submit", requireAuth);
+app.use("/events/submit", requireActorContext);
+app.route("/events/submit", eventsSubmitRoute);
+
 app.use("/events", optionalActor);
 app.use("/events/*", optionalActor);
 app.route("/events", eventsRoute);

--- a/packages/api/src/middleware/optionalActor.ts
+++ b/packages/api/src/middleware/optionalActor.ts
@@ -26,6 +26,13 @@ import type { AppEnv } from "../types";
  * every request.
  */
 export const optionalActor = createMiddleware<AppEnv>(async (c, next) => {
+  // Short-circuit: if a previous middleware already established an actor
+  // (e.g., requireActorContext on a stacked auth route), don't overwrite it.
+  if (c.get("actor")) {
+    await next();
+    return;
+  }
+
   let workosId: string | undefined;
 
   // Test escape hatch: when TEST_BYPASS_AUTH=1 and the Authorization

--- a/packages/api/src/middleware/optionalActor.ts
+++ b/packages/api/src/middleware/optionalActor.ts
@@ -28,6 +28,35 @@ import type { AppEnv } from "../types";
 export const optionalActor = createMiddleware<AppEnv>(async (c, next) => {
   let workosId: string | undefined;
 
+  // Test escape hatch: when TEST_BYPASS_AUTH=1 and the Authorization
+  // header is in `test:<role>:<userId>` form, synthesize an ActorContext
+  // directly. Mirrors the bypass in requireActorContext so tests can
+  // exercise the signed-in branch of optional-auth routes.
+  if (c.env.TEST_BYPASS_AUTH === "1") {
+    const header = c.req.header("Authorization") ?? "";
+    const match = header.match(/^test:(staff|member|super_admin):(.+)$/);
+    if (match) {
+      const role = match[1] as "staff" | "member" | "super_admin";
+      const userId = match[2];
+      const tier = role === "member" ? 0 : role === "staff" ? 1 : 2;
+      const actor: ActorContext = {
+        user: {
+          id: userId,
+          memberId: userId,
+          email: `${userId}@test.local`,
+          role,
+        },
+        systemTier: tier as 0 | 1 | 2,
+        leadershipPositions: [],
+        chairedGroupIds: new Set(),
+        chairedEventIds: new Set(),
+      };
+      c.set("actor", actor);
+      await next();
+      return;
+    }
+  }
+
   try {
     // Extract the Authorization header and parse the token.
     const header = c.req.header("Authorization");

--- a/packages/api/src/routes/admin/events/byId.test.ts
+++ b/packages/api/src/routes/admin/events/byId.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import type { NeonQueryFunction } from "@neondatabase/serverless";
+import { testApp, makeStaffActor, makeMemberActor } from "../../../test/helpers";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const describeIfDb = HAS_DB ? describe : describe.skip;
+
+const AUTHOR = "00000000-0000-0000-0000-000000000d01";
+const STAFF = "00000000-0000-0000-0000-000000000d02";
+const EVT = "00000000-0000-0000-0000-000000000d03";
+
+// Narrow `sql` to the same generic shape that `neon(url)` picks at top-level
+// so result rows index as `Record<string, any>` and not the union type.
+type Sql = NeonQueryFunction<false, false>;
+
+describeIfDb("/admin/events/:id", () => {
+  let sql: Sql;
+
+  beforeAll(async () => {
+    sql = neon(process.env.DATABASE_URL!) as Sql;
+    for (const [id, role] of [
+      [AUTHOR, "member"],
+      [STAFF, "staff"],
+    ] as const) {
+      // audit_log.actor_id references users; clear before deleting the user.
+      await sql`DELETE FROM audit_log WHERE actor_id = ${id}::uuid`;
+      await sql`DELETE FROM users WHERE id = ${id}::uuid`;
+      await sql`
+        INSERT INTO users (id, workos_id, member_id, email, role)
+        VALUES (${id}::uuid, ${"w-" + id}, ${"m-" + id}, ${id + "@t"}, ${role}::user_role)
+      `;
+    }
+    await sql`DELETE FROM events WHERE id = ${EVT}::uuid`;
+    await sql`
+      INSERT INTO events (id, slug, name, type, start_date, status, revision, author_id, scope)
+      VALUES (
+        ${EVT}::uuid, ${'detail-test-' + Date.now()}, 'Detail Test', 'workshop'::event_type,
+        '2099-01-01'::date, 'draft'::artifact_status, 1, ${AUTHOR}::uuid, 'community'::artifact_scope
+      )
+    `;
+  });
+
+  afterAll(async () => {
+    await sql`DELETE FROM artifact_comments WHERE entity_id = ${EVT}::uuid`;
+    await sql`DELETE FROM artifact_reviews WHERE entity_id = ${EVT}::uuid`;
+    await sql`DELETE FROM audit_log WHERE target_id = ${EVT}::uuid`;
+    await sql`DELETE FROM events WHERE id = ${EVT}::uuid`;
+    // PATCH handler writes audit rows actor=STAFF; clear before user delete.
+    await sql`DELETE FROM audit_log WHERE actor_id IN (${AUTHOR}::uuid, ${STAFF}::uuid)`;
+    await sql`DELETE FROM users WHERE id IN (${AUTHOR}::uuid, ${STAFF}::uuid)`;
+  });
+
+  test("GET 200 returns event detail for staff", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}`, {
+      headers: { Authorization: makeStaffActor(STAFF) },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: true; event: { id: string; name: string }; reviews: unknown[]; comments: unknown[] };
+    expect(body.event.id).toBe(EVT);
+    expect(Array.isArray(body.reviews)).toBe(true);
+    expect(Array.isArray(body.comments)).toBe(true);
+  });
+
+  test("GET 200 returns event detail for the author", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}`, {
+      headers: { Authorization: makeMemberActor(AUTHOR) },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("GET 403 for non-author non-staff", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}`, {
+      headers: { Authorization: makeMemberActor("00000000-0000-0000-0000-000000000d99") },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("PATCH 200 staff can update any field on any state", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: makeStaffActor(STAFF) },
+      body: JSON.stringify({ name: "Updated by staff" }),
+    });
+    expect(res.status).toBe(200);
+    const after = await sql`SELECT name FROM events WHERE id = ${EVT}::uuid`;
+    expect(after[0].name).toBe("Updated by staff");
+  });
+
+  test("PATCH 403 non-author non-staff", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", Authorization: makeMemberActor("00000000-0000-0000-0000-000000000d99") },
+      body: JSON.stringify({ name: "Nope" }),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/api/src/routes/admin/events/byId.ts
+++ b/packages/api/src/routes/admin/events/byId.ts
@@ -1,0 +1,164 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { and, asc, desc, eq } from "drizzle-orm";
+import { createDb } from "../../../db";
+import {
+  artifactComments,
+  artifactReviews,
+  auditLog,
+  events,
+  users,
+} from "../../../db/schema";
+import { canEditArtifact } from "../../../lib/policies";
+import type { AppEnv } from "../../../types";
+
+export const adminEventByIdRoute = new Hono<AppEnv>();
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const patchBodySchema = z.object({
+  name: z.string().min(1).max(200).optional(),
+  type: z.enum(["conference", "workshop", "meetup", "webinar", "community_call", "other"]).optional(),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
+  location: z.string().max(200).nullable().optional(),
+  url: z.string().url().max(500).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
+  scope: z.enum(["public", "community", "group", "staff_only"]).optional(),
+  hostGroupId: z.string().uuid().nullable().optional(),
+  hostOrgId: z.string().uuid().nullable().optional(),
+  externalUrl: z.string().url().max(500).nullable().optional(),
+}).strict();
+
+adminEventByIdRoute.get("/", async (c) => {
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const actor = c.get("actor");
+  if (!actor) return c.json({ ok: false, error: "unauthorized" }, 401);
+  const id = c.req.param("id");
+  if (!id || !UUID_RE.test(id)) return c.json({ ok: false, error: "invalid_input" }, 400);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const event = await db
+    .select()
+    .from(events)
+    .where(eq(events.id, id))
+    .limit(1)
+    .then((r) => r[0]);
+  if (!event) return c.json({ ok: false, error: "not_found" }, 404);
+
+  // Access: staff can view any; author can view their own; everyone else 403.
+  if (actor.systemTier < 1 && event.authorId !== actor.user.id) {
+    return c.json({ ok: false, error: "forbidden" }, 403);
+  }
+
+  const [reviews, comments, audit] = await Promise.all([
+    db
+      .select({
+        id: artifactReviews.id,
+        reviewerId: artifactReviews.reviewerId,
+        reviewerName: users.email,
+        decision: artifactReviews.decision,
+        comment: artifactReviews.comment,
+        entityRevision: artifactReviews.entityRevision,
+        createdAt: artifactReviews.createdAt,
+      })
+      .from(artifactReviews)
+      .leftJoin(users, eq(users.id, artifactReviews.reviewerId))
+      .where(and(eq(artifactReviews.entityType, "event"), eq(artifactReviews.entityId, id)))
+      .orderBy(asc(artifactReviews.createdAt)),
+    db
+      .select({
+        id: artifactComments.id,
+        authorId: artifactComments.authorId,
+        authorName: users.email,
+        body: artifactComments.body,
+        createdAt: artifactComments.createdAt,
+      })
+      .from(artifactComments)
+      .leftJoin(users, eq(users.id, artifactComments.authorId))
+      .where(and(eq(artifactComments.entityType, "event"), eq(artifactComments.entityId, id)))
+      .orderBy(asc(artifactComments.createdAt)),
+    db
+      .select({
+        id: auditLog.id,
+        action: auditLog.action,
+        actorId: auditLog.actorId,
+        payload: auditLog.payload,
+        createdAt: auditLog.createdAt,
+      })
+      .from(auditLog)
+      .where(eq(auditLog.targetId, id))
+      .orderBy(desc(auditLog.createdAt))
+      .limit(50),
+  ]);
+
+  return c.json({ ok: true, event, reviews, comments, audit });
+});
+
+adminEventByIdRoute.patch(
+  "/",
+  zValidator("json", patchBodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ ok: false, error: "invalid_input", issues: result.error.issues }, 400);
+    }
+  }),
+  async (c) => {
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const actor = c.get("actor");
+    if (!actor) return c.json({ ok: false, error: "unauthorized" }, 401);
+    const id = c.req.param("id");
+    if (!id || !UUID_RE.test(id)) return c.json({ ok: false, error: "invalid_input" }, 400);
+    const db = createDb(c.env.DATABASE_URL);
+
+    const existing = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, id))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+
+    if (
+      !canEditArtifact(actor, {
+        entityType: "event",
+        entityId: id,
+        status: existing.status,
+        authorId: existing.authorId,
+      })
+    ) {
+      return c.json({ ok: false, error: "forbidden" }, 403);
+    }
+
+    const body = c.req.valid("json");
+    const next: Record<string, unknown> = { updatedAt: new Date() };
+    const before: Record<string, unknown> = {};
+    const after: Record<string, unknown> = {};
+
+    for (const k of [
+      "name", "type", "startDate", "endDate", "location", "url",
+      "description", "scope", "hostGroupId", "hostOrgId", "externalUrl",
+    ] as const) {
+      if (k in body && body[k] !== undefined && body[k] !== existing[k]) {
+        next[k] = body[k];
+        before[k] = existing[k];
+        after[k] = body[k];
+      }
+    }
+    if (Object.keys(after).length === 0) {
+      return c.json({ ok: true, noChange: true });
+    }
+
+    await db.update(events).set(next).where(eq(events.id, id));
+    await db.insert(auditLog).values({
+      actorId: actor.user.id,
+      actorRole: actor.user.role,
+      action: "events.update",
+      targetType: "events",
+      targetId: id,
+      payload: { before, after },
+    });
+
+    return c.json({ ok: true });
+  }
+);

--- a/packages/api/src/routes/admin/events/comments.test.ts
+++ b/packages/api/src/routes/admin/events/comments.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import { testApp, makeMemberActor, makeStaffActor } from "../../../test/helpers";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const describeIfDb = HAS_DB ? describe : describe.skip;
+
+const AUTHOR = "00000000-0000-0000-0000-000000000f01";
+const STAFF = "00000000-0000-0000-0000-000000000f02";
+const EVT = "00000000-0000-0000-0000-000000000f03";
+
+describeIfDb("/admin/events/:id/comments", () => {
+  let sql: ReturnType<typeof neon>;
+
+  beforeAll(async () => {
+    sql = neon(process.env.DATABASE_URL!);
+    await sql`DELETE FROM artifact_comments WHERE entity_id = ${EVT}::uuid`;
+    await sql`DELETE FROM audit_log WHERE actor_id IN (${AUTHOR}::uuid, ${STAFF}::uuid)`;
+    for (const [id, role] of [
+      [AUTHOR, "member"], [STAFF, "staff"],
+    ] as const) {
+      await sql`DELETE FROM users WHERE id = ${id}::uuid`;
+      await sql`
+        INSERT INTO users (id, workos_id, member_id, email, role)
+        VALUES (${id}::uuid, ${"w-" + id}, ${"m-" + id}, ${id + "@t"}, ${role}::user_role)
+      `;
+    }
+    await sql`DELETE FROM events WHERE id = ${EVT}::uuid`;
+    await sql`
+      INSERT INTO events (id, slug, name, type, start_date, status, revision, author_id, scope)
+      VALUES (
+        ${EVT}::uuid, ${'cmt-' + Date.now()}, 'Comments Test', 'workshop'::event_type,
+        '2099-01-01'::date, 'in_review'::artifact_status, 1, ${AUTHOR}::uuid, 'community'::artifact_scope
+      )
+    `;
+  });
+
+  afterAll(async () => {
+    await sql`DELETE FROM artifact_comments WHERE entity_id = ${EVT}::uuid`;
+    await sql`DELETE FROM events WHERE id = ${EVT}::uuid`;
+    await sql`DELETE FROM audit_log WHERE actor_id IN (${AUTHOR}::uuid, ${STAFF}::uuid)`;
+    await sql`DELETE FROM users WHERE id IN (${AUTHOR}::uuid, ${STAFF}::uuid)`;
+  });
+
+  test("staff posts a comment", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeStaffActor(STAFF) },
+      body: JSON.stringify({ body: "Looks good but title needs work." }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  test("author posts a comment", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeMemberActor(AUTHOR) },
+      body: JSON.stringify({ body: "Updated, please re-review." }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  test("non-author non-staff cannot comment", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeMemberActor("00000000-0000-0000-0000-000000000f99") },
+      body: JSON.stringify({ body: "should be blocked" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("empty body rejected", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeStaffActor(STAFF) },
+      body: JSON.stringify({ body: "   " }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/api/src/routes/admin/events/comments.ts
+++ b/packages/api/src/routes/admin/events/comments.ts
@@ -1,0 +1,61 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../db";
+import { artifactComments, events } from "../../../db/schema";
+import { sanitizeCommentBody } from "../../../lib/artifacts/comments";
+import type { AppEnv } from "../../../types";
+
+export const adminEventCommentsRoute = new Hono<AppEnv>();
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const bodySchema = z.object({ body: z.string() });
+
+adminEventCommentsRoute.post(
+  "/",
+  zValidator("json", bodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json({ ok: false, error: "invalid_input" }, 400);
+    }
+  }),
+  async (c) => {
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const actor = c.get("actor");
+    if (!actor) return c.json({ ok: false, error: "unauthorized" }, 401);
+    const id = c.req.param("id");
+    if (!id || !UUID_RE.test(id)) return c.json({ ok: false, error: "invalid_input" }, 400);
+
+    const db = createDb(c.env.DATABASE_URL);
+    const existing = await db
+      .select({ authorId: events.authorId })
+      .from(events)
+      .where(eq(events.id, id))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+
+    // Visibility: staff or the artifact author can comment
+    if (actor.systemTier < 1 && existing.authorId !== actor.user.id) {
+      return c.json({ ok: false, error: "forbidden" }, 403);
+    }
+
+    const sanitized = sanitizeCommentBody(c.req.valid("json").body);
+    if (!sanitized.ok) {
+      return c.json({ ok: false, error: sanitized.error }, 400);
+    }
+
+    const [row] = await db
+      .insert(artifactComments)
+      .values({
+        entityType: "event",
+        entityId: id,
+        authorId: actor.user.id,
+        body: sanitized.body,
+      })
+      .returning();
+
+    return c.json({ ok: true, comment: row }, 201);
+  }
+);

--- a/packages/api/src/routes/admin/events/index.test.ts
+++ b/packages/api/src/routes/admin/events/index.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import { testApp, makeStaffActor, makeMemberActor } from "../../../test/helpers";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const describeIfDb = HAS_DB ? describe : describe.skip;
+
+const TEST_AUTHOR = "00000000-0000-0000-0000-000000000c01";
+const TEST_STAFF = "00000000-0000-0000-0000-000000000c02";
+
+describeIfDb("POST /admin/events", () => {
+  let sql: ReturnType<typeof neon>;
+  const createdIds: string[] = [];
+
+  beforeAll(async () => {
+    sql = neon(process.env.DATABASE_URL!);
+    for (const [id, role] of [
+      [TEST_AUTHOR, "member"],
+      [TEST_STAFF, "staff"],
+    ] as const) {
+      // audit_log.actor_id references users; clear before deleting the user.
+      await sql`DELETE FROM audit_log WHERE actor_id = ${id}::uuid`;
+      await sql`DELETE FROM users WHERE id = ${id}::uuid`;
+      await sql`
+        INSERT INTO users (id, workos_id, member_id, email, role)
+        VALUES (${id}::uuid, ${"wos-" + id}, ${"mem-" + id}, ${id + "@test"}, ${role}::user_role)
+      `;
+    }
+  });
+
+  afterAll(async () => {
+    if (createdIds.length) {
+      await sql`DELETE FROM events WHERE id = ANY(${createdIds}::uuid[])`;
+    }
+    await sql`DELETE FROM audit_log WHERE actor_id IN (${TEST_AUTHOR}::uuid, ${TEST_STAFF}::uuid)`;
+    await sql`DELETE FROM users WHERE id IN (${TEST_AUTHOR}::uuid, ${TEST_STAFF}::uuid)`;
+  });
+
+  test("requires actor context (rejects unauthenticated)", async () => {
+    const res = await testApp.request("/admin/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "x", type: "workshop", startDate: "2099-01-01" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("any signed-in actor can create a draft", async () => {
+    const res = await testApp.request("/admin/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: makeMemberActor(TEST_AUTHOR),
+      },
+      body: JSON.stringify({
+        name: "Member-submitted draft",
+        type: "meetup",
+        startDate: "2099-06-01",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { ok: true; event: { id: string; status: string; scope: string } };
+    expect(body.event.status).toBe("draft");
+    expect(body.event.scope).toBe("community");
+    createdIds.push(body.event.id);
+  });
+
+  test("rejects invalid input", async () => {
+    const res = await testApp.request("/admin/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: makeStaffActor(TEST_STAFF),
+      },
+      body: JSON.stringify({ name: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("auto-generates slug from name", async () => {
+    const res = await testApp.request("/admin/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: makeStaffActor(TEST_STAFF),
+      },
+      body: JSON.stringify({
+        name: "Awesome Workshop 2099!",
+        type: "workshop",
+        startDate: "2099-09-15",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { ok: true; event: { id: string; slug: string } };
+    expect(body.event.slug).toMatch(/^awesome-workshop-2099-[a-z0-9]{4,}$/);
+    createdIds.push(body.event.id);
+  });
+});

--- a/packages/api/src/routes/admin/events/index.ts
+++ b/packages/api/src/routes/admin/events/index.ts
@@ -1,0 +1,172 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { and, desc, eq, ilike, isNull } from "drizzle-orm";
+import { createDb } from "../../../db";
+import { events } from "../../../db/schema";
+import type { AppEnv } from "../../../types";
+
+export const adminEventsRoute = new Hono<AppEnv>();
+
+const EVENT_TYPES = ["conference", "workshop", "meetup", "webinar", "community_call", "other"] as const;
+const SCOPES = ["public", "community", "group", "staff_only"] as const;
+const STATUSES = [
+  "draft", "in_review", "changes_requested", "rejected", "published",
+  "cancelled", "completed", "archived",
+] as const;
+
+const createBodySchema = z.object({
+  name: z.string().min(1).max(200),
+  type: z.enum(EVENT_TYPES),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  location: z.string().max(200).optional(),
+  url: z.string().url().max(500).optional(),
+  description: z.string().max(5000).optional(),
+  scope: z.enum(SCOPES).optional(),
+  hostGroupId: z.string().uuid().optional(),
+  hostOrgId: z.string().uuid().optional(),
+  externalUrl: z.string().url().max(500).optional(),
+});
+
+function slugify(name: string): string {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  const suffix = Math.random().toString(36).slice(2, 6);
+  return base ? `${base}-${suffix}` : `event-${suffix}`;
+}
+
+adminEventsRoute.post(
+  "/",
+  zValidator("json", createBodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        { ok: false, error: "invalid_input", issues: result.error.issues },
+        400
+      );
+    }
+  }),
+  async (c) => {
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const actor = c.get("actor");
+    if (!actor) return c.json({ ok: false, error: "unauthorized" }, 401);
+    const db = createDb(c.env.DATABASE_URL);
+    const body = c.req.valid("json");
+
+    let scope = body.scope;
+    if (!scope) {
+      if (actor.systemTier === 0 && actor.chairedGroupIds.size > 0) {
+        scope = "group";
+      } else if (actor.systemTier === 0) {
+        scope = "community";
+      } else {
+        scope = "community";
+      }
+    }
+
+    let hostGroupId = body.hostGroupId;
+    if (!hostGroupId && scope === "group" && actor.chairedGroupIds.size > 0) {
+      hostGroupId = [...actor.chairedGroupIds][0];
+    }
+
+    const slug = slugify(body.name);
+
+    const [row] = await db
+      .insert(events)
+      .values({
+        slug,
+        name: body.name,
+        type: body.type,
+        startDate: body.startDate,
+        endDate: body.endDate ?? null,
+        location: body.location ?? null,
+        url: body.url ?? null,
+        description: body.description ?? null,
+        status: "draft",
+        revision: 1,
+        authorId: actor.user.id,
+        scope,
+        hostGroupId: hostGroupId ?? null,
+        hostOrgId: body.hostOrgId ?? null,
+        externalUrl: body.externalUrl ?? null,
+      })
+      .returning();
+
+    return c.json(
+      {
+        ok: true,
+        event: {
+          id: row.id,
+          slug: row.slug,
+          name: row.name,
+          type: row.type,
+          status: row.status,
+          scope: row.scope,
+          revision: row.revision,
+          authorId: row.authorId,
+          startDate: row.startDate,
+          endDate: row.endDate,
+          createdAt: row.createdAt,
+        },
+      },
+      201
+    );
+  }
+);
+
+adminEventsRoute.get("/", async (c) => {
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+  const actor = c.get("actor");
+  if (!actor) return c.json({ ok: false, error: "unauthorized" }, 401);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const status = c.req.query("status");
+  const type = c.req.query("type");
+  const scope = c.req.query("scope");
+  const hostGroupId = c.req.query("hostGroupId");
+  const hostOrgId = c.req.query("hostOrgId");
+  const q = c.req.query("q");
+  const limit = Math.min(200, parseInt(c.req.query("limit") ?? "50", 10));
+  const offset = Math.max(0, parseInt(c.req.query("offset") ?? "0", 10));
+
+  const whereParts = [isNull(events.deletedAt)];
+  if (status && STATUSES.includes(status as (typeof STATUSES)[number])) {
+    whereParts.push(eq(events.status, status as (typeof STATUSES)[number]));
+  }
+  if (type && EVENT_TYPES.includes(type as (typeof EVENT_TYPES)[number])) {
+    whereParts.push(eq(events.type, type as (typeof EVENT_TYPES)[number]));
+  }
+  if (scope && SCOPES.includes(scope as (typeof SCOPES)[number])) {
+    whereParts.push(eq(events.scope, scope as (typeof SCOPES)[number]));
+  }
+  if (hostGroupId) whereParts.push(eq(events.hostGroupId, hostGroupId));
+  if (hostOrgId) whereParts.push(eq(events.hostOrgId, hostOrgId));
+  if (q) whereParts.push(ilike(events.name, `%${q}%`));
+
+  const rows = await db
+    .select({
+      id: events.id,
+      slug: events.slug,
+      name: events.name,
+      type: events.type,
+      status: events.status,
+      revision: events.revision,
+      scope: events.scope,
+      authorId: events.authorId,
+      hostGroupId: events.hostGroupId,
+      hostOrgId: events.hostOrgId,
+      startDate: events.startDate,
+      endDate: events.endDate,
+      createdAt: events.createdAt,
+    })
+    .from(events)
+    .where(and(...whereParts))
+    .orderBy(desc(events.createdAt))
+    .limit(limit)
+    .offset(offset);
+
+  return c.json({ ok: true, rows });
+});

--- a/packages/api/src/routes/admin/events/index.ts
+++ b/packages/api/src/routes/admin/events/index.ts
@@ -5,6 +5,7 @@ import { and, desc, eq, ilike, isNull } from "drizzle-orm";
 import { createDb } from "../../../db";
 import { events } from "../../../db/schema";
 import type { AppEnv } from "../../../types";
+import { adminEventByIdRoute } from "./byId";
 
 export const adminEventsRoute = new Hono<AppEnv>();
 
@@ -170,3 +171,5 @@ adminEventsRoute.get("/", async (c) => {
 
   return c.json({ ok: true, rows });
 });
+
+adminEventsRoute.route("/:id", adminEventByIdRoute);

--- a/packages/api/src/routes/admin/events/index.ts
+++ b/packages/api/src/routes/admin/events/index.ts
@@ -6,6 +6,7 @@ import { createDb } from "../../../db";
 import { events } from "../../../db/schema";
 import type { AppEnv } from "../../../types";
 import { adminEventByIdRoute } from "./byId";
+import { adminEventTransitionsRoute } from "./transitions";
 
 export const adminEventsRoute = new Hono<AppEnv>();
 
@@ -172,4 +173,5 @@ adminEventsRoute.get("/", async (c) => {
   return c.json({ ok: true, rows });
 });
 
+adminEventsRoute.route("/:id/transitions", adminEventTransitionsRoute);
 adminEventsRoute.route("/:id", adminEventByIdRoute);

--- a/packages/api/src/routes/admin/events/index.ts
+++ b/packages/api/src/routes/admin/events/index.ts
@@ -7,6 +7,7 @@ import { events } from "../../../db/schema";
 import type { AppEnv } from "../../../types";
 import { adminEventByIdRoute } from "./byId";
 import { adminEventTransitionsRoute } from "./transitions";
+import { adminEventCommentsRoute } from "./comments";
 
 export const adminEventsRoute = new Hono<AppEnv>();
 
@@ -174,4 +175,5 @@ adminEventsRoute.get("/", async (c) => {
 });
 
 adminEventsRoute.route("/:id/transitions", adminEventTransitionsRoute);
+adminEventsRoute.route("/:id/comments", adminEventCommentsRoute);
 adminEventsRoute.route("/:id", adminEventByIdRoute);

--- a/packages/api/src/routes/admin/events/transitions.test.ts
+++ b/packages/api/src/routes/admin/events/transitions.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import type { NeonQueryFunction } from "@neondatabase/serverless";
+import { testApp, makeMemberActor, makeStaffActor } from "../../../test/helpers";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const describeIfDb = HAS_DB ? describe : describe.skip;
+
+const AUTHOR = "00000000-0000-0000-0000-000000000e01";
+const REV1 = "00000000-0000-0000-0000-000000000e02";
+const REV2 = "00000000-0000-0000-0000-000000000e03";
+const EVT = "00000000-0000-0000-0000-000000000e04";
+
+type Sql = NeonQueryFunction<false, false>;
+
+describeIfDb("POST /admin/events/:id/transitions", () => {
+  let sql: Sql;
+
+  beforeAll(async () => {
+    sql = neon(process.env.DATABASE_URL!) as Sql;
+    // Clean up any leftover review/audit rows from a previous failed run
+    // before deleting users (audit_log.actor_id FK).
+    await sql`DELETE FROM artifact_reviews WHERE entity_id = ${EVT}::uuid`;
+    await sql`DELETE FROM audit_log WHERE target_id = ${EVT}::uuid`;
+    await sql`DELETE FROM audit_log WHERE actor_id IN (${AUTHOR}::uuid, ${REV1}::uuid, ${REV2}::uuid)`;
+    for (const [id, role] of [
+      [AUTHOR, "member"],
+      [REV1, "staff"],
+      [REV2, "staff"],
+    ] as const) {
+      await sql`DELETE FROM users WHERE id = ${id}::uuid`;
+      await sql`
+        INSERT INTO users (id, workos_id, member_id, email, role)
+        VALUES (${id}::uuid, ${"w-" + id}, ${"m-" + id}, ${id + "@t"}, ${role}::user_role)
+      `;
+    }
+    await sql`DELETE FROM events WHERE id = ${EVT}::uuid`;
+    await sql`
+      INSERT INTO events (id, slug, name, type, start_date, status, revision, author_id, scope)
+      VALUES (
+        ${EVT}::uuid, ${'trans-' + Date.now()}, 'Transition Test', 'workshop'::event_type,
+        '2099-01-01'::date, 'draft'::artifact_status, 1, ${AUTHOR}::uuid, 'community'::artifact_scope
+      )
+    `;
+  });
+
+  afterAll(async () => {
+    await sql`DELETE FROM artifact_reviews WHERE entity_id = ${EVT}::uuid`;
+    await sql`DELETE FROM audit_log WHERE target_id = ${EVT}::uuid`;
+    await sql`DELETE FROM events WHERE id = ${EVT}::uuid`;
+    await sql`DELETE FROM audit_log WHERE actor_id IN (${AUTHOR}::uuid, ${REV1}::uuid, ${REV2}::uuid)`;
+    await sql`DELETE FROM users WHERE id IN (${AUTHOR}::uuid, ${REV1}::uuid, ${REV2}::uuid)`;
+  });
+
+  test("author submits → in_review", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/transitions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeMemberActor(AUTHOR) },
+      body: JSON.stringify({ action: "submit_for_review" }),
+    });
+    expect(res.status).toBe(200);
+    const after = await sql`SELECT status FROM events WHERE id = ${EVT}::uuid`;
+    expect(after[0].status).toBe("in_review");
+  });
+
+  test("reviewer 1 approves → still in_review", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/transitions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeStaffActor(REV1) },
+      body: JSON.stringify({ action: "approve" }),
+    });
+    expect(res.status).toBe(200);
+    const after = await sql`SELECT status FROM events WHERE id = ${EVT}::uuid`;
+    expect(after[0].status).toBe("in_review");
+  });
+
+  test("reviewer 2 approves → published", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/transitions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeStaffActor(REV2) },
+      body: JSON.stringify({ action: "approve" }),
+    });
+    expect(res.status).toBe(200);
+    const after = await sql`SELECT status FROM events WHERE id = ${EVT}::uuid`;
+    expect(after[0].status).toBe("published");
+  });
+
+  test("members cannot trigger review actions on someone else's event", async () => {
+    const res = await testApp.request(`/admin/events/${EVT}/transitions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: makeMemberActor("00000000-0000-0000-0000-000000000e99") },
+      body: JSON.stringify({ action: "approve" }),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/packages/api/src/routes/admin/events/transitions.ts
+++ b/packages/api/src/routes/admin/events/transitions.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { eq } from "drizzle-orm";
+import { createDb } from "../../../db";
+import { applyTransition } from "../../../lib/lifecycle";
+import { drizzleLifecycleDb } from "../../../lib/lifecycle/drizzleAdapter";
+import { canEditArtifact, canReviewArtifact } from "../../../lib/policies";
+import { events } from "../../../db/schema";
+import type { AppEnv } from "../../../types";
+
+export const adminEventTransitionsRoute = new Hono<AppEnv>();
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+const bodySchema = z.object({
+  action: z.enum([
+    "submit_for_review",
+    "approve",
+    "reject",
+    "request_changes",
+    "cancel",
+    "archive",
+  ]),
+  comment: z.string().max(4000).optional(),
+});
+
+adminEventTransitionsRoute.post(
+  "/",
+  zValidator("json", bodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        { ok: false, error: "invalid_input", issues: result.error.issues },
+        400
+      );
+    }
+  }),
+  async (c) => {
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const actor = c.get("actor");
+    if (!actor) return c.json({ ok: false, error: "unauthorized" }, 401);
+    const id = c.req.param("id");
+    if (!id || !UUID_RE.test(id)) return c.json({ ok: false, error: "invalid_input" }, 400);
+    const db = createDb(c.env.DATABASE_URL);
+    const body = c.req.valid("json");
+
+    const existing = await db
+      .select({ status: events.status, authorId: events.authorId })
+      .from(events)
+      .where(eq(events.id, id))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!existing) return c.json({ ok: false, error: "not_found" }, 404);
+
+    // Policy gates by action class
+    if (body.action === "submit_for_review") {
+      if (
+        !canEditArtifact(actor, {
+          entityType: "event",
+          entityId: id,
+          status: existing.status,
+          authorId: existing.authorId,
+        })
+      ) {
+        return c.json({ ok: false, error: "forbidden" }, 403);
+      }
+    } else if (
+      body.action === "approve" ||
+      body.action === "reject" ||
+      body.action === "request_changes"
+    ) {
+      if (!canReviewArtifact(actor, { authorId: existing.authorId })) {
+        return c.json({ ok: false, error: "forbidden" }, 403);
+      }
+    } else {
+      // cancel, archive — staff only
+      if (actor.systemTier < 1) {
+        return c.json({ ok: false, error: "forbidden" }, 403);
+      }
+    }
+
+    const lifecycleDb = drizzleLifecycleDb(db, {
+      id: actor.user.id,
+      role: actor.user.role,
+    });
+    const result = await applyTransition(lifecycleDb, {
+      entityType: "event",
+      entityId: id,
+      action: body.action,
+      actorId: actor.user.id,
+      comment: body.comment,
+    });
+    if (!result.ok) {
+      return c.json({ ok: false, error: result.error }, 400);
+    }
+    return c.json({ ok: true, newStatus: result.newStatus });
+  }
+);

--- a/packages/api/src/routes/admin/index.ts
+++ b/packages/api/src/routes/admin/index.ts
@@ -10,6 +10,7 @@ import { adminOrganizationsRoute } from "./organizations";
 import { adminVocabRoute } from "./vocab";
 import { adminGroupsRoute } from "./groups";
 import { adminQueueRoute } from "./queue";
+import { adminEventsRoute } from "./events";
 
 /**
  * Hono sub-app for /api/admin/*. Order matters:
@@ -33,3 +34,4 @@ adminApi.route("/vocab", adminVocabRoute);
 adminApi.route("/groups", adminGroupsRoute);
 adminApi.route("/organizations", adminOrganizationsRoute);
 adminApi.route("/queue", adminQueueRoute);
+adminApi.route("/events", adminEventsRoute);

--- a/packages/api/src/routes/events.test.ts
+++ b/packages/api/src/routes/events.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import { testApp, makeMemberActor } from "../test/helpers";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const describeIfDb = HAS_DB ? describe : describe.skip;
+
+const PUBLIC_EVT = "00000000-0000-0000-0000-00000000ee01";
+const COMMUNITY_EVT = "00000000-0000-0000-0000-00000000ee02";
+const DRAFT_EVT = "00000000-0000-0000-0000-00000000ee03";
+const MEMBER = "00000000-0000-0000-0000-00000000ee04";
+
+describeIfDb("public events routes", () => {
+  let sql: ReturnType<typeof neon>;
+
+  beforeAll(async () => {
+    sql = neon(process.env.DATABASE_URL!);
+    // Defensive cleanup in case a prior run left state behind.
+    await sql`DELETE FROM events WHERE id IN (${PUBLIC_EVT}::uuid, ${COMMUNITY_EVT}::uuid, ${DRAFT_EVT}::uuid)`;
+    await sql`DELETE FROM audit_log WHERE actor_id = ${MEMBER}::uuid`;
+    await sql`DELETE FROM users WHERE id = ${MEMBER}::uuid`;
+    await sql`
+      INSERT INTO users (id, workos_id, member_id, email, role)
+      VALUES (${MEMBER}::uuid, ${"w-" + MEMBER}, ${"m-" + MEMBER}, ${MEMBER + "@t"}, 'member'::user_role)
+    `;
+    await sql`
+      INSERT INTO events (id, slug, name, type, start_date, status, revision, scope)
+      VALUES
+        (${PUBLIC_EVT}::uuid, ${"pub-" + Date.now()}, 'Public Event', 'workshop'::event_type, '2099-06-01'::date, 'published'::artifact_status, 1, 'public'::artifact_scope),
+        (${COMMUNITY_EVT}::uuid, ${"com-" + Date.now()}, 'Community Event', 'meetup'::event_type, '2099-06-02'::date, 'published'::artifact_status, 1, 'community'::artifact_scope),
+        (${DRAFT_EVT}::uuid, ${"drf-" + Date.now()}, 'Draft Event', 'webinar'::event_type, '2099-06-03'::date, 'draft'::artifact_status, 1, 'public'::artifact_scope)
+    `;
+  });
+
+  afterAll(async () => {
+    await sql`DELETE FROM events WHERE id IN (${PUBLIC_EVT}::uuid, ${COMMUNITY_EVT}::uuid, ${DRAFT_EVT}::uuid)`;
+    await sql`DELETE FROM audit_log WHERE actor_id = ${MEMBER}::uuid`;
+    await sql`DELETE FROM users WHERE id = ${MEMBER}::uuid`;
+  });
+
+  test("anonymous: only public published events", async () => {
+    const res = await testApp.request("/events");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: { id: string; scope: string }[] };
+    const ids = body.events.map((e) => e.id);
+    expect(ids).toContain(PUBLIC_EVT);
+    expect(ids).not.toContain(COMMUNITY_EVT);
+    expect(ids).not.toContain(DRAFT_EVT);
+  });
+
+  test("authenticated: public + community published events", async () => {
+    const res = await testApp.request("/events", {
+      headers: { Authorization: makeMemberActor(MEMBER) },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: { id: string }[] };
+    const ids = body.events.map((e) => e.id);
+    expect(ids).toContain(PUBLIC_EVT);
+    expect(ids).toContain(COMMUNITY_EVT);
+    expect(ids).not.toContain(DRAFT_EVT);
+  });
+
+  test("GET /events/:slug returns published event detail", async () => {
+    const row = (await sql`SELECT slug FROM events WHERE id = ${PUBLIC_EVT}::uuid`) as Array<{ slug: string }>;
+    const slug = row[0].slug;
+    const res = await testApp.request(`/events/${slug}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { event: { id: string; scope: string } };
+    expect(body.event.id).toBe(PUBLIC_EVT);
+  });
+
+  test("GET /events/:slug 404 on non-published", async () => {
+    const row = (await sql`SELECT slug FROM events WHERE id = ${DRAFT_EVT}::uuid`) as Array<{ slug: string }>;
+    const slug = row[0].slug;
+    const res = await testApp.request(`/events/${slug}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -1,0 +1,141 @@
+import { Hono } from "hono";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import { createDb } from "../db";
+import { events, groups, organizations, users } from "../db/schema";
+import type { AppEnv } from "../types";
+
+export const eventsRoute = new Hono<AppEnv>();
+
+/**
+ * GET /events
+ *
+ * Public list of published events, filtered by scope visibility:
+ *   - anonymous viewer: only scope='public'
+ *   - signed-in member: scope IN ('public', 'community')
+ *
+ * Auto-completed events (past end_date) are filtered out at read time.
+ */
+eventsRoute.get("/", async (c) => {
+  if (!c.env.DATABASE_URL) return c.json({ events: [] });
+  const db = createDb(c.env.DATABASE_URL);
+  const actor = c.get("actor");
+
+  const visibleScopes: ("public" | "community" | "group")[] = ["public"];
+  if (actor && actor.systemTier >= 0) {
+    visibleScopes.push("community");
+  }
+
+  const rows = await db
+    .select({
+      id: events.id,
+      slug: events.slug,
+      name: events.name,
+      type: events.type,
+      startDate: events.startDate,
+      endDate: events.endDate,
+      location: events.location,
+      description: events.description,
+      scope: events.scope,
+      externalUrl: events.externalUrl,
+      authorId: events.authorId,
+    })
+    .from(events)
+    .where(
+      and(
+        eq(events.status, "published"),
+        isNull(events.deletedAt),
+        inArray(events.scope, visibleScopes)
+      )
+    )
+    .orderBy(asc(events.startDate));
+
+  // Filter out events whose end_date has passed (effective auto-completed)
+  const today = new Date().toISOString().slice(0, 10);
+  const active = rows.filter((e) => !e.endDate || e.endDate >= today);
+
+  return c.json({ events: active });
+});
+
+/**
+ * GET /events/:slug
+ *
+ * Public event detail. Returns the event + host_group + host_org +
+ * author display name (when public profile permits). 404 for non-published.
+ */
+eventsRoute.get("/:slug", async (c) => {
+  if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "not_found" }, 404);
+  const slug = c.req.param("slug");
+  if (!slug) return c.json({ ok: false, error: "not_found" }, 404);
+  const db = createDb(c.env.DATABASE_URL);
+
+  const event = await db
+    .select()
+    .from(events)
+    .where(
+      and(
+        eq(events.slug, slug),
+        eq(events.status, "published"),
+        isNull(events.deletedAt)
+      )
+    )
+    .limit(1)
+    .then((r) => r[0]);
+  if (!event) return c.json({ ok: false, error: "not_found" }, 404);
+
+  // Visibility check: anonymous viewer only sees public.
+  const actor = c.get("actor");
+  if (event.scope === "community" && !actor) {
+    return c.json({ ok: false, error: "not_found" }, 404);
+  }
+  if (event.scope === "group" || event.scope === "staff_only") {
+    if (!actor || actor.systemTier < 1) {
+      return c.json({ ok: false, error: "not_found" }, 404);
+    }
+  }
+
+  const [hostGroup, hostOrg, author] = await Promise.all([
+    event.hostGroupId
+      ? db
+          .select({ id: groups.id, name: groups.name, slug: groups.slug })
+          .from(groups)
+          .where(eq(groups.id, event.hostGroupId))
+          .limit(1)
+          .then((r) => r[0])
+      : null,
+    event.hostOrgId
+      ? db
+          .select({ id: organizations.id, name: organizations.name })
+          .from(organizations)
+          .where(eq(organizations.id, event.hostOrgId))
+          .limit(1)
+          .then((r) => r[0])
+      : null,
+    event.authorId
+      ? db
+          .select({ id: users.id, email: users.email })
+          .from(users)
+          .where(eq(users.id, event.authorId))
+          .limit(1)
+          .then((r) => r[0])
+      : null,
+  ]);
+
+  return c.json({
+    event: {
+      id: event.id,
+      slug: event.slug,
+      name: event.name,
+      type: event.type,
+      startDate: event.startDate,
+      endDate: event.endDate,
+      location: event.location,
+      url: event.url,
+      description: event.description,
+      scope: event.scope,
+      externalUrl: event.externalUrl,
+      hostGroup,
+      hostOrg,
+      author: author ? { id: author.id } : null,
+    },
+  });
+});

--- a/packages/api/src/routes/eventsSubmit.test.ts
+++ b/packages/api/src/routes/eventsSubmit.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import { testApp, makeMemberActor } from "../test/helpers";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const describeIfDb = HAS_DB ? describe : describe.skip;
+
+const MEMBER = "00000000-0000-0000-0000-00000000fa01";
+
+describeIfDb("POST /events/submit", () => {
+  let sql: ReturnType<typeof neon>;
+  const createdIds: string[] = [];
+
+  beforeAll(async () => {
+    sql = neon(process.env.DATABASE_URL!);
+    await sql`DELETE FROM audit_log WHERE actor_id = ${MEMBER}::uuid`;
+    await sql`DELETE FROM users WHERE id = ${MEMBER}::uuid`;
+    await sql`
+      INSERT INTO users (id, workos_id, member_id, email, role)
+      VALUES (${MEMBER}::uuid, ${"w-" + MEMBER}, ${"m-" + MEMBER}, ${MEMBER + "@t"}, 'member'::user_role)
+    `;
+  });
+
+  afterAll(async () => {
+    if (createdIds.length) {
+      await sql`DELETE FROM artifact_reviews WHERE entity_id = ANY(${createdIds}::uuid[])`;
+      await sql`DELETE FROM audit_log WHERE target_id = ANY(${createdIds}::uuid[])`;
+      await sql`DELETE FROM events WHERE id = ANY(${createdIds}::uuid[])`;
+    }
+    await sql`DELETE FROM audit_log WHERE actor_id = ${MEMBER}::uuid`;
+    await sql`DELETE FROM users WHERE id = ${MEMBER}::uuid`;
+  });
+
+  test("requires auth (401 unauthenticated)", async () => {
+    const res = await testApp.request("/events/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "x", type: "workshop", startDate: "2099-01-01" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("auth'd member submits → lands as in_review with author=member", async () => {
+    const res = await testApp.request("/events/submit", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: makeMemberActor(MEMBER),
+      },
+      body: JSON.stringify({
+        name: "Member-submitted from another community",
+        type: "conference",
+        startDate: "2099-10-15",
+        externalUrl: "https://example.org/conf",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      ok: true;
+      event: { id: string; status: string; authorId: string };
+    };
+    expect(body.event.status).toBe("in_review");
+    expect(body.event.authorId).toBe(MEMBER);
+    createdIds.push(body.event.id);
+  });
+});

--- a/packages/api/src/routes/eventsSubmit.ts
+++ b/packages/api/src/routes/eventsSubmit.ts
@@ -1,0 +1,117 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { zValidator } from "@hono/zod-validator";
+import { createDb } from "../db";
+import { events } from "../db/schema";
+import { applyTransition } from "../lib/lifecycle";
+import { drizzleLifecycleDb } from "../lib/lifecycle/drizzleAdapter";
+import type { AppEnv } from "../types";
+
+export const eventsSubmitRoute = new Hono<AppEnv>();
+
+const submitBodySchema = z.object({
+  name: z.string().min(1).max(200),
+  type: z.enum([
+    "conference",
+    "workshop",
+    "meetup",
+    "webinar",
+    "community_call",
+    "other",
+  ]),
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  location: z.string().max(200).optional(),
+  description: z.string().max(5000).optional(),
+  externalUrl: z.string().url().max(500).optional(),
+  hostOrgId: z.string().uuid().optional(),
+});
+
+function slugify(name: string): string {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+  const suffix = Math.random().toString(36).slice(2, 6);
+  return base ? `${base}-${suffix}` : `event-${suffix}`;
+}
+
+/**
+ * POST /events/submit
+ *
+ * Auth-gated member submission. Creates a draft event with the member
+ * as author, defaults scope to 'community', then transitions to
+ * 'in_review' immediately so it appears in the staff queue.
+ *
+ * If the transition fails (shouldn't normally happen — draft → in_review
+ * is always valid), the row is left as `draft` for staff cleanup via the
+ * admin queue. We don't try to delete it, since the failed transition may
+ * have already produced audit_log entries that FK back via target_id.
+ */
+eventsSubmitRoute.post(
+  "/",
+  zValidator("json", submitBodySchema, (result, c) => {
+    if (!result.success) {
+      return c.json(
+        { ok: false, error: "invalid_input", issues: result.error.issues },
+        400
+      );
+    }
+  }),
+  async (c) => {
+    if (!c.env.DATABASE_URL) return c.json({ ok: false, error: "internal" }, 500);
+    const actor = c.get("actor");
+    if (!actor) return c.json({ ok: false, error: "unauthorized" }, 401);
+    const body = c.req.valid("json");
+    const db = createDb(c.env.DATABASE_URL);
+
+    const slug = slugify(body.name);
+    const [row] = await db
+      .insert(events)
+      .values({
+        slug,
+        name: body.name,
+        type: body.type,
+        startDate: body.startDate,
+        endDate: body.endDate ?? null,
+        location: body.location ?? null,
+        description: body.description ?? null,
+        status: "draft",
+        revision: 1,
+        authorId: actor.user.id,
+        scope: "community",
+        hostOrgId: body.hostOrgId ?? null,
+        externalUrl: body.externalUrl ?? null,
+      })
+      .returning();
+
+    // Immediately submit for review.
+    const lifecycleDb = drizzleLifecycleDb(db, {
+      id: actor.user.id,
+      role: actor.user.role,
+    });
+    const result = await applyTransition(lifecycleDb, {
+      entityType: "event",
+      entityId: row.id,
+      action: "submit_for_review",
+      actorId: actor.user.id,
+    });
+    if (!result.ok) {
+      return c.json({ ok: false, error: result.error }, 400);
+    }
+
+    return c.json(
+      {
+        ok: true,
+        event: {
+          id: row.id,
+          status: "in_review",
+          slug: row.slug,
+          authorId: row.authorId,
+        },
+      },
+      201
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Plan 2 of 5 from the events / announcements / forms brainstorm. Lands the events admin + member submit + public surfaces on top of the Plan 1 foundation (#1994).

### Admin API
- `POST/GET /admin/events` — create draft + list with filters (status/type/scope/host/q + pagination)
- `GET/PATCH /admin/events/:id` — detail (with reviews/comments/audit) + patch gated by `canEditArtifact`
- `POST /admin/events/:id/transitions` — wraps `applyTransition` with per-action policy gates (submit_for_review/approve/reject/request_changes/cancel/archive)
- `POST /admin/events/:id/comments` — comment endpoint using `sanitizeCommentBody`

### Public API
- `GET /events` — scope-aware list (anonymous: public only; signed-in: public + community)
- `GET /events/:slug` — published-event detail with host_group/host_org/author attribution
- `POST /events/submit` — auth-gated member submission, auto-transitions to `in_review`

### Admin UI
- `/admin/events` list with status filter + search
- `/admin/events/new` compose form
- `/admin/events/:id` detail page with Identity / Content / Review / Audit tabs (Broadcast tab deferred to Plan 5; attached-form section deferred to Plan 4)
- Sidebar nav: the data-driven `useNavSections` already exposed an Events entry — wired it to the real page

### Public UI
- `UpcomingEventsPage` now renders dynamic API-driven events between the featured (USRSE'26) and recurring-events sections, with magazine-style date block + matching purple/teal accents. Plus "Submit an event" CTA.
- New `/events/submit` form (auth-gated via `useAuth`; shows sign-in CTA for anonymous visitors)
- New `/events/:slug` detail page matching the site's design language (magazine date treatment, teal host attribution, purple register CTA)

### Middleware
- `optionalActor` middleware got the same `TEST_BYPASS_AUTH` escape hatch that `auth.ts` and `actorContext.ts` got in Plan 1 — env-gated, inert in production, not in `wrangler.jsonc`.

## Stats

- 13 commits, all atomic, conventional, **zero AI attribution**
- 216/216 vitest tests pass (193 from Plan 1 + 23 new)
- Full repo typecheck clean

## Test plan

- [ ] CI green (Cloudflare Pages preview deploys; CircleCI legacy may error — expected on site-redesign-base PRs)
- [ ] Manual: super_admin creates an event in `/admin/events/new`, submits for review, second super_admin approves twice — event publishes
- [ ] Manual: member submits via `/events/submit`, event appears in `/admin/queue` as `in_review`
- [ ] Manual: anonymous viewer hits `/events`, sees only public published events; sign in, sees community events too
- [ ] Manual: published event with `externalUrl` set renders "Register at … →" CTA on `/events/:slug`

## Plan + spec

- Spec: `docs/superpowers/specs/2026-05-20-events-announcements-forms-design.md`
- Plan: `docs/superpowers/plans/2026-05-24-events-implementation.md`
- Builds on: PR #1994 (Plan 1 foundation)

## Deferred to subsequent plans (per scope decision)

- Thumbnail upload — needs `ARTIFACT_THUMBNAILS` R2 binding provisioning (own follow-up)
- Broadcast tab on event detail — Plan 5
- Attached-form section on event detail — Plan 4