### PR TITLE
Add North Carolina Regional Group meetup for September 16, 2026; also added LinkedIn group

### DIFF
--- a/_events/2026/2026-09-rg-nc-meetup.md
+++ b/_events/2026/2026-09-rg-nc-meetup.md
@@ -1,0 +1,26 @@
+---
+title: North Carolina Regional Group Meetup September 2026
+location: Namu, 5420 Durham-Chapel Hill Blvd, Durham, NC 27707
+excerpt_separator: <!--more-->
+expires: 2026-09-16
+event_date: "September 16, 2026"
+layout: event
+duration: 120
+repeated: false
+category: social
+time:
+ - - start: 2026-09-16T17:00:00-04:00
+     end: 2026-09-16T19:00:00-04:00
+---
+
+The North Carolina Regional Group will hold an in-person social meeting at Namu on Wednesday, September 16th, 2026 from 5:00pm ET to 7:00pm ET.
+
+<!--more-->
+
+We'll meet in the restaurant section of <a href="https://www.yelp.com/biz/namu-durham">Namu Durham</a>, 5420 Durham-Chapel Hill Blvd, Durham, NC 27707.
+I'm planning to stay there until 7pm at least, so no worries if you're running late.
+Please <a href="mailto:gaurav@ggvaidya.com">email me</a> or message me on Slack if you can't find us.
+
+You can find out more about our group on [our regional group page]({{ site.baseurl }}/ag/rg-north-carolina/)
+or by joining the [US-RSE Slack `#rg-north-carolina` channel](https://usrse.slack.com/messages/rg-north-carolina)
+(you will need to [join US-RSE]({{site.baseurl}}/join/) first!).

--- a/pages/ag/rg-north-carolina.md
+++ b/pages/ag/rg-north-carolina.md
@@ -32,10 +32,11 @@ organize more structured events in the future.
 
 ## Upcoming meetups
 
-- April 21, 2026 at 5pm ET: [April Meetup]({{site.baseurl}}/events/2026/2026-04-rg-nc-meetup/) at [Namu](https://www.yelp.com/biz/namu-durham), 5420 Durham-Chapel Hill Blvd, Durham, NC 27707.
+- September 16, 2026 at 5pm ET: [September Meetup]({{site.baseurl}}/events/2026/2026-09-rg-nc-meetup/) at [Namu](https://www.yelp.com/biz/namu-durham), 5420 Durham-Chapel Hill Blvd, Durham, NC 27707.
 
 ## Archive of past meetups
 
+- April 21, 2026 at 5pm ET: [April Meetup]({{site.baseurl}}/events/2026/2026-04-rg-nc-meetup/) at [Namu](https://www.yelp.com/biz/namu-durham), 5420 Durham-Chapel Hill Blvd, Durham, NC 27707.
 - March 24, 2026 at 5pm ET: [March Meetup]({{site.baseurl}}/events/2026/2026-03-rg-nc-meetup/) at [Boxyard RTP](https://boxyard.rtp.org/vendors/), 900 Park Offices Drive, Durham, NC 27709.
 - January 21, 2026 at 5pm ET: [January Meetup]({{site.baseurl}}/events/2026/2026-01-rg-nc-meetup/), virtual.
 - October 21, 2025 at 5pm ET: [October Meetup]({{site.baseurl}}/events/2025/2025-10-rg-nc-meetup/) at [Namu](https://www.yelp.com/biz/namu-durham), 5420 Durham-Chapel Hill Blvd, Durham, NC 27707.

--- a/pages/ag/rg-north-carolina.md
+++ b/pages/ag/rg-north-carolina.md
@@ -21,6 +21,7 @@ To stay informed, please:
 * [Join US-RSE]({{site.baseurl}}/join/).
 * Subscribe to event announcements by joining one of:
   * The [US-RSE Slack `#rg-north-carolina` channel](https://usrse.slack.com/messages/rg-north-carolina)
+  * Our [LinkedIn group](https://www.linkedin.com/groups/17844009/)
   * Our [Google group](https://groups.google.com/a/us-rse.org/g/rg-north-carolina/about) (mailing list)
 
 If you are interested in giving a talk or have other ideas for a future meetup, please contact one of the coordinators (see the [Questions?](#questions) section below).


### PR DESCRIPTION
## Description
<!--- Describe your changes.  If it fixes an open issue, please link to the issue here. -->

Same time and place as the April 2026 meetup (Namu, Durham, 5-7pm ET). Also moves the April meetup into the past-meetups archive on the group page. It also adds a link to our new LinkedIn group to our regional group's webpage.

## Checklist:
<!---Check these off after you create the PR --->
- [x] I have previewed changes locally or with CircleCI (runs when PR is created)
- [x] I have completed any content reviews, such as getting input from relevant working groups.  If no, please note this and wait to post the PR to the #website channel until the content has been settled.  

When you are ready for a technical review/merge, post the for the link for the PR in the US-RSE Slack (#website) to ask for reviewers.

<!---Ask questions if needed in the #website channel of US-RSE Slack --->
