### PR TITLE
Changing Zenodo urls to dois

### DIFF
--- a/_data/newsletter/articles.yml
+++ b/_data/newsletter/articles.yml
@@ -174,7 +174,7 @@ references:
     Building a Community Vision"
   title-short: Research Software Engineering in the Age of Generative AI
   type: report
-  url: "https://zenodo.org/records/20320884"
+  url: "https://doi.org/10.5281/zenodo.20320884"
 - abstract: Research software is a class of software developed to
     support research. Today a wealth of such software is created daily
     in universities, government, and commercial research enterprises
@@ -459,7 +459,7 @@ references:
     Changing Practice"
   title-short: Research Software Engineers in the Age of GenAI
   type: report
-  url: "https://zenodo.org/records/20320179"
+  url: "https://doi.org/10.5281/zenodo.20320179"
 - abstract: Research software (also called scientific software) is
     essential for advancing scientific endeavours. Research software
     encapsulates complex algorithms and domain-specific knowledge and is
@@ -760,7 +760,7 @@ references:
     Reflections from Edinburgh"
   title-short: Research Software in an Age of AI-Assisted Development
   type: report
-  url: "https://zenodo.org/records/20321134"
+  url: "https://doi.org/10.5281/zenodo.20321134"
 - abstract: "Scientific claims increasingly rely upon the interplay of
     code, data, and computational environments. Yet the record of how
     they are used together is often incomplete, scattered, or lost. This

--- a/_data/newsletter/media.yml
+++ b/_data/newsletter/media.yml
@@ -152,7 +152,7 @@ references:
   issued: 2025-10-08
   title: USRSE 25 rapid access micro talks
   type: manuscript
-  url: "https://zenodo.org/records/17297728"
+  url: "https://doi.org/10.5281/zenodo.17297728"
 - abstract: "English Edition: how are real numbers e.g. 0.1 represented
     on computers? What can go wrong with using their representation in
     calculations? And does it matter? These and other questions are the

--- a/_data/newsletter_bib_yml.yml
+++ b/_data/newsletter_bib_yml.yml
@@ -174,7 +174,7 @@ references:
     Building a Community Vision"
   title-short: Research Software Engineering in the Age of Generative AI
   type: report
-  url: "https://zenodo.org/records/20320884"
+  url: "https://doi.org/10.5281/zenodo.20320884"
 - accessed: 2026-04-08
   annote: |
     Read_Status: Read\
@@ -567,7 +567,7 @@ references:
     Changing Practice"
   title-short: Research Software Engineers in the Age of GenAI
   type: report
-  url: "https://zenodo.org/records/20320179"
+  url: "https://doi.org/10.5281/zenodo.20320179"
 - abstract: Research software (also called scientific software) is
     essential for advancing scientific endeavours. Research software
     encapsulates complex algorithms and domain-specific knowledge and is
@@ -887,7 +887,7 @@ references:
     Reflections from Edinburgh"
   title-short: Research Software in an Age of AI-Assisted Development
   type: report
-  url: "https://zenodo.org/records/20321134"
+  url: "https://doi.org/10.5281/zenodo.20321134"
 - abstract: United States Research Software Engineer Association
   accessed: 2022-05-21
   annote: |
@@ -1235,7 +1235,7 @@ references:
   issued: 2025-10-08
   title: USRSE 25 rapid access micro talks
   type: manuscript
-  url: "https://zenodo.org/records/17297728"
+  url: "https://doi.org/10.5281/zenodo.17297728"
 - abstract: Beginning in the 1970s, statistician-cum-logician Per
     Martin-L\\\"of wrote a series of papers developing what became
     Martin-L\\\"of type theory, realizing a system where the distinction

--- a/pages/get_involved/organizational_membership.md
+++ b/pages/get_involved/organizational_membership.md
@@ -55,9 +55,9 @@ Examples include:
   - The [Education and Training speaker series](/wg/education_training/)
 - A heavily visited and successful [job board](/jobs/)
 - Creation of resources such as the
-  - [Career Guidebook](https://zenodo.org/records/8329337) in collaboration with
+  - [Career Guidebook](https://doi.org/10.5281/zenodo.8329337) in collaboration with
     the Academic Data Science Alliance (over 100 pages)
-  - [Career Guide Brochure](https://zenodo.org/records/10073233) for RSEs in
+  - [Career Guide Brochure](https://doi.org/10.5281/zenodo.10073233) for RSEs in
     collaboration with IEEE Computer Society (25 pages)
 
 

--- a/pages/resources/rses.md
+++ b/pages/resources/rses.md
@@ -10,7 +10,7 @@ subtitle: Resources for RSEs
 - [Hiring, Managing, and Retaining Data Scientists and Research Software Engineers in Academia: A Career Guidebook from ADSA and US-RSE](https://doi.org/10.5281/zenodo.8264152){:target="_blank"}
 - [Research Software Engineers: Creating a Career Path—and a Career](https://doi.org/10.5281/zenodo.10073233){:target="_blank"}
 - [Getting Started with the RSE Movement within your Organization: A Guide for Individuals](https://doi.org/10.5281/zenodo.10436166){:target="_blank"}
-- [Illustrating Impacts of User Experience Work in Research Software Engineering](https://zenodo.org/records/17944188){:target="_blank"}
+- [Illustrating Impacts of User Experience Work in Research Software Engineering](https://doi.org/10.5281/zenodo.17944188){:target="_blank"}
 
 ## USRSE Conference Proceedings
 

--- a/pages/wg/ux.md
+++ b/pages/wg/ux.md
@@ -38,6 +38,6 @@ the US-RSE slack or contact the co-chairs at
 
 # Work Products
 
-Working paper: [Illustrating Impacts of User Experience Work in Research Software Engineering](https://zenodo.org/records/17944188)
+Working paper: [Illustrating Impacts of User Experience Work in Research Software Engineering](https://doi.org/10.5281/zenodo.17944188)
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->

I happened to notice a bunch of places we are referring to zenodo items by their records rather than by the DOIs, which are more permanent, and better practice to use than URLs, so this PR changes those that I noticed.

## Checklist:
<!---Check these off after you create the PR --->
- [ ] I have previewed changes locally or with CircleCI (runs when PR is created)
- [ ] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  


When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
