### PR TITLE
Update DEI working group page and fix Pride spotlight tags

### DIFF
--- a/_posts/2024-06-12-pride-spotlight-sally-ride.md
+++ b/_posts/2024-06-12-pride-spotlight-sally-ride.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "US-RSE Pride Month Spotlight - Sally Ride"
-tags: [dei, pride-month]
+tags: [dei, pride]
 author: Lance Parsons 
 ---
 

--- a/_posts/2025-06-16-edith-windsor.md
+++ b/_posts/2025-06-16-edith-windsor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "US-RSE Pride Month Spotlight - Edith Windsor"
-tags: [dei, pride-month]
+tags: [dei, pride]
 ---
 
 US-RSE's [DEI working group (DEI-WG)](https://us-rse.org/wg/dei/) is proud to

--- a/pages/wg/dei.md
+++ b/pages/wg/dei.md
@@ -11,19 +11,35 @@ set_last_modified: true
 
 # Overview
 
-The US-RSE Diversity, Equity, and Inclusion (DEI) working group is dedicated to supporting DEI through education, outreach, and more as described in [our mission statement]({{ site.baseurl }}/about/dei-mission). Those interested in contributing to this goal are encouraged to join in our bi-weekly Zoom meetings.
+The US-RSE Diversity, Equity, and Inclusion (DEI) working group is dedicated to supporting DEI through education, outreach, and more as described in [our mission statement]({{ site.baseurl }}/about/dei-mission). Those interested in contributing to this goal are encouraged to join our monthly Zoom meetings, held on the second Wednesday of each month at 12 PM PT / 3 PM ET.
 
 # Getting involved
 
