### PR TITLE
Offset in-page anchor jumps below the fixed navbar

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,9 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+// Offset in-page anchor jumps so targets aren't hidden behind the fixed navbar
+html {
+    scroll-padding-top: 3.25rem;
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->

Adds a `scroll-padding-top` rule on the `html` element so that following an in-page anchor link scrolls the target below the fixed (sticky) navbar instead of leaving it hidden behind the navbar. The offset (`3.25rem`) matches the Bulma fixed-navbar height, and applies to in-page anchor jumps site-wide.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.

This is a small style/functionality fix with no content changes.

When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