-To get involved with the DEI working group, visit the [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channel on the US-RSE slack, or contact the <a href="mailto:wg-dei@us-rse.org">DEI working group list</a>.
+To get involved with the DEI working group, join the [`#wg-diversity-equity-inclusion`](https://usrse.slack.com/messages/wg-diversity-equity-inclusion) channel for working group activities and the [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channel for general DEI discussion on the US-RSE slack, or contact the <a href="mailto:wg-dei@us-rse.org">DEI working group list</a>. If you are interested in helping throughout the year or joining the group, fill out the [DEI General Interest Form](https://docs.google.com/forms/d/e/1FAIpQLScZqbiFCqo685cguQi9_0QnZBdI4CJ4jUrrIJAts36-PKNvJw/viewform).
 
 Suggestions for media, other resources (such as guides), speakers, and
 future activities can also be submitted through this form:
 [Diversity, Equity, and Inclusion (DEI) Suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdtCVAmJnUQCKnIXdn93xN5e9_zCQkrVdQsnPOiSBIcptma6w/viewform)
 
-# Work Products
+**Co-Chairs**: Lance Parsons, Alex Koufos
+{: #co-chairs}
 
-The US-RSE DEI working group has produced and hosts the following documents and events.
+# Current Focus
+
+The working group's efforts are currently centered on:
+
+- [**Annual diversity report**](#annual-diversity-report) — developing an annual diversity report for US-RSE (in progress).
+- [**Education and promotion of DEI**](#education-and-promotion-of-dei) in the US-RSE and broader RSE community, including our DEI Speaker Series and DEI Media Club.
+- [**Equity and inclusion challenges**](#equity-and-inclusion-challenges) — understanding the equity and inclusion challenges that members encounter in their RSE roles.
+- [**Celebrating diversity**](#celebrating-diversity) — leading US-RSE's celebration of diversity through observances such as Black History Month, Women's History Month, and Pride Month.
+
+# Annual Diversity Report
+
+The US-RSE DEI working group is developing an annual diversity report for US-RSE to better understand the makeup of our community and to track progress over time. This effort is currently in progress.
+
+# Education and Promotion of DEI
+
+The US-RSE DEI working group works to educate and promote DEI within US-RSE and the broader RSE community through the following efforts.
 
 ## DEI Mission Statement
 
@@ -31,18 +47,17 @@ The US-RSE DEI working group's first large initiative was to create a US-RSE DEI
 
 ## DEI Speaker Series
 
-The US-RSE DEI working group invites DEI speakers to present on DEI topics.
+The US-RSE DEI working group occasionally invites DEI speakers to present on DEI topics.
 A playlist with talks from all the speakers to date
 can be found on the US-RSE YouTube channel here:  
 <https://www.youtube.com/playlist?list=PLMgG8jy8w-8lUu8Uflt1WCsI8yzEEVybS>
 
-We will continue to invite and host speakers as they are available.
 Suggestions regarding potential speakers are welcome,
 by reaching out to the working group in Slack or through the form above.
 
 ## DEI Media Club
 
-The US-RSE DEI working group hosts monthly DEI Media Club discussions in which we invite participants to read, listen to, or watch the chosen monthly DEI media and come ready to discuss the content as a small group. In 2021, we hosted three sessions to discuss the book "Better Allies" by Karen Catlin and two Podcast sessions to discuss series 4, episode 6 of *reWorked - The Diversity and Inclusion Podcast* and [Code Switch - The Folk Devil Made Me Do It](https://www.npr.org/2021/08/20/1029775224/the-folk-devil-made-me-do-it).
+The US-RSE DEI working group hosts occasional DEI Media Club discussions in which we invite participants to read, listen to, or watch the chosen DEI media and come ready to discuss the content as a small group. In 2021, we hosted three sessions to discuss the book "Better Allies" by Karen Catlin and two Podcast sessions to discuss series 4, episode 6 of *reWorked - The Diversity and Inclusion Podcast* and [Code Switch - The Folk Devil Made Me Do It](https://www.npr.org/2021/08/20/1029775224/the-folk-devil-made-me-do-it).
 
 These are announced via the [`#events`](https://usrse.slack.com/messages/events) and [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channels on the US-RSE slack, as well as in monthly newsletters, and are hosted virtually via Zoom.
 
@@ -58,10 +73,15 @@ Please feel free to suggest additional media
 and other resources through this form:
 [Diversity, Equity, and Inclusion (DEI) Suggestions](https://docs.google.com/forms/d/e/1FAIpQLSdtCVAmJnUQCKnIXdn93xN5e9_zCQkrVdQsnPOiSBIcptma6w/viewform)
 
-## US-RSE Spanish Webpage Translation
+# Equity and Inclusion Challenges
 
-The US-RSE DEI working group is spearheading an effort to translate the US-RSE webpage into Spanish in order to broaden accessibility to a wider audience. This is an ongoing effort. To get involved, visit the [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channel on the US-RSE slack.
+The US-RSE DEI working group seeks to understand the equity and inclusion challenges that members encounter in their RSE roles, so that US-RSE can better support a diverse community.
 
-## RSE Mentorship
+We want to hear from members. Please share your experiences and suggestions through the [DEI Suggestions form](https://docs.google.com/forms/d/e/1FAIpQLSdtCVAmJnUQCKnIXdn93xN5e9_zCQkrVdQsnPOiSBIcptma6w/viewform), in the [`#dei-discussion`](https://usrse.slack.com/messages/dei-discussion) channel on the US-RSE slack, or by messaging the [co-chairs](#co-chairs) directly on Slack.
 
-In 2022, the US-RSE DEI working group will begin an effort to promote and support mentorship in the RSE community. We welcome suggestions on how to get this effort started and where we would make the most impact.
+# Celebrating Diversity
+
+The US-RSE DEI working group leads US-RSE's celebration of diversity throughout the year, including spotlight posts that recognize inspiring individuals in computing, science, engineering, and math:
+
+- [Pride Month]({{ site.baseurl }}/tags/#pride)
+- [Black History Month]({{ site.baseurl }}/tags/#black-history)


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->

Updates to the [DEI working group page](https://us-rse.org/wg/dei/):

- Restructured the page around the working group's current focus areas, each as its own section linked from a "Current Focus" list: **Annual Diversity Report** (in progress), **Education and Promotion of DEI** (Mission Statement, Speaker Series, Media Club, and Resources nested here), **Equity and Inclusion Challenges**, and **Celebrating Diversity** (Pride Month and Black History Month spotlight links).
- Updated co-chairs to Lance Parsons and Alex Koufos.
- Corrected the meeting cadence (monthly, second Wednesday at 12 PM PT / 3 PM ET).
- Added the `#wg-diversity-equity-inclusion` Slack channel and the DEI General Interest Form to "Getting involved."
- Marked the Speaker Series and Media Club as occasional.
- Added a feedback invitation in the Equity and Inclusion Challenges section (form, `#dei-discussion`, or messaging the co-chairs).
- Removed the outdated Spanish translation and RSE mentorship sections.

Also fixed the tags on two Pride Month spotlight posts (`pride-month` → `pride`) so they show up on the `/tags/#pride` page alongside the other Pride posts.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.

This content was authored by a DEI working group co-chair.

When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
